### PR TITLE
feat(storage): surface cloud-provider error code in upload failures

### DIFF
--- a/src/keboola_agent_cli/client.py
+++ b/src/keboola_agent_cli/client.py
@@ -20,6 +20,7 @@ from urllib.parse import quote
 import httpx
 
 from .constants import (
+    CLOUD_UPLOAD_ERROR_BODY_LIMIT,
     DEFAULT_GROUPED_JOBS_LIMIT,
     DEFAULT_JOB_LIMIT,
     DEFAULT_JOBS_PER_CONFIG,
@@ -1921,8 +1922,20 @@ class KeboolaClient(BaseHttpClient):
             success_codes = (200, 201)
 
         if response.status_code not in success_codes:
+            # The provider's error body names the exact denial (service
+            # account, missing permission) -- essential when diagnosing e.g.
+            # a platform-side IAM misconfiguration -- but it may embed signed
+            # URLs, so the full text goes to the DEBUG log only; the raised
+            # message carries just the short whitelisted error code.
+            logger.debug(
+                "Cloud storage error response (HTTP %d): %s",
+                response.status_code,
+                response.text[:CLOUD_UPLOAD_ERROR_BODY_LIMIT],
+            )
+            provider_code = _extract_cloud_error_code(response)
+            code_suffix = f", {provider_code}" if provider_code else ""
             raise KeboolaApiError(
-                message=f"Cloud storage upload failed (HTTP {response.status_code})",
+                message=(f"Cloud storage upload failed (HTTP {response.status_code}{code_suffix})"),
                 status_code=response.status_code,
                 error_code=ErrorCode.UPLOAD_FAILED,
                 retryable=False,
@@ -3343,6 +3356,26 @@ def _build_abs_upload_url(abs_params: dict[str, Any]) -> str:
     sas = parts.get("SharedAccessSignature", "")
 
     return f"{blob_endpoint}/{container}/{blob_name}?{sas}"
+
+
+# Strict charset: provider error codes are short alphanumeric tokens (GCS/S3
+# "AccessDenied", Azure "AuthorizationFailure"). Anything else in the response
+# -- signed URLs, credentials, free-form messages -- must never reach the
+# user-facing error string.
+_CLOUD_ERROR_CODE_RE = re.compile(r"<Code>([A-Za-z0-9._-]{1,64})</Code>")
+
+
+def _extract_cloud_error_code(response: httpx.Response) -> str | None:
+    """Best-effort short error code from a failed cloud-storage response.
+
+    Azure surfaces it in the ``x-ms-error-code`` header; GCS and S3 return an
+    XML body with a ``<Code>`` element. Returns ``None`` when neither matches.
+    """
+    header_code = response.headers.get("x-ms-error-code", "")
+    if header_code and re.fullmatch(r"[A-Za-z0-9._-]{1,64}", header_code):
+        return header_code
+    match = _CLOUD_ERROR_CODE_RE.search(response.text[:CLOUD_UPLOAD_ERROR_BODY_LIMIT])
+    return match.group(1) if match else None
 
 
 # ---------------------------------------------------------------------------

--- a/src/keboola_agent_cli/constants.py
+++ b/src/keboola_agent_cli/constants.py
@@ -170,6 +170,11 @@ FILE_UPLOAD_TIMEOUT: httpx.Timeout = httpx.Timeout(
     connect=30.0, read=300.0, write=3600.0, pool=30.0
 )
 
+# Max chars of a failed cloud-storage response body to inspect/log. Provider
+# error XMLs are well under 1 KB; the cap keeps a pathological body from
+# bloating the DEBUG log or the error-code regex scan.
+CLOUD_UPLOAD_ERROR_BODY_LIMIT: int = 1500
+
 # --- File Download Timeout ---
 FILE_DOWNLOAD_TIMEOUT: httpx.Timeout = httpx.Timeout(
     connect=30.0, read=3600.0, write=10.0, pool=30.0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import json
+import logging
 from typing import SupportsIndex
 from unittest.mock import patch
 from urllib.parse import parse_qs, quote
@@ -3737,4 +3738,116 @@ class TestGlobalSearchRegex:
 
         sent = httpx_mock.get_request()
         assert b"mode" not in sent.url.query
+        client.close()
+
+
+GCS_ACCESS_DENIED_XML = (
+    "<?xml version='1.0' encoding='UTF-8'?><Error><Code>AccessDenied</Code>"
+    "<Message>Access denied.</Message><Details>sa@project.iam.gserviceaccount.com "
+    "does not have storage.objects.create access to the object.</Details></Error>"
+)
+
+
+class TestExtractCloudErrorCode:
+    """Short provider error code extraction from a failed cloud-storage response."""
+
+    def test_gcs_s3_xml_code(self) -> None:
+        from keboola_agent_cli.client import _extract_cloud_error_code
+
+        response = httpx.Response(403, text=GCS_ACCESS_DENIED_XML)
+        assert _extract_cloud_error_code(response) == "AccessDenied"
+
+    def test_azure_header_code(self) -> None:
+        from keboola_agent_cli.client import _extract_cloud_error_code
+
+        response = httpx.Response(403, text="", headers={"x-ms-error-code": "AuthorizationFailure"})
+        assert _extract_cloud_error_code(response) == "AuthorizationFailure"
+
+    def test_unparseable_body_returns_none(self) -> None:
+        from keboola_agent_cli.client import _extract_cloud_error_code
+
+        response = httpx.Response(403, text="upstream gateway error (html)")
+        assert _extract_cloud_error_code(response) is None
+
+    def test_code_outside_whitelist_charset_rejected(self) -> None:
+        # A <Code> carrying anything beyond the short alphanumeric token charset
+        # (e.g. an injected signed URL) must not reach the error message.
+        from keboola_agent_cli.client import _extract_cloud_error_code
+
+        response = httpx.Response(403, text="<Error><Code>https://evil?sig=secret</Code></Error>")
+        assert _extract_cloud_error_code(response) is None
+
+
+GCS_UPLOAD_INFO = {
+    "id": 99,
+    "gcsUploadParams": {
+        "bucket": "kbc-test-files",
+        "key": "exp-15/9621/files/test.csv",
+        "access_token": "901-gcs-fakeUploadTokenXXXX",
+    },
+}
+
+
+class TestUploadToCloudErrorDiagnostics:
+    """_upload_to_cloud failure carries the provider code + DEBUG-logs the body."""
+
+    def test_403_message_carries_provider_code_and_logs_body(
+        self, httpx_mock, tmp_path, caplog
+    ) -> None:
+        test_file = tmp_path / "test.csv"
+        test_file.write_text("a,b\n1,2\n")
+        httpx_mock.add_response(
+            url="https://storage.googleapis.com/kbc-test-files/exp-15/9621/files/test.csv",
+            method="PUT",
+            status_code=403,
+            text=GCS_ACCESS_DENIED_XML,
+        )
+        client = KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token="901-55555-fakeTestTokenDoNotUseXXXXXXXX",
+        )
+        with (
+            caplog.at_level(logging.DEBUG, logger="keboola_agent_cli.client"),
+            pytest.raises(KeboolaApiError) as exc_info,
+        ):
+            client._upload_to_cloud(GCS_UPLOAD_INFO, str(test_file))
+        client.close()
+
+        assert exc_info.value.message == "Cloud storage upload failed (HTTP 403, AccessDenied)"
+        # Full provider body (service account + missing permission) is DEBUG-only.
+        assert "storage.objects.create" in caplog.text
+        assert "storage.objects.create" not in exc_info.value.message
+
+    def test_403_without_parseable_code_keeps_plain_message(self, httpx_mock, tmp_path) -> None:
+        test_file = tmp_path / "test.csv"
+        test_file.write_text("a,b\n1,2\n")
+        httpx_mock.add_response(
+            url="https://storage.googleapis.com/kbc-test-files/exp-15/9621/files/test.csv",
+            method="PUT",
+            status_code=403,
+            text="<html>gateway error</html>",
+        )
+        client = KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token="901-55555-fakeTestTokenDoNotUseXXXXXXXX",
+        )
+        with pytest.raises(KeboolaApiError) as exc_info:
+            client._upload_to_cloud(GCS_UPLOAD_INFO, str(test_file))
+        client.close()
+
+        assert exc_info.value.message == "Cloud storage upload failed (HTTP 403)"
+
+    def test_success_path_unaffected(self, httpx_mock, tmp_path) -> None:
+        test_file = tmp_path / "test.csv"
+        test_file.write_text("a,b\n1,2\n")
+        httpx_mock.add_response(
+            url="https://storage.googleapis.com/kbc-test-files/exp-15/9621/files/test.csv",
+            method="PUT",
+            status_code=200,
+        )
+        client = KeboolaClient(
+            stack_url="https://connection.keboola.com",
+            token="901-55555-fakeTestTokenDoNotUseXXXXXXXX",
+        )
+        client._upload_to_cloud(GCS_UPLOAD_INFO, str(test_file))
         client.close()


### PR DESCRIPTION
## What

Upload failures against cloud storage (`storage file-upload`, `storage upload-table`, data-app artifact paths -- everything flowing through `KeboolaClient._upload_to_cloud`) now surface the provider's short error code and preserve the full provider error body in the DEBUG log:

- **Message**: `Cloud storage upload failed (HTTP 403, AccessDenied)` instead of the previous opaque `Cloud storage upload failed (HTTP 403)`.
- **DEBUG log**: the raw response body (truncated to `CLOUD_UPLOAD_ERROR_BODY_LIMIT` = 1500 chars) is logged before raising, so `--verbose` reveals the exact denial detail.

## Why

On 2026-07-20 file uploads to project 9621 (BigQuery, `connection.keboola.com`) started failing with a bare `HTTP 403`. The actual cause -- a platform-side IAM misconfiguration, with GCS answering `AccessDenied: <service account> does not have storage.objects.create access` -- was only visible in the response body that the CLI discarded. Diagnosing it required a temporary code edit. This change makes that class of failure self-explanatory from the CLI output.

## Safety

Provider error bodies can embed signed URLs, so the full body goes to the DEBUG log only. The user-facing message carries just the short error code, validated against a strict `[A-Za-z0-9._-]{1,64}` whitelist (GCS/S3 XML `<Code>`, Azure `x-ms-error-code` header). A `<Code>` containing anything else (e.g. injected URL with a signature) is dropped -- covered by a dedicated test.

## Tests

- `TestExtractCloudErrorCode`: GCS/S3 XML code, Azure header code, unparseable body -> `None`, charset-whitelist rejection of injected content.
- `TestUploadToCloudErrorDiagnostics`: 403 message carries the code while the body detail stays DEBUG-only; 403 without parseable code keeps the plain message; success path unaffected.
- `make check` green (4321 passed).

No version bump (code-only, rides with the next release).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->