### PR TITLE
fix(release): trust homebrew tap before install in test-install

### DIFF
--- a/.github/workflows/release-kbagent.yml
+++ b/.github/workflows/release-kbagent.yml
@@ -485,6 +485,11 @@ jobs:
           docker run --rm -e VERSION homebrew/brew bash -c '
             set -e
             brew tap keboola/keboola-cli2 https://github.com/keboola/homebrew-keboola-cli2
+            # brew now refuses to load a formula from a third-party tap until the tap is
+            # explicitly trusted ("Refusing to load formula ... from untrusted tap ...").
+            # First observed on the v0.66.1 run (github.com/keboola/cli, release-kbagent
+            # #29430278032) -- this is a real end-user install step too, not CI-only.
+            brew trust keboola/keboola-cli2
             brew install keboola-cli2
             kbagent --version | grep -q "${VERSION}"
           '


### PR DESCRIPTION
## Why

The `v0.66.1` release run (https://github.com/keboola/cli/actions/runs/29430278032) failed the `test-install` job's Homebrew leg:

```
==> Tapping keboola/keboola-cli2
Error: Refusing to load formula keboola/keboola-cli2/keboola-cli2 from untrusted tap keboola/keboola-cli2.
Run `brew trust --formula keboola/keboola-cli2/keboola-cli2` or `brew trust keboola/keboola-cli2` to trust it.
```

This is the **first release run that actually reaches this step** — homebrew/chocolatey were broken on every prior tag (v0.63.3 through v0.66.0) and fixed only in #476, merged after v0.66.0 was cut. So this "untrusted tap" gate was never exercised before now.

Note the actual `homebrew` publish job (pushing the formula to the tap) succeeded — this only affects the `test-install` smoke-test leg that verifies `brew install` works end to end.

## What changed

Add `brew trust keboola/keboola-cli2` right after `brew tap`, matching the remedy `brew` itself prints on failure.

## Verification

Ran the fixed sequence locally against the real tap (arm64 linuxbrew container, Docker Desktop):

```
brew tap keboola/keboola-cli2 https://github.com/keboola/homebrew-keboola-cli2
brew trust keboola/keboola-cli2
brew install keboola-cli2
```

`brew install` completes successfully. The container image is `homebrew/brew`, and `kbagent --version` fails there with an arm64-bottle/glibc mismatch that's specific to my local (arm64) test container — not indicative of a problem on the actual `ubuntu-latest` (amd64) CI runner, where the same v0.66.1 binary already passes `kbagent --version` via this job's apt/rpm legs.

No `make check` changes needed — this is a workflow-only fix (no Python/CLI behavior change), and `release-kbagent.yml` only triggers on `v*.*.*` tag pushes, so it can't be exercised by this PR's own CI. Next real verification is the next tag push.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->