### PR TITLE
fix(semantic-layer): classify numeric/temporal field roles by normalized type

### DIFF
--- a/src/keboola_agent_cli/services/_semantic_layer_internals.py
+++ b/src/keboola_agent_cli/services/_semantic_layer_internals.py
@@ -955,6 +955,7 @@ _FIELD_TYPE_MAP: dict[str, str] = {
     "bigint": "integer",
     "smallint": "integer",
     "tinyint": "integer",
+    "int64": "integer",  # BigQuery
     # decimals
     "decimal": "decimal",
     "numeric": "decimal",
@@ -963,6 +964,8 @@ _FIELD_TYPE_MAP: dict[str, str] = {
     "double": "decimal",
     "real": "decimal",
     "money": "decimal",
+    "float64": "decimal",  # BigQuery
+    "bignumeric": "decimal",  # BigQuery
     # booleans
     "boolean": "boolean",
     "bool": "boolean",

--- a/src/keboola_agent_cli/services/semantic_layer_service.py
+++ b/src/keboola_agent_cli/services/semantic_layer_service.py
@@ -35,8 +35,8 @@ from ._semantic_layer_crud import edit_simple as _edit_simple_helper
 from ._semantic_layer_crud import find_target_for_remove as _find_target_for_remove
 from ._semantic_layer_crud import scan_orphan_constraints as _scan_orphan_constraints
 from ._semantic_layer_crud import validate_constraint_attrs as _validate_constraint_attrs
+from ._semantic_layer_internals import _normalize_field_type, collect_side_from_file
 from ._semantic_layer_internals import build_export_snapshot as _build_export_snapshot
-from ._semantic_layer_internals import collect_side_from_file
 from ._semantic_layer_internals import default_export_path as _default_export_path
 from ._semantic_layer_internals import diff_one_type as _diff_one_type_helper
 from ._semantic_layer_internals import fetch_table_schemas as _fetch_table_schemas
@@ -94,7 +94,11 @@ _MEASURE_TOKENS = (
     "QTY",
     "QUANTITY",
 )
-_NUMERIC_TYPES = ("NUMBER", "DECIMAL", "FLOAT", "INTEGER", "INT")
+# Normalized field types (see ``_normalize_field_type``) that represent a
+# numeric quantity, and thus qualify a measure-named column as a `measure`.
+_NUMERIC_NORMALIZED_TYPES = ("integer", "decimal")
+# Normalized field types that represent a point in time.
+_TEMPORAL_NORMALIZED_TYPES = ("date", "datetime")
 
 
 def _derive_fqn(table_id: str) -> str:
@@ -130,13 +134,25 @@ def _derive_fqn(table_id: str) -> str:
 
 
 def _classify_field_role(name: str, basetype: str) -> str:
-    """Apply the documented role heuristic to (column name, basetype)."""
+    """Apply the documented role heuristic to (column name, basetype).
+
+    The type test runs through ``_normalize_field_type`` rather than matching
+    raw type names, so it is warehouse-agnostic: Snowflake ``NUMBER``,
+    BigQuery ``INT64`` / ``FLOAT64`` / ``NUMERIC`` and the Keboola basetypes
+    (``INTEGER`` / ``NUMERIC`` / ``FLOAT``) all resolve to the same normalized
+    families. Before this, ``NUMERIC`` (Keboola's own basetype for BigQuery
+    and Snowflake decimals) was absent from the numeric whitelist, so numeric
+    measure columns silently fell through to ``dimension``.
+    """
     upper = name.upper()
     if any(upper.startswith(prefix) for prefix in _KEY_PREFIXES):
         return "key"
-    if any(tok in upper for tok in _TIMESTAMP_NAMES):
+    normalized = _normalize_field_type(basetype)
+    # A DATE / TIMESTAMP column is a timestamp regardless of its name; the
+    # name tokens stay as a fallback for untyped columns (basetype missing).
+    if normalized in _TEMPORAL_NORMALIZED_TYPES or any(tok in upper for tok in _TIMESTAMP_NAMES):
         return "timestamp"
-    if basetype.upper() in _NUMERIC_TYPES and any(tok in upper for tok in _MEASURE_TOKENS):
+    if normalized in _NUMERIC_NORMALIZED_TYPES and any(tok in upper for tok in _MEASURE_TOKENS):
         return "measure"
     return "dimension"
 

--- a/tests/test_semantic_layer_service.py
+++ b/tests/test_semantic_layer_service.py
@@ -165,6 +165,30 @@ class TestClassifyFieldRole:
     def test_plain_dimension_default(self) -> None:
         assert _classify_field_role("USER_NAME", "STRING") == "dimension"
 
+    def test_numeric_basetype_measure_regression(self) -> None:
+        # Regression: NUMERIC is Keboola's basetype for Snowflake/BigQuery
+        # decimals. It used to be absent from the numeric whitelist, so every
+        # NUMERIC measure column was misclassified as a dimension.
+        assert _classify_field_role("TOTAL_REVENUE", "NUMERIC") == "measure"
+
+    def test_bigquery_native_numeric_types_are_measures(self) -> None:
+        # BigQuery native type names (surfaced when types are read straight
+        # from the warehouse) must classify like their Keboola basetypes.
+        assert _classify_field_role("COUNT_ORDERS", "INT64") == "measure"
+        assert _classify_field_role("REVENUE", "FLOAT64") == "measure"
+        assert _classify_field_role("PRICE", "BIGNUMERIC") == "measure"
+
+    def test_date_typed_column_is_timestamp_regardless_of_name(self) -> None:
+        # A DATE/TIMESTAMP column is temporal even when its name carries none
+        # of the timestamp tokens (e.g. a bare "date" column).
+        assert _classify_field_role("date", "DATE") == "timestamp"
+        assert _classify_field_role("_timestamp", "TIMESTAMP") == "timestamp"
+
+    def test_missing_basetype_stays_dimension(self) -> None:
+        # With no basetype (untyped column) the numeric test cannot fire, so a
+        # measure-named column falls back to dimension.
+        assert _classify_field_role("total_revenue", "") == "dimension"
+
 
 # ---------------------------------------------------------------------------
 # Model resolution
@@ -2064,6 +2088,10 @@ class TestNormalizeFieldType:
             ("DATE", "date"),
             ("TIMESTAMP_NTZ", "datetime"),
             ("VARIANT", "json"),
+            # BigQuery native type names.
+            ("INT64", "integer"),
+            ("FLOAT64", "decimal"),
+            ("BIGNUMERIC", "decimal"),
             # Unknown types fall through to `"string"` — safest default.
             ("CUSTOM_UDT", "string"),
             ("geography", "string"),


### PR DESCRIPTION
## Problem

`kbagent semantic-layer build` (and `add dataset --deep-fields`) classifies every column of a table into a field *role* — `key`, `timestamp`, `measure`, or `dimension`. In practice, numeric measure columns were being classified as `dimension`, even on fully-typed tables.

Root cause: the heuristic matched **raw** type names against a Snowflake-flavored whitelist:

```python
_NUMERIC_TYPES = ("NUMBER", "DECIMAL", "FLOAT", "INTEGER", "INT")
```

Keboola's own basetype for decimals is **`NUMERIC`**, which is not in that list. So a column whose Storage basetype is `NUMERIC` (the common case for revenue/amount/ratio columns on **both** Snowflake and BigQuery) never matched the numeric test and fell through to `dimension`. BigQuery native names (`INT64`, `FLOAT64`, `BIGNUMERIC`) weren't recognized either.

Concrete example — a BigQuery metrics table with columns like `total_ppc_revenue` (NUMERIC), `marketplace_gmv` (NUMERIC), `count_marketplace_orders` (INT64): all 50+ numeric columns classified as `dimension`.

## Fix

- Route the type test through the existing `_normalize_field_type` closed vocabulary instead of matching raw names, so it is warehouse-agnostic (`NUMBER`, `NUMERIC`, `INT64`, `FLOAT64`, Keboola basetypes — all resolve correctly).
- Add the missing BigQuery native names to `_FIELD_TYPE_MAP` (`int64`, `float64`, `bignumeric`).
- A `DATE`/`TIMESTAMP`-typed column now classifies as `timestamp` regardless of its name (a bare `date` column was previously a `dimension`); the existing name tokens stay as a fallback for untyped columns.

## Tests

- Added regression cases to `TestClassifyFieldRole`: NUMERIC measure, BigQuery native numeric types, type-driven timestamp, and the untyped-column fallback.
- Extended the `_normalize_field_type` parametrization with the BigQuery names.
- Full `tests/test_semantic_layer_service.py` suite passes (156 tests); `ruff check` clean.

## Scope / follow-up

This fixes classification **when column types are available**. A separate follow-up PR addresses the orthogonal issue that *alias / linked-bucket* tables carry no column datatype metadata locally (the types live on the source table), which leaves `basetype` empty and is a different code path.
