### PR TITLE
fix(release): unbreak homebrew + chocolatey publish jobs

### DIFF
--- a/.github/workflows/release-kbagent.yml
+++ b/.github/workflows/release-kbagent.yml
@@ -383,8 +383,13 @@ jobs:
         env:
           API_TOKEN_GITHUB: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         with:
-          source-directory: "out"
-          target-directory: "."
+          # Copy the rendered formula into the tap's `Formula/` dir (its canonical
+          # location) rather than the repo root. target-directory "." made the
+          # push action run `rm` against `.`/`..` while clearing the target, which
+          # fails fatally ("can't remove '.' or '..'"); a real subdirectory clears
+          # cleanly. The resulting tap layout (`Formula/keboola-cli2.rb`) is unchanged.
+          source-directory: "out/Formula"
+          target-directory: "Formula"
           destination-github-username: keboola
           destination-repository-name: homebrew-keboola-cli2
           target-branch: main
@@ -405,7 +410,12 @@ jobs:
           CHOCOLATEY_KEY: ${{ secrets.CHOCOLATEY_KEY }}
         run: |
           $url = "$env:BASE_URL/$env:S3_PREFIX/v$env:VERSION/keboola-cli2_${env:VERSION}_windows_amd64.zip"
-          $checksum = (Invoke-WebRequest "$url.sha256").Content.Split(" ")[0]
+          # The .sha256 asset is served as application/octet-stream, so pwsh returns
+          # Invoke-WebRequest's .Content as a byte[] (no .Split method -> the job failed
+          # with "[System.Byte] does not contain a method named 'Split'"). Download it to
+          # a file and read it back as text, splitting on any whitespace ("<hash>  <file>").
+          Invoke-WebRequest "$url.sha256" -OutFile checksum.txt
+          $checksum = ((Get-Content checksum.txt -Raw).Trim() -split '\s+')[0]
           $push = "build/package/chocolatey"
           (Get-Content "$push/keboola-cli2.nuspec" -Raw).Replace('{VERSION}', $env:VERSION) | Set-Content "$push/keboola-cli2.nuspec"
           (Get-Content "$push/tools/chocolateyinstall.ps1" -Raw).Replace('{URL}', $url).Replace('{CHECKSUM}', $checksum) | Set-Content "$push/tools/chocolateyinstall.ps1"


### PR DESCRIPTION
Two pre-existing bugs in `release-kbagent` failed the **brew** + **choco** pushes on the v0.66.0 run (they surfaced now because the macOS *Sign & notarize* step — previously blocked on an expired Apple Developer agreement — is green again, so the downstream package-manager jobs finally ran):

- **chocolatey** — the `.sha256` asset is served as `application/octet-stream`, so `pwsh` returns `Invoke-WebRequest`'s `.Content` as a `byte[]` and `.Split(" ")` threw `[System.Byte] does not contain a method named 'Split'`. Now downloads it via `-OutFile` and reads it back as text, splitting on any whitespace.
- **homebrew** — `target-directory: "."` made the push-to-tap action run `rm` against `.`/`..` (`can't remove '.' or '..'`), aborting the job. Now pushes the rendered formula into the tap's `Formula/` dir (same resulting layout `Formula/keboola-cli2.rb`); keeps the SHA-pinned action (no supply-chain change).
- **winget** (`needs: chocolatey`) was skipped as a consequence and unblocks once choco is green.

No app/runtime code changed — workflow-only. Applies to the next tag; see PR discussion for backfilling v0.66.x to brew/choco.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->