### PR TITLE
docs: complete error-codes.md (46 -> 66 codes) + enforce enum-doc sync

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -19,6 +19,8 @@ of `ErrorCode` in `src/keboola_agent_cli/errors.py`.
 | `INVALID_TOKEN` | Storage API token is invalid or expired |
 | `ACCESS_DENIED` | Token lacks the required permission for this API call |
 | `PERMISSION_DENIED` | Operation blocked by the active kbagent permission policy |
+| `MISSING_MASTER_TOKEN` | Operation requires a master (admin) Storage token (e.g. `config oauth-url` pre-flight); maps to exit 3 |
+| `UNAUTHORIZED` | `kbagent serve` rejected the request's Bearer token |
 
 ### Network / transport
 
@@ -41,6 +43,8 @@ of `ErrorCode` in `src/keboola_agent_cli/errors.py`.
 | `USAGE_ERROR` | Incorrect CLI flag combination or missing required argument |
 | `MISSING_PARAMETER` | A required parameter was not supplied |
 | `UNKNOWN_ERROR` | Catch-all for unclassified errors |
+| `HTTP_ERROR` | Generic HTTP-layer error in the `kbagent serve` envelope (HTTPException passthrough) |
+| `INTERNAL_ERROR` | Uncaught exception inside a `kbagent serve` route handler (HTTP 500) |
 
 ### Configuration
 
@@ -60,6 +64,7 @@ of `ErrorCode` in `src/keboola_agent_cli/errors.py`.
 | `STORAGE_JOB_TIMEOUT` | Polling timed out waiting for a Storage async job |
 | `QUERY_JOB_FAILED` | Query Service job finished in a failed state |
 | `QUERY_JOB_TIMEOUT` | Polling timed out waiting for a Query Service job |
+| `JOB_TIMEOUT_TERMINATED` | `job run --wait` timeout expired and the remote job was successfully cancelled (exit 7; distinct from `QUEUE_JOB_TIMEOUT`, where the remote may still be running) |
 
 ### Variables
 
@@ -121,9 +126,39 @@ of `ErrorCode` in `src/keboola_agent_cli/errors.py`.
 | Code | Description |
 |---|---|
 | `PARENT_CONFIG_NOT_TRACKED` | Row operation references a parent config not in the manifest |
+| `VARIABLE_LINK_UNRESOLVED` | `sync push` could not resolve a transformation's variables link to a tracked config |
+| `SYNC_CONFLICT` | `sync pull --force` aborted: local and remote both changed since the last pull (`details.conflicts` lists them) |
 
 ### Encryption
 
 | Code | Description |
 |---|---|
 | `ENCRYPTION_FAILED` | Secret encryption via the Encryption API failed |
+
+### Flow
+
+| Code | Description |
+|---|---|
+| `SCHEDULE_DELETE_FAILED` | Deleting or deregistering a flow schedule failed |
+| `INVALID_FLOW_DEFINITION` | Flow definition failed schema or semantic validation |
+
+### Data Apps
+
+| Code | Description |
+|---|---|
+| `DATA_APP_BUILD_FAILED` | Data app deploy/start poll loop ended in a failed build or setup state |
+| `DATA_APP_DEPLOY_TIMEOUT` | Polling timed out waiting for a data app deploy or start |
+| `DATA_APP_INVALID_GIT` | Data app git repository configuration is invalid or inaccessible |
+| `DATA_APP_INVALID_SECRET` | Data app secret key or value failed validation |
+| `DATA_APP_INVALID_REPO` | Reserved: repository failed data-app validation (not currently emitted; `validate-repo` reports findings with exit 1) |
+| `DATA_APP_REPO_VALIDATION_BLOCKING` | Reserved: blocking repo-validation findings (not currently emitted; `validate-repo` reports findings with exit 1) |
+
+### Developer Portal
+
+| Code | Description |
+|---|---|
+| `DP_LOGIN_FAILED` | Developer Portal login failed (bad credentials or unexpected auth response) |
+| `DP_MFA_REQUIRED` | Developer Portal account requires MFA, which the CLI login flow does not support |
+| `DP_APP_NOT_FOUND` | Developer Portal app not found under the vendor |
+| `DP_PUBLISH_REQUIREMENTS_MISSING` | App is missing required fields for publishing (fix via `dev-portal patch` first) |
+| `DP_ICON_UPLOAD_FAILED` | Uploading the app icon to the Developer Portal failed |

--- a/scripts/check_error_codes.py
+++ b/scripts/check_error_codes.py
@@ -3,6 +3,11 @@
 Any site that passes error_code="LITERAL_STRING" to KeboolaApiError,
 ConfigError, or formatter.error() must use ErrorCode.<MEMBER> instead.
 
+Also verifies docs/error-codes.md completeness: every ErrorCode enum member
+must appear in the doc's code catalogue (as a `` `CODE` `` table cell) and
+vice versa. The doc is publicly linked from help.keboola.com, so drift ships
+broken documentation.
+
 Usage (run from repo root):
     python scripts/check_error_codes.py          # exits 1 if violations found
     python scripts/check_error_codes.py --list   # print all current enum members
@@ -13,11 +18,55 @@ Safe exceptions (not flagged):
 """
 
 import ast
+import re
 import sys
 from pathlib import Path
 
-SRC_ROOT = Path(__file__).parent.parent / "src"
+REPO_ROOT = Path(__file__).parent.parent
+SRC_ROOT = REPO_ROOT / "src"
+ERRORS_PATH = SRC_ROOT / "keboola_agent_cli" / "errors.py"
+DOC_PATH = REPO_ROOT / "docs" / "error-codes.md"
 SKIP_FILES = {"errors.py"}
+
+
+def _enum_members() -> set[str]:
+    """Parse ErrorCode members from errors.py without importing the package."""
+    tree = ast.parse(ERRORS_PATH.read_text(encoding="utf-8"))
+    members: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "ErrorCode":
+            for item in node.body:
+                if isinstance(item, ast.Assign):
+                    for t in item.targets:
+                        if isinstance(t, ast.Name):
+                            members.add(t.id)
+    return members
+
+
+def _documented_codes() -> set[str]:
+    """Parse code names from docs/error-codes.md table rows (`` | `CODE` | ... ``)."""
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    return set(re.findall(r"^\| `([A-Z][A-Z0-9_]*)` \|", doc, re.MULTILINE))
+
+
+def _check_doc_completeness() -> bool:
+    """Return True when the enum and docs/error-codes.md list the same codes."""
+    enum_codes = _enum_members()
+    doc_codes = _documented_codes()
+    ok = True
+    missing = sorted(enum_codes - doc_codes)
+    if missing:
+        ok = False
+        print(f"  docs/error-codes.md is missing {len(missing)} enum member(s):")
+        for code in missing:
+            print(f"    {code}")
+    stale = sorted(doc_codes - enum_codes)
+    if stale:
+        ok = False
+        print(f"  docs/error-codes.md documents {len(stale)} unknown code(s):")
+        for code in stale:
+            print(f"    {code}")
+    return ok
 
 
 def _collect_violations(path: Path) -> list[tuple[int, str]]:
@@ -42,17 +91,8 @@ def _collect_violations(path: Path) -> list[tuple[int, str]]:
 
 def main() -> int:
     if "--list" in sys.argv:
-        # Print all known enum members without importing the package
-        errors_path = SRC_ROOT / "keboola_agent_cli" / "errors.py"
-        source = errors_path.read_text(encoding="utf-8")
-        tree = ast.parse(source)
-        for node in ast.walk(tree):
-            if isinstance(node, ast.ClassDef) and node.name == "ErrorCode":
-                for item in node.body:
-                    if isinstance(item, ast.Assign):
-                        for t in item.targets:
-                            if isinstance(t, ast.Name):
-                                print(f"  ErrorCode.{t.id}")
+        for member in sorted(_enum_members()):
+            print(f"  ErrorCode.{member}")
         return 0
 
     found_any = False
@@ -70,7 +110,11 @@ def main() -> int:
         print("\nFAIL: raw error_code string literals found. Replace with ErrorCode.<MEMBER>.")
         return 1
 
-    print("OK: no raw error_code string literals in source.")
+    if not _check_doc_completeness():
+        print("\nFAIL: docs/error-codes.md is out of sync with the ErrorCode enum.")
+        return 1
+
+    print("OK: no raw error_code literals; docs/error-codes.md matches the enum.")
     return 0
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -309,3 +309,46 @@ class TestCheckErrorCodesGuard:
                     violations.append(kw.value.value)
 
         assert violations == [], "Enum usage should not be flagged as a violation"
+
+
+@pytest.mark.integration
+class TestErrorCodesDocCompleteness:
+    """Verify the enum-vs-docs/error-codes.md completeness guard."""
+
+    @staticmethod
+    def _load_script():
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "check_error_codes", Path("scripts") / "check_error_codes.py"
+        )
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_doc_matches_enum(self) -> None:
+        """docs/error-codes.md documents exactly the ErrorCode members."""
+        mod = self._load_script()
+        assert mod._enum_members() == mod._documented_codes()
+
+    def test_detects_missing_code(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Removing one documented code from the doc makes the check fail."""
+        mod = self._load_script()
+        doc_lines = mod.DOC_PATH.read_text(encoding="utf-8").splitlines(keepends=True)
+        pruned = [line for line in doc_lines if not line.startswith("| `INVALID_TOKEN` |")]
+        assert len(pruned) == len(doc_lines) - 1
+        stripped_doc = tmp_path / "error-codes.md"
+        stripped_doc.write_text("".join(pruned), encoding="utf-8")
+        monkeypatch.setattr(mod, "DOC_PATH", stripped_doc)
+        assert mod._check_doc_completeness() is False
+
+    def test_detects_stale_code(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A doc row for a code that is not in the enum makes the check fail."""
+        mod = self._load_script()
+        doc = mod.DOC_PATH.read_text(encoding="utf-8")
+        doc += "| `NO_SUCH_CODE_EVER` | Planted stale row |\n"
+        stale_doc = tmp_path / "error-codes.md"
+        stale_doc.write_text(doc, encoding="utf-8")
+        monkeypatch.setattr(mod, "DOC_PATH", stale_doc)
+        assert mod._check_doc_completeness() is False


### PR DESCRIPTION
## Why

`docs/error-codes.md` had drifted 20 codes behind the `ErrorCode` enum (46 documented vs 66 members) — everything added since ~0.22.0 was missing: Data Apps, Developer Portal, Flow, the `kbagent serve` envelope codes, and the newer Sync/Auth codes. The doc is now publicly linked from the new help-docs CLI section (keboola/connection-docs#1015), so an incomplete list ships broken public documentation.

## What

- **`docs/error-codes.md`**: adds the 20 missing codes to their category sections; new sections **Flow**, **Data Apps**, **Developer Portal**. Descriptions were written from the actual emit sites, not guessed. `DATA_APP_INVALID_REPO` and `DATA_APP_REPO_VALIDATION_BLOCKING` are honestly marked *reserved* — defined in the enum since 0.28.0 but not emitted anywhere (`validate-repo` signals findings via exit 1).
- **`scripts/check_error_codes.py`** (`make check-error-codes`): new enum-vs-doc completeness check — every `ErrorCode` member must appear in the doc's tables and vice versa, so the doc cannot silently drift again. `--list` now reuses the shared enum parser.
- **Tests**: `TestErrorCodesDocCompleteness` in `tests/test_integration.py` — doc matches enum; a pruned code and a planted stale row are both detected.

## Verification

- `uv run python scripts/check_error_codes.py` → `OK: no raw error_code literals; docs/error-codes.md matches the enum.`
- `uv run pytest tests/test_integration.py -q` → 6 passed, 3 skipped (env-gated)
- `ruff check` + `ruff format --check` clean

No version bump: docs + local-only CI guard, no runtime behavior change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->