### PR TITLE
fix(release): unblock homebrew Linux smoke test on untrusted-tap gate

### DIFF
--- a/.github/workflows/release-kbagent.yml
+++ b/.github/workflows/release-kbagent.yml
@@ -484,6 +484,12 @@ jobs:
         run: |
           docker run --rm -e VERSION homebrew/brew bash -c '
             set -e
+            # Some homebrew/brew image builds ship HOMEBREW_REQUIRE_TAP_TRUST set, which makes
+            # brew refuse to load formulae from a third-party tap ("Refusing to load formula
+            # ... from untrusted tap"). Unset it so the smoke test can install: this is
+            # version-independent (the suggested `brew trust` command does not exist across all
+            # brew versions) and mirrors the default end-user environment where the var is unset.
+            unset HOMEBREW_REQUIRE_TAP_TRUST
             brew tap keboola/keboola-cli2 https://github.com/keboola/homebrew-keboola-cli2
             brew install keboola-cli2
             kbagent --version | grep -q "${VERSION}"


### PR DESCRIPTION
## Summary

The `test-install` **Homebrew (Linux)** leg fails with:

```
Error: Refusing to load formula keboola/keboola-cli2/keboola-cli2 from untrusted tap keboola/keboola-cli2.
```

Some `homebrew/brew` image builds ship `HOMEBREW_REQUIRE_TAP_TRUST` set, which blocks loading formulae from a third-party tap. This `unset`s it in the smoke-test container.

Chosen over the `brew trust` command the error message suggests, because **`brew trust` does not exist in current Homebrew (4.6.20)** — verified directly in the image (`Unknown command: brew trust`). Unsetting the gating env var is version-independent and mirrors the default end-user environment, where the var is unset (so real `brew install` users are unaffected either way).

## Scope
- `.github/workflows/release-kbagent.yml`, the `Homebrew (Linux)` smoke-test step only. One line + comment.
- The other release-workflow failures are handled elsewhere and are **not** in this PR:
  - Homebrew tap push (`target-directory` `.` → `Formula/`) + chocolatey checksum byte[] — **#476 (merged)**.
  - WinGet bootstrap-aware skip — **#485 (open, @padak)**. That PR supersedes the winget fix this branch originally carried.
- Rebased onto current `main`; the redundant homebrew/chocolatey/winget changes this branch previously had were dropped.

## Impact analysis
- No product/SDK/runtime code touched.
- Runs on non-prerelease tags (`IS_PRERELEASE == 'false'`); takes effect on the next stable tag.
- No breaking changes.

## Test plan / verification notes
- [ ] Next stable tag: `test-install` Homebrew (Linux) leg taps + installs `keboola-cli2` and greps the version.
- **Local verification caveat:** the `brew install` path could not be run locally — the sandbox Docker has no outbound network (`Could not resolve host: formulae.brew.sh`). The fix rests on two network-independent facts confirmed in the image: `brew trust` is not a command in 4.6.20, and the untrusted-tap refusal is gated by `HOMEBREW_REQUIRE_TAP_TRUST` (per `man brew` / `brew trust` help text).