### PR TITLE
fix(build): npm ci --ignore-scripts in the wheel build hook (GHSA-pfvh, code-only)

### DIFF
--- a/scripts/hatch_build.py
+++ b/scripts/hatch_build.py
@@ -138,7 +138,19 @@ def _bundle_ui(repo_root: Path, log: Callable[[str], None] = print) -> None:
     log("no prebuilt dist found; running npm build")
     try:
         subprocess.check_call(
-            [npm, "ci", "--prefer-offline", "--no-audit", "--no-fund"],
+            # --ignore-scripts: do NOT run npm lifecycle scripts from the
+            # (transitive) dependency tree at wheel-build / `git+` install time.
+            # Without it, a compromised dependency's postinstall would execute
+            # arbitrary code on the user's machine during install (GHSA-pfvh).
+            # Verified non-breaking: `tsc -b && vite build` needs no dependency
+            # install-scripts -- vite 8 (rolldown) ships prebuilt platform
+            # binaries rather than fetching them via a postinstall.
+            # NOTE: this also suppresses any *root* web/frontend/package.json
+            # prepare/postinstall script (there is none today). If one is ever
+            # added AND required for the build, invoke it explicitly here rather
+            # than dropping --ignore-scripts, which would re-open the dependency
+            # lifecycle-script RCE surface.
+            [npm, "ci", "--prefer-offline", "--no-audit", "--no-fund", "--ignore-scripts"],
             cwd=frontend_dir,
         )
         subprocess.check_call([npm, "run", "build"], cwd=frontend_dir)

--- a/tests/test_build_hook.py
+++ b/tests/test_build_hook.py
@@ -187,8 +187,10 @@ class TestBundleUiBug1NpmInvocation:
         assert _target(root).is_dir()
 
     def test_passes_resolved_npm_path_not_bare_name(self, tmp_path: Path) -> None:
-        """Root-cause fix: the resolved ``shutil.which`` path (``npm.cmd`` on
-        Windows) is handed to subprocess, never the bare string ``"npm"``."""
+        """Two regressions guarded here: (1) the resolved ``shutil.which`` path
+        (``npm.cmd`` on Windows) is handed to subprocess, never the bare string
+        ``"npm"``; (2) ``npm ci`` carries ``--ignore-scripts`` (GHSA-pfvh) while
+        ``npm run build`` intentionally does NOT."""
         root = _make_repo(tmp_path)
         resolved = "C:\\Program Files\\nodejs\\npm.cmd"
         with (
@@ -203,7 +205,15 @@ class TestBundleUiBug1NpmInvocation:
         assert ci_cmd[0] == resolved
         assert build_cmd[0] == resolved
         assert ci_cmd[1] == "ci"
+        # GHSA-pfvh: dependency lifecycle scripts must NOT run at wheel-build /
+        # `git+` install time (install-time RCE surface). Verified non-breaking
+        # against the real `tsc -b && vite build`.
+        assert "--ignore-scripts" in ci_cmd
+        # Intentional asymmetry: `--ignore-scripts` gates the dependency INSTALL
+        # (`npm ci`). `npm run build` runs our OWN build script and must NOT
+        # carry the flag -- do not "fix" the asymmetry by adding it there.
         assert build_cmd[1:] == ["run", "build"]
+        assert "--ignore-scripts" not in build_cmd
 
     def test_successful_npm_build_is_bundled(self, tmp_path: Path) -> None:
         """When npm produces dist/index.html, it gets copied into _ui_dist/."""


### PR DESCRIPTION
## Summary

Fixes **M9** from the 2026-06-12 security audit (private advisory **GHSA-pfvh-6q5w-9m52**) — an install-time RCE surface in the wheel build hook.

`scripts/hatch_build.py` runs `npm ci` to build the React SPA at wheel-build time **and** when a user installs via `git+https://github.com/keboola/cli` (the fallback when no prebuilt wheel asset is present). Without `--ignore-scripts`, every `preinstall`/`install`/`postinstall` lifecycle script in the (transitive) npm dependency tree executes on the user's machine during install — so a single compromised transitive dependency lands arbitrary code execution on every user who takes the `git+` install path with Node on PATH.

## Fix

Add `--ignore-scripts` to the `npm ci` invocation. `tsc -b && vite build` compiles the SPA without needing any dependency install-script.

### Verified non-breaking (not assumed)
`--ignore-scripts` can break builds whose deps fetch a binary via `postinstall` (the classic esbuild trap). I **ran the real build** with the flag in `web/frontend`:
```
npm ci --ignore-scripts --prefer-offline --no-audit --no-fund   # added 393 packages, exit 0
npm run build                                                    # tsc -b && vite build -> ✓ built, dist/index.html present
```
vite 8 uses **rolldown** (Rust bundler) which ships prebuilt platform binaries as regular package files, not via a postinstall download — so `--ignore-scripts` is safe here. The lockfile (`package-lock.json`) remains committed + integrity-pinned, so this is defense-in-depth on top of the existing tarball-hash verification.

## Tests

`tests/test_build_hook.py::test_passes_resolved_npm_path_not_bare_name` now also asserts `--ignore-scripts` is in the `npm ci` command (mock-based regression test). Full suite green: **4177 passed, 135 skipped**; lint/format clean.

## ⚠️ Code-only PR
Touches only `scripts/hatch_build.py` + `tests/test_build_hook.py` — **no version bump / changelog entry** (added at the next release, same conflict-immunity rationale as #422/#460).

## Audit progress
Open after this: M7 (plaintext-on-encrypt warning — 3 services), M10 (version regex), + M1/M5 residuals.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->