### PR TITLE
ci(release): make winget job bootstrap-aware for un-submitted manifest (#484)

### DIFF
--- a/.github/workflows/release-kbagent.yml
+++ b/.github/workflows/release-kbagent.yml
@@ -442,7 +442,32 @@ jobs:
           curl -fLSs https://aka.ms/wingetcreate/latest -o wingetcreate.exe
           # Verify it's validly Authenticode-signed by Microsoft before executing.
           powershell -Command '$s = Get-AuthenticodeSignature wingetcreate.exe; if ($s.Status -ne "Valid" -or $s.SignerCertificate.Subject -notmatch "Microsoft") { Write-Error "wingetcreate.exe signature not valid/Microsoft: $($s.Status)"; exit 1 }'
-          ./wingetcreate.exe update -v "$VERSION" -u "$url" -t "$WINGET_TOKEN" Keboola.KeboolaCLI2 -s
+          # `wingetcreate update` only works against an EXISTING manifest in
+          # microsoft/winget-pkgs. Until Keboola.KeboolaCLI2 is bootstrapped there
+          # with a one-time interactive `wingetcreate new` submission (see issue #484),
+          # every run 404s with "was not found". Treat that known, expected state as a
+          # skip with a loud pointer instead of a hard failure, so a first-run-after-a-gap
+          # doesn't masquerade as a silent regression — while any genuine winget error
+          # still fails the job.
+          set +e
+          output=$(./wingetcreate.exe update -v "$VERSION" -u "$url" -t "$WINGET_TOKEN" Keboola.KeboolaCLI2 -s 2>&1)
+          status=$?
+          set -e
+          echo "$output"
+          if [ "$status" -ne 0 ]; then
+            if echo "$output" | grep -qi "was not found"; then
+              msg="WinGet package Keboola.KeboolaCLI2 is not yet bootstrapped in microsoft/winget-pkgs; skipping. A one-time interactive \`wingetcreate new\` submission is required first — see https://github.com/keboola/cli/issues/484."
+              echo "::warning::${msg}"
+              {
+                echo "### WinGet skipped — package not bootstrapped"
+                echo ""
+                echo "${msg}"
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            echo "::error::wingetcreate update failed (exit ${status})"
+            exit "$status"
+          fi
 
   # ── Smoke-test the real install paths end to end. Runs on every tag (incl. dev tags,
   #    against PUBLISH_PREFIX); the Homebrew leg is prod-only since the tap isn't pushed


### PR DESCRIPTION
## What

Make the `winget` job in `release-kbagent.yml` **bootstrap-aware**: distinguish the known, expected "package not yet submitted to `microsoft/winget-pkgs`" state from a genuine `wingetcreate` failure.

- On a `"was not found"` result (the package has no initial manifest yet), the job now **skips** with a loud `::warning::` and a `$GITHUB_STEP_SUMMARY` entry pointing to #484, and exits 0.
- Any **other** non-zero result still hard-fails the job (`::error::` + original exit code).

## Why

Per #484, `v0.66.1` was the first release ever to actually reach the `winget` job (previously skipped because its `needs:` chain failed until #476). `wingetcreate update` only patches an **existing** manifest — and `Keboola.KeboolaCLI2` has never been bootstrapped in `microsoft/winget-pkgs`. So the job 404s with `was not found` and fails, even though the WinGet channel being absent is the same expected state as every prior version.

This change stops that expected, un-bootstrapped state from masquerading as a silent regression in the release run, while keeping real winget errors fatal.

## Scope / what this does NOT do

This is **only** issue #484's optional follow-up (point 3). It does **not** perform the actual first-time submission — that still requires a human with `WINGET_TOKEN` access to run `wingetcreate new` locally/interactively once against the Windows asset and shepherd the initial PR through Microsoft's review, as described in the issue. Once that initial manifest is merged upstream, `wingetcreate update` succeeds normally and this skip branch is never taken.

## Testing

- `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses.
- Reviewed the bash branch logic: `set +e` / captured `$status` / `set -e`, case-insensitive `grep -qi "was not found"` for the skip path, hard-fail preserved for every other exit code.
- Pure CI workflow change — no CLI/Python surface, no changelog entry required (`make changelog-check` passes), no silent-drift command surfaces affected.

Note for review: this deliberately makes the un-bootstrapped winget state non-fatal. If the release pipeline should instead keep hard-failing until bootstrap, that's a one-line change (drop the `exit 0`).

Fixes #484
