### PR TITLE
fix(encrypt): surface leaked secret key-paths on plaintext fallback (GHSA-7jrf, code-only)

### DIFF
--- a/src/keboola_agent_cli/services/_encryption.py
+++ b/src/keboola_agent_cli/services/_encryption.py
@@ -182,10 +182,29 @@ def encrypt_secrets_in_config(
         logger.info("Encrypted %d secret value(s) for %s", len(encrypted), component_id)
     except Exception as exc:
         if allow_plaintext_fallback:
+            # The user opted into --allow-plaintext-on-encrypt-failure, but the
+            # actual plaintext write is otherwise silent (GHSA-7jrf-xc86-8wf6).
+            # Name the exact secret key-paths now persisted in PLAINTEXT (never
+            # the values) so the leak is visible and actionable rather than a
+            # vague "fallback allowed" log line.
+            leaked = find_plaintext_secret_keys(configuration)
+            # An HTTP client's exception message can echo the request body (the
+            # plaintext secrets we just sent to encrypt_values), so redact every
+            # secret value from the logged exception -- the warning that exists
+            # to flag a plaintext leak must not itself leak a credential.
+            safe_exc = str(exc)
+            for secret_value in secrets.values():
+                if secret_value:
+                    safe_exc = safe_exc.replace(secret_value, "***")
             logger.warning(
-                "Failed to encrypt secrets for %s: %s (plaintext fallback allowed)",
+                "Encryption FAILED for %s (%s). --allow-plaintext-on-encrypt-failure "
+                "is set, so %d secret value(s) are being written in PLAINTEXT: %s. "
+                "Rotate these credentials and re-encrypt once the Encryption API is "
+                "reachable -- config version history retains the plaintext copy.",
                 component_id,
-                exc,
+                safe_exc,
+                len(leaked),
+                ", ".join(leaked) or "(unable to enumerate)",
             )
         else:
             raise KeboolaApiError(

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -177,6 +177,55 @@ class TestEncryptSecretsInConfigNameValueShape:
         # plaintext must not be in the config after the raise path either
         # (it's in place, but the caller must not push it — that's the contract)
 
+    def test_plaintext_fallback_warning_names_leaked_keys(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # GHSA-7jrf: with --allow-plaintext-on-encrypt-failure AND a failing
+        # Encryption API, the (otherwise silent) plaintext write must be
+        # surfaced -- naming the exact leaked key-PATHS, never the values.
+        client = MagicMock()
+        client.encrypt_values.side_effect = RuntimeError("api down")
+        config = {"parameters": {"#api_key": "s3cr3t-value"}}
+
+        with caplog.at_level("WARNING"):
+            encrypt_secrets_in_config(
+                client=client,
+                project_id=901,
+                component_id="keboola.ex-generic",
+                configuration=config,
+                allow_plaintext_fallback=True,
+            )
+
+        msg = caplog.text
+        assert "PLAINTEXT" in msg
+        assert "#parameters.#api_key" in msg  # the key PATH is named
+        assert "s3cr3t-value" not in msg  # the secret VALUE is NEVER logged
+
+    def test_plaintext_fallback_redacts_secret_value_echoed_in_exception(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # GHSA-7jrf (Devin follow-up): even if the encryption client's exception
+        # message echoes the request body, the warning must redact the secret
+        # VALUE -- str(exc) is the remaining transitive leak vector.
+        client = MagicMock()
+        client.encrypt_values.side_effect = RuntimeError(
+            "400 Bad Request while sending {'#api_key': 's3cr3t-value'}"
+        )
+        config = {"parameters": {"#api_key": "s3cr3t-value"}}
+
+        with caplog.at_level("WARNING"):
+            encrypt_secrets_in_config(
+                client=client,
+                project_id=901,
+                component_id="keboola.ex-generic",
+                configuration=config,
+                allow_plaintext_fallback=True,
+            )
+
+        assert "s3cr3t-value" not in caplog.text  # value redacted out of exc
+        assert "***" in caplog.text  # redaction marker present
+        assert "#parameters.#api_key" in caplog.text  # key path still named
+
     def test_noop_when_no_secrets(self) -> None:
         client = MagicMock()
         config = {"values": [{"name": "regular", "value": "public"}]}

--- a/tests/test_sync_encrypt.py
+++ b/tests/test_sync_encrypt.py
@@ -104,9 +104,12 @@ class TestEncryptSecretsWarnsWithFallback:
         assert result["parameters"]["#apiToken"] == original_token
         assert result["parameters"]["nested"]["#password"] == "super-secret"
 
-        # Warning was logged
-        assert any("Failed to encrypt secrets" in record.message for record in caplog.records)
-        assert any("plaintext fallback allowed" in record.message for record in caplog.records)
+        # Warning now names the leaked key-paths written in PLAINTEXT
+        # (GHSA-7jrf) -- never the secret values.
+        assert "Encryption FAILED" in caplog.text
+        assert "PLAINTEXT" in caplog.text
+        assert "#parameters.#apiToken" in caplog.text
+        assert "super-secret" not in caplog.text
 
 
 class TestEncryptSecretsSuccess:


### PR DESCRIPTION
## Summary

Addresses **M7** from the 2026-06-12 security audit (private advisory **GHSA-7jrf-xc86-8wf6**) — the silent plaintext secret write on encryption failure.

When a user passes `--allow-plaintext-on-encrypt-failure` and the Encryption API then fails, `encrypt_secrets_in_config` falls back to writing the secrets in **plaintext**. The only signal was a vague `logger.warning("Failed to encrypt secrets for X (plaintext fallback allowed)")` — it never said **which** secrets actually went out in plaintext, so an operator could miss that a real credential just landed unencrypted in config (and in version history).

## Fix

The fallback warning now **enumerates the exact secret key-paths** that were persisted in plaintext, via the existing `find_plaintext_secret_keys` helper (returns key *paths* like `#parameters.#api_key`, **never the values**), and states the remediation (rotate the credentials + re-encrypt once the Encryption API is reachable; config version history retains the plaintext copy).

This is a **central** fix in the shared `_encryption.encrypt_secrets_in_config` helper, so it covers **every** caller automatically — config update / row-create / row-update, `config new --push`, `variables-set`, `data-app secrets-set`, and the sync push paths — without threading a field through 8+ call sites. The `test_sync_encrypt` test (which goes through `SyncService._encrypt_secrets_in_config`) confirms the sync path inherits it.

## Scope note (honest)

The advisory also mentions the write is "absent from **structured output**". This PR makes the warning **loud and actionable** (names the leaked keys) but keeps it a `logger.warning` — it does **not** yet add a `plaintext_written: [...]` field to each command's `--json` envelope. Doing that cleanly would thread a structured field through all ~8 service callers + their command layers (a much larger change). I chose the central, caller-agnostic warning as the proportionate fix; happy to follow up with the per-caller `--json` field if you want the structured-output surface too (it's the right call for the AI-agent/scripted audience).

## Tests

`test_encryption.py`: new test asserts the fallback warning names the key-PATH (`#parameters.#api_key`) and **never** the secret value. `test_sync_encrypt.py`: updated to the new wording + the never-log-the-value invariant. Full suite green: **4178 passed, 135 skipped**; lint/format/`ty` clean.

## ⚠️ Code-only PR
No version bump / changelog (added at next release) — same conflict-immunity rationale as #422 / #460 / #461 / #462.

## Audit progress
This is the **last MEDIUM**. After M7 + M10 (#462) merge, only the owner-accepted residuals remain (M1 residual: KBC_TOKEN/cli_command stripping; M5: capability-scoped child token), both deferred by design.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->