### PR TITLE
fix(sync): sync push no longer duplicates configs inherited from main on a dev branch

### DIFF
--- a/src/keboola_agent_cli/services/sync_service.py
+++ b/src/keboola_agent_cli/services/sync_service.py
@@ -1225,26 +1225,48 @@ class SyncService(BaseService):
                 }
             )
 
-        # Also add untracked local configs (new files)
-        for added_cfg in self._find_untracked_configs(project_root, manifest, branch_id):
-            branch_path = self._resolve_source_branch_path(manifest, project_root, branch_id)
-            config_dir = project_root / branch_path / added_cfg["path"]
+        # Build set of manifest-tracked keys so that compute_changeset only
+        # flags configs that were previously pulled (not brand-new remote ones).
+        tracked_keys = {f"{cfg.component_id}/{cfg.id}" for cfg in manifest.configurations}
+
+        # Also add untracked local configs (new files). Scan ONLY the branch
+        # subtree push reads from -- scanning another branch's tree (e.g.
+        # ``main/`` while targeting a dev branch) turned configs orphaned by a
+        # branch switch into phantom "added" entries, and push then created a
+        # duplicate on the target branch for each of them (issue #482).
+        source_branch_path = self._resolve_source_branch_path(manifest, project_root, branch_id)
+        for added_cfg in self._find_untracked_configs(
+            project_root, manifest, only_branch_path=source_branch_path
+        ):
+            config_dir = project_root / source_branch_path / added_cfg["path"]
             local_data = self._read_config_file(config_dir)
             if local_data is None:
                 continue
+            component_id = added_cfg.get("component_id", "unknown")
+            merge_code_files(component_id, local_data, config_dir)
+            # Adopt-by-id guard (issue #482): an untracked file whose
+            # ``_keboola.config_id`` resolves on the target branch and is not
+            # claimed by any manifest entry refers to an EXISTING remote
+            # config -- diff against it (unchanged/modified) instead of
+            # letting push create a duplicate. A claimed id means the user
+            # copied a tracked config dir to fork it: keep the create.
+            untracked_id = added_cfg.get("config_id", "")
+            untracked_key = f"{component_id}/{untracked_id}"
+            if not (
+                untracked_id
+                and untracked_key in remote_configs
+                and untracked_key not in tracked_keys
+            ):
+                untracked_id = ""  # new config, push creates it
             local_configs.append(
                 {
-                    "component_id": added_cfg.get("component_id", "unknown"),
-                    "config_id": "",  # new config, no ID yet
+                    "component_id": component_id,
+                    "config_id": untracked_id,
                     "config_name": local_data.get("name", ""),
                     "path": added_cfg["path"],
                     "data": local_data,
                 }
             )
-
-        # Build set of manifest-tracked keys so that compute_changeset only
-        # flags configs that were previously pulled (not brand-new remote ones).
-        tracked_keys = {f"{cfg.component_id}/{cfg.id}" for cfg in manifest.configurations}
 
         # Build base hashes for 3-way diff.
         # Preferred: pull_config_hash (normalized hash stored at pull time).
@@ -2141,20 +2163,28 @@ class SyncService(BaseService):
         self,
         project_root: Path,
         manifest: Manifest,
-        resolved_branch_id: int | None = None,
+        only_branch_path: str | None = None,
     ) -> list[dict[str, str]]:
         """Scan for _config.yml files that are not tracked in the manifest.
 
-        Scans branch directories that the user is actively working with:
-        branches that already have tracked configs, the default branch
-        (production), and the branch the caller resolved for the current
-        operation (when provided). This supports the documented
-        "scaffold locally then push" workflow on git-branching workspaces
-        with empty ``manifest.configurations`` (issue #267, Bug B).
+        When ``only_branch_path`` is given, scan exactly that branch subtree.
+        ``diff`` / ``push`` pass the resolved *source* branch path (the tree
+        push reads configs from) so that files belonging to a different
+        branch's tree can never be classified as "added" for the target
+        branch: after a branch switch, ``sync pull`` re-targets
+        ``manifest.configurations`` to the new branch, orphaning the previous
+        branch's tree on disk -- and every orphaned file used to surface as
+        "added", making ``sync push`` create a duplicate config on the target
+        branch for each of them (issue #482).
 
-        Branches outside this scope are skipped to avoid phantom "added"
-        configs from orphaned dev-branch directories left over from
-        previous work.
+        Without ``only_branch_path`` (``sync status``), scan branch
+        directories the user is actively working with: branches that already
+        have tracked configs and the default branch (production). The default
+        branch is always in scope so the documented "scaffold locally then
+        push" workflow works on workspaces with empty
+        ``manifest.configurations`` (issue #267, Bug B). Branches outside
+        this scope are skipped to avoid phantom "added" configs from
+        orphaned dev-branch directories left over from previous work.
         """
         tracked_paths: set[str] = set()
         in_scope_branch_ids: set[int] = set()
@@ -2168,14 +2198,12 @@ class SyncService(BaseService):
         if manifest.branches:
             in_scope_branch_ids.add(manifest.branches[0].id)
 
-        # The branch the caller resolved is in scope (linked feature branch
-        # the user explicitly switched to via git checkout + branch-link).
-        if resolved_branch_id is not None:
-            in_scope_branch_ids.add(resolved_branch_id)
-
         added: list[dict[str, str]] = []
         for branch in manifest.branches:
-            if branch.id not in in_scope_branch_ids:
+            if only_branch_path is not None:
+                if branch.path != only_branch_path:
+                    continue
+            elif branch.id not in in_scope_branch_ids:
                 continue
             branch_dir = project_root / branch.path
             if not branch_dir.exists():

--- a/tests/test_sync_service.py
+++ b/tests/test_sync_service.py
@@ -2583,7 +2583,8 @@ class TestIssue267Regressions:
     def test_walker_finds_untracked_with_empty_configurations(self, tmp_path: Path) -> None:
         """``_find_untracked_configs`` surfaces a scaffold under a non-default
         branch even when ``manifest.configurations: []``, given that the
-        branch is the resolved one for this op (Bug B fix)."""
+        branch is the resolved *source* tree for this op (Bug B fix; the
+        walker takes the source branch path since issue #482)."""
         project_root = tmp_path / "project"
         project_root.mkdir()
 
@@ -2630,10 +2631,12 @@ class TestIssue267Regressions:
 
         manifest = load_manifest(project_root)
         svc = SyncService(config_store=MagicMock())
+        # diff/push resolve the source tree first (the scaffold materializes
+        # branch-99999) and pass its path to the walker.
         added = svc._find_untracked_configs(
             project_root,
             manifest,
-            resolved_branch_id=99999,
+            only_branch_path="branch-99999",
         )
 
         assert len(added) == 1
@@ -2641,8 +2644,8 @@ class TestIssue267Regressions:
 
     def test_walker_skips_orphaned_branch_dirs(self, tmp_path: Path) -> None:
         """Phantom-add protection still holds: a directory under a branch
-        whose id is neither tracked, default, nor explicitly resolved is
-        ignored. Guards against regression of Bug B in the wrong direction."""
+        other than the resolved source tree is ignored. Guards against
+        regression of Bug B in the wrong direction."""
         project_root = tmp_path / "project"
         project_root.mkdir()
         keboola_dir = project_root / KEBOOLA_DIR_NAME
@@ -2687,10 +2690,13 @@ class TestIssue267Regressions:
 
         manifest = load_manifest(project_root)
         svc = SyncService(config_store=MagicMock())
+        # Nothing on disk under the resolved branch 99999, so diff/push
+        # promote the default tree ("main") as the source -- branch-orphan
+        # must stay out of scope.
         added = svc._find_untracked_configs(
             project_root,
             manifest,
-            resolved_branch_id=99999,  # nothing on disk under this branch
+            only_branch_path="main",
         )
         assert added == []
 
@@ -2742,6 +2748,196 @@ class TestIssue267Regressions:
             pytest.raises(ConfigError, match="not linked"),
         ):
             SyncService._resolve_branch_id(project, manifest, project_root)
+
+
+# ===================================================================
+# Issue #482 regression tests
+# ===================================================================
+
+
+class TestIssue482BranchSwitchDuplicates:
+    """Regression coverage for issue #482.
+
+    ``sync pull`` replaces ``manifest.configurations`` with the pulled
+    branch's entries, so after ``branch use <dev>`` + ``pull`` the previously
+    pulled ``main/`` tree is orphaned on disk. The untracked-config walker
+    used to keep the default branch tree in scope unconditionally, so every
+    orphaned file surfaced as ``added`` (with empty ``config_id``) and
+    ``sync push`` created a duplicate config on the dev branch for each of
+    them -- 100 duplicates from a single push in the report.
+
+    The fix scopes the walker to the resolved *source* branch tree (the one
+    push reads from) and adds an adopt-by-id guard: an untracked file whose
+    ``_keboola.config_id`` resolves on the target branch and is unclaimed by
+    the manifest diffs against the existing remote config instead of
+    creating a duplicate.
+    """
+
+    def _init_and_pull_main(
+        self,
+        tmp_config_dir: Path,
+        project_root: Path,
+        components: list,
+    ) -> ConfigStore:
+        """Helper: init + pull production so ``main/`` is materialized."""
+        init_client = _make_sync_mock_client(
+            verify_token_response=SAMPLE_VERIFY_TOKEN,
+            branches_response=SAMPLE_BRANCHES,
+        )
+        store = setup_single_project(tmp_config_dir)
+        init_svc = SyncService(
+            config_store=store,
+            client_factory=lambda url, token: init_client,
+        )
+        init_svc.init_sync(alias="prod", project_root=project_root)
+
+        pull_client = _make_sync_mock_client(components_response=components)
+        pull_svc = SyncService(
+            config_store=store,
+            client_factory=lambda url, token: pull_client,
+        )
+        pull_svc.pull(alias="prod", project_root=project_root)
+        return store
+
+    def test_push_on_dev_branch_after_pull_is_noop(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """The issue's exact repro: pull main, pull a dev branch that inherits
+        the same configs, then push with zero local edits -- must be a no-op
+        instead of duplicating every config orphaned under ``main/``."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        store = self._init_and_pull_main(tmp_config_dir, project_root, SAMPLE_COMPONENTS)
+
+        # Pull the dev branch: it inherits the same configs from main.
+        dev_client = _make_sync_mock_client(
+            components_response=SAMPLE_COMPONENTS,
+            branches_response=SAMPLE_BRANCHES_WITH_DEV,
+        )
+        dev_svc = SyncService(
+            config_store=store,
+            client_factory=lambda url, token: dev_client,
+        )
+        dev_svc.pull(alias="prod", project_root=project_root, branch_override=99999)
+
+        # Bug precondition: the manifest now tracks only the dev branch while
+        # the previously pulled main/ tree is still on disk.
+        manifest = load_manifest(project_root)
+        assert {cfg.branch_id for cfg in manifest.configurations} == {99999}
+        assert (project_root / "main").is_dir()
+        assert (project_root / "feature-x").is_dir()
+
+        diff_result = dev_svc.diff(alias="prod", project_root=project_root, branch_override=99999)
+        assert diff_result["changes"] == []
+        assert diff_result["summary"]["added"] == 0
+
+        push_result = dev_svc.push(alias="prod", project_root=project_root, branch_override=99999)
+        assert push_result["status"] == "no_changes"
+        assert push_result["created"] == 0
+        dev_client.create_config.assert_not_called()
+
+    def test_untracked_file_with_known_remote_id_updates_instead_of_creating(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Adopt-by-id guard: an untracked ``_config.yml`` whose
+        ``_keboola.config_id`` exists on the target branch and is not claimed
+        by any manifest entry is diffed as ``modified`` (an update), never
+        ``added`` (a duplicate create)."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        store = self._init_and_pull_main(tmp_config_dir, project_root, SAMPLE_COMPONENTS_NO_ROWS)
+
+        # Hand-drop an untracked config dir carrying the id of a remote
+        # config the manifest does not track (e.g. rebuilt/lost manifest).
+        adopted_dir = project_root / "main" / "extractor" / "keboola.ex-http" / "orphaned-extractor"
+        adopted_dir.mkdir(parents=True)
+        (adopted_dir / CONFIG_FILENAME).write_text(
+            yaml.safe_dump(
+                {
+                    "version": 2,
+                    "name": "Orphaned Extractor",
+                    "parameters": {"baseUrl": "https://changed.example.com"},
+                    "_keboola": {
+                        "component_id": "keboola.ex-http",
+                        "config_id": "cfg-777",
+                    },
+                }
+            )
+        )
+
+        remote = [
+            {
+                **SAMPLE_COMPONENTS_NO_ROWS[0],
+                "configurations": [
+                    *SAMPLE_COMPONENTS_NO_ROWS[0]["configurations"],
+                    {
+                        "id": "cfg-777",
+                        "name": "Orphaned Extractor",
+                        "description": "",
+                        "configuration": {
+                            "parameters": {"baseUrl": "https://original.example.com"},
+                        },
+                        "rows": [],
+                    },
+                ],
+            }
+        ]
+        client = _make_sync_mock_client(components_response=remote)
+        svc = SyncService(
+            config_store=store,
+            client_factory=lambda url, token: client,
+        )
+
+        diff_result = svc.diff(alias="prod", project_root=project_root)
+        assert diff_result["summary"]["added"] == 0
+        assert diff_result["summary"]["modified"] == 1
+        modified = [c for c in diff_result["changes"] if c["change_type"] == "modified"]
+        assert modified[0]["config_id"] == "cfg-777"
+
+        push_result = svc.push(alias="prod", project_root=project_root)
+        assert push_result["created"] == 0
+        assert push_result["updated"] == 1
+        client.create_config.assert_not_called()
+        client.update_config.assert_called_once()
+        assert client.update_config.call_args.kwargs["config_id"] == "cfg-777"
+
+    def test_untracked_copy_of_tracked_config_still_creates_fresh(
+        self, tmp_config_dir: Path, tmp_path: Path
+    ) -> None:
+        """Forking by copying a tracked config dir keeps the CREATE semantics:
+        the copy carries the original's ``_keboola.config_id``, but that id is
+        claimed by a manifest entry, so the copy must not be adopted (which
+        would overwrite the original remote config)."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        store = self._init_and_pull_main(tmp_config_dir, project_root, SAMPLE_COMPONENTS_NO_ROWS)
+
+        manifest = load_manifest(project_root)
+        entry = next(c for c in manifest.configurations if c.id == "cfg-001")
+        src_dir = project_root / "main" / entry.path
+        copy_dir = src_dir.parent / f"{src_dir.name}-copy"
+        copy_dir.mkdir()
+        data = yaml.safe_load((src_dir / CONFIG_FILENAME).read_text(encoding="utf-8"))
+        data["name"] = "Forked Extractor"
+        (copy_dir / CONFIG_FILENAME).write_text(yaml.safe_dump(data))
+
+        client = _make_sync_mock_client(components_response=SAMPLE_COMPONENTS_NO_ROWS)
+        client.create_config.return_value = {"id": "cfg-fresh-001"}
+        svc = SyncService(
+            config_store=store,
+            client_factory=lambda url, token: client,
+        )
+
+        diff_result = svc.diff(alias="prod", project_root=project_root)
+        added = [c for c in diff_result["changes"] if c["change_type"] == "added"]
+        assert len(added) == 1
+        assert added[0]["config_id"] == ""  # fresh create, id not reused
+        assert diff_result["summary"]["modified"] == 0
+
+        push_result = svc.push(alias="prod", project_root=project_root)
+        assert push_result["created"] == 1
+        client.create_config.assert_called_once()
+        client.update_config.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #482

## Root cause

Not the Storage API and not the branch listing — `sync pull` on a dev branch receives **all** inherited configs from `GET /branch/{id}/components` (that is exactly how pull materialized all 68 configs in the report). The bug is local manifest bookkeeping:

1. `sync pull` **replaces** `manifest.configurations` wholesale with the pulled branch's entries (`sync_service.py`, end of `pull()`). After `branch use <dev>` + `pull`, the previously pulled `main/` tree is still on disk but no longer tracked by the manifest.
2. `_find_untracked_configs` keeps the **default branch tree in scope unconditionally** (a deliberate choice from the issue #267 scaffold flow). Every orphaned `main/` file is therefore reported as untracked.
3. `diff()` turned each untracked file into an `added` change with **empty `config_id`** — matching the dry-run signature in the report ("66 of 68 configs `added` with empty `config_id`") — and `push` then POSTed a brand-new config **onto the dev branch** for each of them, reading the file content from the colliding path in the dev tree.

## Fix

- **Scope the untracked scan to the source branch tree.** `diff`/`push` now pass the resolved source branch path (`_resolve_source_branch_path` — the tree push actually reads from) to `_find_untracked_configs`, which scans exactly that subtree. Files belonging to another branch's tree can never surface as `added` for the target branch. The issue #267 "scaffold locally then push" flow and the KFR-07 promote-default-tree flow (`push --branch <id>` with no per-branch subtree) both keep working, because they are defined by the same source-path resolution.
- **Adopt-by-id guard** (the "at minimum" ask from the issue): an untracked `_config.yml` whose `_keboola.config_id` resolves on the target branch and is **not claimed** by any manifest entry now diffs against the existing remote config (`unchanged`/`modified`) instead of being created as a duplicate. A **claimed** id (user copied a tracked config dir to fork it) keeps the fresh-create semantics, so the fork-by-copy workflow is unchanged, and `sync clone` is unaffected (its tree is manifest-tracked and requires a fresh target).
- `sync status` scanning is unchanged (it has no branch/remote context; orphaned trees still show there as local-only `added` files, which push now correctly ignores).

## Tests

- `TestIssue482BranchSwitchDuplicates::test_push_on_dev_branch_after_pull_is_noop` — the exact repro from the issue (pull main → pull dev → push with zero edits). Fails on pre-fix `main` with 2 phantom `added` changes (empty `config_id`, one per orphaned config); now asserts diff is empty, push is `no_changes`, and `create_config` is never called.
- Adopt-by-id: untracked file with a known unclaimed remote id → `modified` + `update_config`, never `create_config`.
- Fork-by-copy: copy of a tracked config dir (claimed id) → still a single `added` with empty `config_id` and a fresh create.
- The two issue #267 Bug B walker tests updated to the new `only_branch_path` parameter (same scenarios, expressed through the source-path resolution that diff/push now perform).

`make check`: 4317 passed, 8 skipped.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->