### PR TITLE
fix(config-store): config.json reliability hardening — backup, sidecar lock, transactional mutations (#477, 0.70.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.70.0",
+      "version": "0.70.1",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.70.0",
+  "version": "0.70.1",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-cli"
-version = "0.70.0"
+version = "0.70.1"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -24,6 +24,31 @@ from .constants import CHANGELOG_HEADLINE_MAX_CHARS
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.70.1": [
+        "Fix: config.json reliability hardening (issue #477). Every rewrite now first copies the "
+        "previous config.json to `config.json.bak` (0600, same directory), so stored project "
+        "tokens are recoverable if the config is ever lost or clobbered -- no more re-entering "
+        "tokens by hand. The backup is best-effort and never blocks the save.",
+        "Fix: file locking moved from config.json itself to a sidecar `config.json.lock`. "
+        "Pre-fix, `save()` opened config.json with O_CREAT to lock it, so a save that failed "
+        "before the atomic rename left behind an empty 0-byte config.json that broke the next "
+        "load with 'not valid JSON'. A failed save now leaves no artifact at all (the temp file "
+        "is cleaned up too) and the previous config survives intact. Side effect: the Windows "
+        "close-before-replace special case is gone -- the lock fd never points at config.json.",
+        "Fix: config mutations are now transactional. `ConfigStore.transaction()` holds the "
+        "exclusive lock across the whole load -> mutate -> save cycle (reentrant per thread), "
+        "closing the lost-update race where two concurrent kbagent processes doing "
+        "read-modify-write silently dropped each other's changes -- e.g. a freshly added "
+        "project vanishing from config.json when another command saved a stale snapshot. All "
+        "ConfigStore mutation methods, `permissions set/reset`, the default-project pin, and "
+        "the org-metadata backfill now run inside a transaction.",
+        "Improved: `Project '<alias>' not found` errors now name the RESOLVED config file and "
+        "its source, e.g. `Project 'x' not found in /home/u/.kbagent/config.json (source: "
+        "local). Run 'kbagent project list' to see configured projects.` Config resolution is "
+        "cwd- and env-dependent (--config-dir > KBAGENT_CONFIG_DIR > nearest .kbagent/ walking "
+        "up from cwd > global), so two shells can silently talk to different configs; the "
+        "enriched error makes that split-brain visible instead of opaque (issue #477).",
+    ],
     "0.70.0": [
         "BREAKING: Removed `data-app git-branches` and `data-app git-entrypoints` (and their "
         "`kbagent serve` endpoints). The sandboxes-service backend dropped the underlying "

--- a/src/keboola_agent_cli/commands/permissions.py
+++ b/src/keboola_agent_cli/commands/permissions.py
@@ -249,15 +249,15 @@ def permissions_set(
     require_random_code_confirmation("update permission policy")
 
     config_store: ConfigStore = get_service(ctx, "config_store")
-    config = config_store.load()
-
     policy = PermissionPolicy(
         mode=mode,
         allow=allow or [],
         deny=deny or [],
     )
-    config.permissions = policy
-    config_store.save(config)
+    with config_store.transaction():
+        config = config_store.load()
+        config.permissions = policy
+        config_store.save(config)
 
     if formatter.json_mode:
         formatter.output(
@@ -296,10 +296,10 @@ def permissions_reset(
     require_random_code_confirmation("remove permission policy")
 
     config_store: ConfigStore = get_service(ctx, "config_store")
-    config = config_store.load()
-
-    config.permissions = None
-    config_store.save(config)
+    with config_store.transaction():
+        config = config_store.load()
+        config.permissions = None
+        config_store.save(config)
 
     if formatter.json_mode:
         formatter.output({"status": "ok", "message": "Permission policy removed"})

--- a/src/keboola_agent_cli/config_store.py
+++ b/src/keboola_agent_cli/config_store.py
@@ -3,13 +3,19 @@
 Manages reading and writing of config.json with project connections.
 File permissions are set to 0600 to protect stored tokens.
 Uses atomic writes to prevent TOCTOU race conditions.
-File locking (fcntl) prevents corruption from concurrent access.
+File locking (fcntl) on a sidecar lock file (config.json.lock) prevents
+corruption AND lost updates from concurrent access: mutation methods hold
+the exclusive lock across the whole load -> mutate -> save cycle via
+``transaction()``. Every rewrite first copies the previous config.json to
+config.json.bak as a recovery safety net (issue #477).
 """
 
 import contextlib
 import json
 import logging
 import os
+import threading
+from collections.abc import Iterator
 from pathlib import Path
 
 import platformdirs
@@ -69,6 +75,25 @@ def _try_flock(fd: int, operation: int) -> None:
         fcntl.flock(fd, operation)
 
 
+def project_not_found_error(alias: str, config_path: object, source: object) -> ConfigError:
+    """Build the canonical "project not found" error.
+
+    Names the RESOLVED config file and its source label so a split-brain
+    config resolution (``--config-dir`` / ``KBAGENT_CONFIG_DIR`` / local
+    ``.kbagent`` walk-up vs global) is visible directly in the error message
+    instead of failing opaquely (issue #477).
+
+    A module-level function (not a ConfigStore method) so services can build
+    a real ConfigError even when their config_store is a test double -- the
+    path and source are read as plain attributes, never via a method call.
+    """
+    return ConfigError(
+        f"Project '{alias}' not found in {config_path} "
+        f"(source: {source}). "
+        "Run 'kbagent project list' to see configured projects."
+    )
+
+
 def resolve_config_dir(cli_config_dir: str | None = None) -> tuple[Path, str]:
     """Resolve the config directory using the priority chain.
 
@@ -114,6 +139,8 @@ class ConfigStore:
     """
 
     CONFIG_FILENAME = "config.json"
+    LOCK_FILENAME = "config.json.lock"
+    BACKUP_FILENAME = "config.json.bak"
 
     def __init__(self, config_dir: Path | None = None, source: str = "global") -> None:
         if config_dir is None:
@@ -121,7 +148,14 @@ class ConfigStore:
         else:
             self._config_dir = config_dir
         self._config_path = self._config_dir / self.CONFIG_FILENAME
+        self._lock_path = self._config_dir / self.LOCK_FILENAME
+        self._backup_path = self._config_dir / self.BACKUP_FILENAME
         self._source = source
+        # Per-thread transaction depth: transaction() holds the exclusive
+        # sidecar lock across a whole load->mutate->save cycle, and the nested
+        # load()/save() calls must NOT re-acquire it -- flock treats every open
+        # file description independently, so re-acquiring would self-deadlock.
+        self._txn = threading.local()
 
     @property
     def config_path(self) -> Path:
@@ -138,6 +172,67 @@ class ConfigStore:
         """Return the config source label (cli-flag, env-var, local, global)."""
         return self._source
 
+    def _txn_depth(self) -> int:
+        """Return this thread's active transaction nesting depth."""
+        return getattr(self._txn, "depth", 0)
+
+    def _acquire_lock(self, operation: int) -> int | None:
+        """Open the sidecar lock file and apply an advisory flock.
+
+        The lock file (``config.json.lock``) is deliberately separate from
+        ``config.json`` itself: locking the config file required opening it
+        with ``O_CREAT``, so a save that failed before the atomic rename left
+        behind an empty config.json that broke the next load (issue #477).
+
+        Returns the open fd holding the lock, or None when the lock file
+        cannot be created (unwritable directory) -- locking stays best-effort,
+        matching the ``_try_flock`` silent-skip semantics.
+        """
+        try:
+            self._config_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+            fd = os.open(str(self._lock_path), os.O_RDONLY | os.O_CREAT, 0o600)
+        except OSError:
+            return None
+        _try_flock(fd, operation)
+        return fd
+
+    def _release_lock(self, fd: int | None) -> None:
+        """Release and close a lock fd obtained from ``_acquire_lock``."""
+        if fd is None:
+            return
+        _try_flock(fd, _LOCK_UN)
+        os.close(fd)
+
+    @contextlib.contextmanager
+    def transaction(self) -> Iterator[None]:
+        """Hold the exclusive config lock across a load -> mutate -> save cycle.
+
+        Without this, two concurrent kbagent processes doing read-modify-write
+        can silently drop each other's changes (issue #477): both load the
+        same snapshot and the second save wins, so a project added by the
+        first process vanishes from config.json. Mutation methods wrap
+        themselves in a transaction; ``load()``/``save()`` inside an active
+        transaction skip their own locking (reentrant per thread).
+        """
+        if self._txn_depth() > 0:
+            self._txn.depth += 1
+            try:
+                yield
+            finally:
+                self._txn.depth -= 1
+            return
+        fd = self._acquire_lock(_LOCK_EX)
+        self._txn.depth = 1
+        try:
+            yield
+        finally:
+            self._txn.depth = 0
+            self._release_lock(fd)
+
+    def project_not_found_error(self, alias: str) -> ConfigError:
+        """Build the canonical "project not found" error for this store."""
+        return project_not_found_error(alias, self._config_path, self._source)
+
     def load(self) -> AppConfig:
         """Load configuration from disk.
 
@@ -152,19 +247,20 @@ class ConfigStore:
             logger.debug("Config file does not exist, returning empty config")
             return self._inject_env_project(AppConfig())
 
-        fd: int | None = None
+        lock_fd: int | None = None
         try:
-            fd = os.open(str(self._config_path), os.O_RDONLY)
-            _try_flock(fd, _LOCK_SH)
+            # Shared lock on the sidecar lock file (writers take it
+            # exclusively); skipped inside an active transaction, which
+            # already holds the exclusive lock.
+            if self._txn_depth() == 0:
+                lock_fd = self._acquire_lock(_LOCK_SH)
             raw = self._config_path.read_text(encoding="utf-8")
         except OSError as exc:
             raise ConfigError(f"Cannot read config file {self._config_path}: {exc}") from exc
         except UnicodeDecodeError as exc:
             raise ConfigError(f"Config file is not valid UTF-8 text: {exc}") from exc
         finally:
-            if fd is not None:
-                _try_flock(fd, _LOCK_UN)
-                os.close(fd)
+            self._release_lock(lock_fd)
 
         try:
             data = json.loads(raw)
@@ -306,12 +402,15 @@ class ConfigStore:
         Creates the config directory if it does not exist.
         Uses atomic write to ensure the file is never on disk with
         permissions broader than 0600 (prevents TOCTOU race condition).
+        Before the atomic rename, the previous config.json is copied to
+        config.json.bak as a recovery safety net (issue #477).
 
         Raises:
             ConfigError: If the file cannot be written.
         """
         logger.debug("Saving config to %s", self._config_path)
         lock_fd: int | None = None
+        tmp_path = self._config_path.with_suffix(".tmp")
         try:
             self._config_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
             self._ensure_gitignore()
@@ -328,33 +427,52 @@ class ConfigStore:
             json_str = json.dumps(payload, indent=2, ensure_ascii=False)
             data = (json_str + "\n").encode("utf-8")
 
-            # Acquire an exclusive lock on the target file before writing.
-            # The lock file is opened (or created) with 0600 permissions.
-            lock_fd = os.open(str(self._config_path), os.O_RDONLY | os.O_CREAT, 0o600)
-            _try_flock(lock_fd, _LOCK_EX)
+            # Exclusive lock on the sidecar lock file -- never on config.json
+            # itself, so a failed save can't leave an empty O_CREAT artifact
+            # behind (issue #477). Skipped inside an active transaction, which
+            # already holds the lock. The fd never points at config.json or
+            # the temp file, so os.replace works on Windows too.
+            if self._txn_depth() == 0:
+                lock_fd = self._acquire_lock(_LOCK_EX)
+
+            self._write_backup()
 
             # Write to a temp file created with 0600 from the start,
             # then atomically rename into place. This avoids any window
             # where the config file exists with world-readable permissions.
-            tmp_path = self._config_path.with_suffix(".tmp")
             fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
             try:
                 os.write(fd, data)
             finally:
                 os.close(fd)
-            # On Windows (no fcntl), close the lock fd before os.replace —
-            # Windows cannot atomically replace a file that is currently open.
-            # On POSIX the fd stays open (flock is still held) until the finally block.
-            if not _HAS_FCNTL and lock_fd is not None:
-                os.close(lock_fd)
-                lock_fd = None
             os.replace(str(tmp_path), str(self._config_path))
         except OSError as exc:
+            with contextlib.suppress(OSError):
+                tmp_path.unlink()
             raise ConfigError(f"Cannot write config file {self._config_path}: {exc}") from exc
         finally:
-            if lock_fd is not None:
-                _try_flock(lock_fd, _LOCK_UN)
-                os.close(lock_fd)
+            self._release_lock(lock_fd)
+
+    def _write_backup(self) -> None:
+        """Copy the current config.json to config.json.bak (0600), best-effort.
+
+        Runs under the exclusive lock right before the atomic replace, so the
+        backup always holds the last pre-rewrite state -- if config.json is
+        ever lost or clobbered, stored tokens can be recovered from the backup
+        instead of being re-entered by hand (issue #477). A backup failure
+        must never block the save itself.
+        """
+        if not self._config_path.exists():
+            return
+        try:
+            current = self._config_path.read_bytes()
+            fd = os.open(str(self._backup_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            try:
+                os.write(fd, current)
+            finally:
+                os.close(fd)
+        except OSError:
+            logger.debug("Could not write config backup %s", self._backup_path)
 
     def _ensure_gitignore(self) -> None:
         """Create a .gitignore inside the config directory to protect tokens.
@@ -386,13 +504,16 @@ class ConfigStore:
         Raises:
             ConfigError: If the alias already exists.
         """
-        config = self.load()
-        if alias in config.projects:
-            raise ConfigError(f"Project '{alias}' already exists. Use 'project edit' to modify it.")
-        config.projects[alias] = project
-        if not config.default_project:
-            config.default_project = alias
-        self.save(config)
+        with self.transaction():
+            config = self.load()
+            if alias in config.projects:
+                raise ConfigError(
+                    f"Project '{alias}' already exists. Use 'project edit' to modify it."
+                )
+            config.projects[alias] = project
+            if not config.default_project:
+                config.default_project = alias
+            self.save(config)
 
     def ensure_removable(self, alias: str) -> None:
         """Validate that ``alias`` can be removed, without mutating anything.
@@ -407,7 +528,7 @@ class ConfigStore:
         """
         config = self.load()
         if alias not in config.projects:
-            raise ConfigError(f"Project '{alias}' not found.")
+            raise self.project_not_found_error(alias)
         self._reject_ephemeral_mutation(config, alias, "removed")
 
     def remove_project(self, alias: str) -> None:
@@ -422,14 +543,15 @@ class ConfigStore:
             ConfigError: If the alias does not exist, or is an ephemeral
                 ``__env__`` project.
         """
-        config = self.load()
-        if alias not in config.projects:
-            raise ConfigError(f"Project '{alias}' not found.")
-        self._reject_ephemeral_mutation(config, alias, "removed")
-        del config.projects[alias]
-        if config.default_project == alias:
-            config.default_project = next(iter(config.projects), "")
-        self.save(config)
+        with self.transaction():
+            config = self.load()
+            if alias not in config.projects:
+                raise self.project_not_found_error(alias)
+            self._reject_ephemeral_mutation(config, alias, "removed")
+            del config.projects[alias]
+            if config.default_project == alias:
+                config.default_project = next(iter(config.projects), "")
+            self.save(config)
 
     def get_project(self, alias: str) -> ProjectConfig | None:
         """Get a project by alias, or None if not found."""
@@ -446,12 +568,13 @@ class ConfigStore:
         Raises:
             ConfigError: If the alias does not exist.
         """
-        config = self.load()
-        if alias not in config.projects:
-            raise ConfigError(f"Project '{alias}' not found.")
-        self._reject_ephemeral_mutation(config, alias, "modified")
-        config.projects[alias].active_branch_id = branch_id
-        self.save(config)
+        with self.transaction():
+            config = self.load()
+            if alias not in config.projects:
+                raise self.project_not_found_error(alias)
+            self._reject_ephemeral_mutation(config, alias, "modified")
+            config.projects[alias].active_branch_id = branch_id
+            self.save(config)
 
     def edit_project(self, alias: str, **kwargs: str | int | None) -> None:
         """Update fields on an existing project.
@@ -465,16 +588,17 @@ class ConfigStore:
         Raises:
             ConfigError: If the alias does not exist.
         """
-        config = self.load()
-        if alias not in config.projects:
-            raise ConfigError(f"Project '{alias}' not found.")
-        self._reject_ephemeral_mutation(config, alias, "edited")
-        project = config.projects[alias]
-        for key, value in kwargs.items():
-            if hasattr(project, key) and value is not None:
-                setattr(project, key, value)
-        config.projects[alias] = project
-        self.save(config)
+        with self.transaction():
+            config = self.load()
+            if alias not in config.projects:
+                raise self.project_not_found_error(alias)
+            self._reject_ephemeral_mutation(config, alias, "edited")
+            project = config.projects[alias]
+            for key, value in kwargs.items():
+                if hasattr(project, key) and value is not None:
+                    setattr(project, key, value)
+            config.projects[alias] = project
+            self.save(config)
 
     def rename_project(self, old_alias: str, new_alias: str) -> None:
         """Rename a project alias in the persisted config.
@@ -493,19 +617,20 @@ class ConfigStore:
             ConfigError: If ``old_alias`` does not exist or ``new_alias``
                 is already in use by another project.
         """
-        config = self.load()
-        if old_alias not in config.projects:
-            raise ConfigError(f"Project '{old_alias}' not found.")
-        self._reject_ephemeral_mutation(config, old_alias, "renamed")
-        if new_alias in config.projects:
-            raise ConfigError(
-                f"Cannot rename '{old_alias}' to '{new_alias}': "
-                f"alias '{new_alias}' is already in use."
-            )
-        config.projects[new_alias] = config.projects.pop(old_alias)
-        if config.default_project == old_alias:
-            config.default_project = new_alias
-        self.save(config)
+        with self.transaction():
+            config = self.load()
+            if old_alias not in config.projects:
+                raise self.project_not_found_error(old_alias)
+            self._reject_ephemeral_mutation(config, old_alias, "renamed")
+            if new_alias in config.projects:
+                raise ConfigError(
+                    f"Cannot rename '{old_alias}' to '{new_alias}': "
+                    f"alias '{new_alias}' is already in use."
+                )
+            config.projects[new_alias] = config.projects.pop(old_alias)
+            if config.default_project == old_alias:
+                config.default_project = new_alias
+            self.save(config)
 
     def add_dev_portal_identity(self, alias: str, identity: DeveloperPortalIdentity) -> None:
         """Add a Developer Portal identity to the configuration.
@@ -515,16 +640,17 @@ class ConfigStore:
         Raises:
             ConfigError: If the alias already exists.
         """
-        config = self.load()
-        if alias in config.dev_portal_identities:
-            raise ConfigError(
-                f"Developer Portal identity '{alias}' already exists. "
-                "Use 'dev-portal identity edit' to modify it."
-            )
-        config.dev_portal_identities[alias] = identity
-        if not config.default_dev_portal_identity:
-            config.default_dev_portal_identity = alias
-        self.save(config)
+        with self.transaction():
+            config = self.load()
+            if alias in config.dev_portal_identities:
+                raise ConfigError(
+                    f"Developer Portal identity '{alias}' already exists. "
+                    "Use 'dev-portal identity edit' to modify it."
+                )
+            config.dev_portal_identities[alias] = identity
+            if not config.default_dev_portal_identity:
+                config.default_dev_portal_identity = alias
+            self.save(config)
 
     def remove_dev_portal_identity(self, alias: str) -> None:
         """Remove a Developer Portal identity.
@@ -534,13 +660,14 @@ class ConfigStore:
         Raises:
             ConfigError: If the alias does not exist.
         """
-        config = self.load()
-        if alias not in config.dev_portal_identities:
-            raise ConfigError(f"Developer Portal identity '{alias}' not found.")
-        del config.dev_portal_identities[alias]
-        if config.default_dev_portal_identity == alias:
-            config.default_dev_portal_identity = next(iter(config.dev_portal_identities), "")
-        self.save(config)
+        with self.transaction():
+            config = self.load()
+            if alias not in config.dev_portal_identities:
+                raise ConfigError(f"Developer Portal identity '{alias}' not found.")
+            del config.dev_portal_identities[alias]
+            if config.default_dev_portal_identity == alias:
+                config.default_dev_portal_identity = next(iter(config.dev_portal_identities), "")
+            self.save(config)
 
     def get_dev_portal_identity(self, alias: str) -> DeveloperPortalIdentity | None:
         """Get a Developer Portal identity by alias, or None if not found."""
@@ -555,15 +682,16 @@ class ConfigStore:
         Raises:
             ConfigError: If the alias does not exist.
         """
-        config = self.load()
-        if alias not in config.dev_portal_identities:
-            raise ConfigError(f"Developer Portal identity '{alias}' not found.")
-        ident = config.dev_portal_identities[alias]
-        for key, value in kwargs.items():
-            if hasattr(ident, key) and value is not None:
-                setattr(ident, key, value)
-        config.dev_portal_identities[alias] = ident
-        self.save(config)
+        with self.transaction():
+            config = self.load()
+            if alias not in config.dev_portal_identities:
+                raise ConfigError(f"Developer Portal identity '{alias}' not found.")
+            ident = config.dev_portal_identities[alias]
+            for key, value in kwargs.items():
+                if hasattr(ident, key) and value is not None:
+                    setattr(ident, key, value)
+            config.dev_portal_identities[alias] = ident
+            self.save(config)
 
     def rename_dev_portal_identity(self, old_alias: str, new_alias: str) -> None:
         """Rename a Developer Portal identity alias.
@@ -573,18 +701,19 @@ class ConfigStore:
         Raises:
             ConfigError: If old alias does not exist, or new alias is in use.
         """
-        config = self.load()
-        if old_alias not in config.dev_portal_identities:
-            raise ConfigError(f"Developer Portal identity '{old_alias}' not found.")
-        if new_alias in config.dev_portal_identities:
-            raise ConfigError(
-                f"Cannot rename '{old_alias}' to '{new_alias}': "
-                f"alias '{new_alias}' is already in use."
-            )
-        config.dev_portal_identities[new_alias] = config.dev_portal_identities.pop(old_alias)
-        if config.default_dev_portal_identity == old_alias:
-            config.default_dev_portal_identity = new_alias
-        self.save(config)
+        with self.transaction():
+            config = self.load()
+            if old_alias not in config.dev_portal_identities:
+                raise ConfigError(f"Developer Portal identity '{old_alias}' not found.")
+            if new_alias in config.dev_portal_identities:
+                raise ConfigError(
+                    f"Cannot rename '{old_alias}' to '{new_alias}': "
+                    f"alias '{new_alias}' is already in use."
+                )
+            config.dev_portal_identities[new_alias] = config.dev_portal_identities.pop(old_alias)
+            if config.default_dev_portal_identity == old_alias:
+                config.default_dev_portal_identity = new_alias
+            self.save(config)
 
     def set_default_dev_portal_identity(self, alias: str) -> None:
         """Set the default Developer Portal identity.
@@ -592,8 +721,9 @@ class ConfigStore:
         Raises:
             ConfigError: If the alias does not exist.
         """
-        config = self.load()
-        if alias not in config.dev_portal_identities:
-            raise ConfigError(f"Developer Portal identity '{alias}' not found.")
-        config.default_dev_portal_identity = alias
-        self.save(config)
+        with self.transaction():
+            config = self.load()
+            if alias not in config.dev_portal_identities:
+                raise ConfigError(f"Developer Portal identity '{alias}' not found.")
+            config.default_dev_portal_identity = alias
+            self.save(config)

--- a/src/keboola_agent_cli/services/base.py
+++ b/src/keboola_agent_cli/services/base.py
@@ -11,9 +11,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
 from ..client import KeboolaClient
-from ..config_store import ConfigStore
+from ..config_store import ConfigStore, project_not_found_error
 from ..constants import ENV_MAX_PARALLEL_WORKERS, UNEXPECTED_ERROR_MAX_MESSAGE_LEN
-from ..errors import ConfigError
 from ..models import ProjectConfig
 
 logger = logging.getLogger(__name__)
@@ -85,7 +84,9 @@ class BaseService:
         resolved: dict[str, ProjectConfig] = {}
         for alias in aliases:
             if alias not in config.projects:
-                raise ConfigError(f"Project '{alias}' not found.")
+                raise project_not_found_error(
+                    alias, self._config_store.config_path, self._config_store.source
+                )
             resolved[alias] = config.projects[alias]
 
         return resolved

--- a/src/keboola_agent_cli/services/mcp_service.py
+++ b/src/keboola_agent_cli/services/mcp_service.py
@@ -22,6 +22,7 @@ from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamablehttp_client
 
+from ..config_store import project_not_found_error
 from ..constants import (
     DEFAULT_MCP_INIT_TIMEOUT,
     DEFAULT_MCP_MAX_SESSIONS,
@@ -866,7 +867,9 @@ class McpService(BaseService):
                 )
 
         if alias not in config.projects:
-            raise ConfigError(f"Project '{alias}' not found.")
+            raise project_not_found_error(
+                alias, self._config_store.config_path, self._config_store.source
+            )
 
         return alias, config.projects[alias]
 

--- a/src/keboola_agent_cli/services/project_service.py
+++ b/src/keboola_agent_cli/services/project_service.py
@@ -12,6 +12,7 @@ import time
 from pathlib import Path
 from typing import Any
 
+from ..config_store import project_not_found_error
 from ..constants import ENV_KBAGENT_PROJECT
 from ..errors import ConfigError, KeboolaApiError, mask_token
 from ..models import ProjectConfig, normalize_stack_url
@@ -194,7 +195,9 @@ class ProjectService(BaseService):
         """
         existing = self._config_store.get_project(alias)
         if existing is None:
-            raise ConfigError(f"Project '{alias}' not found.")
+            raise project_not_found_error(
+                alias, self._config_store.config_path, self._config_store.source
+            )
 
         # ``--new-alias`` matching the current alias is treated as no change
         # (rename-to-same-name idempotency). Combined with no url/token, it
@@ -556,7 +559,9 @@ class ProjectService(BaseService):
         # 2. Collision check via a read-only load (no rename_project mutation).
         config = self._config_store.load()
         if old_alias not in config.projects:
-            raise ConfigError(f"Project '{old_alias}' not found.")
+            raise project_not_found_error(
+                old_alias, self._config_store.config_path, self._config_store.source
+            )
         if new_alias in config.projects:
             raise ConfigError(
                 f"Cannot rename '{old_alias}' to '{new_alias}': "
@@ -699,17 +704,20 @@ class ProjectService(BaseService):
         if not updates:
             return
 
-        # Single transactional pass: load once, mutate all in-memory, save once.
-        config = self._config_store.load()
-        for alias, (new_id, new_name) in updates.items():
-            if alias not in config.projects:
-                continue
-            project = config.projects[alias]
-            if project.org_id is None and new_id is not None:
-                project.org_id = new_id
-            if not project.org_name and new_name:
-                project.org_name = new_name
-        self._config_store.save(config)
+        # Single transactional pass: load once, mutate all in-memory, save
+        # once -- under the exclusive config lock so a concurrent kbagent
+        # process cannot interleave its own read-modify-write (issue #477).
+        with self._config_store.transaction():
+            config = self._config_store.load()
+            for alias, (new_id, new_name) in updates.items():
+                if alias not in config.projects:
+                    continue
+                project = config.projects[alias]
+                if project.org_id is None and new_id is not None:
+                    project.org_id = new_id
+                if not project.org_name and new_name:
+                    project.org_name = new_name
+            self._config_store.save(config)
 
     def _check_project_status(
         self, alias: str, project: ProjectConfig
@@ -830,13 +838,16 @@ class ProjectService(BaseService):
         Raises:
             ConfigError: If the alias does not exist.
         """
-        config = self._config_store.load()
-        if alias not in config.projects:
-            raise ConfigError(f"Project '{alias}' not found.")
+        with self._config_store.transaction():
+            config = self._config_store.load()
+            if alias not in config.projects:
+                raise project_not_found_error(
+                    alias, self._config_store.config_path, self._config_store.source
+                )
 
-        previous = config.default_project or None
-        config.default_project = alias
-        self._config_store.save(config)
+            previous = config.default_project or None
+            config.default_project = alias
+            self._config_store.save(config)
 
         env_override = os.environ.get(ENV_KBAGENT_PROJECT)
         return {
@@ -909,7 +920,9 @@ class ProjectService(BaseService):
         """
         project = self._config_store.get_project(alias)
         if project is None:
-            raise ConfigError(f"Project '{alias}' not found.")
+            raise project_not_found_error(
+                alias, self._config_store.config_path, self._config_store.source
+            )
 
         client = self._client_factory(project.stack_url, project.token)
         try:
@@ -961,7 +974,9 @@ class ProjectService(BaseService):
 
         if explicit:
             if explicit not in config.projects:
-                raise ConfigError(f"Project '{explicit}' not found.")
+                raise project_not_found_error(
+                    explicit, self._config_store.config_path, self._config_store.source
+                )
             return explicit, "explicit"
 
         env_value = os.environ.get(ENV_KBAGENT_PROJECT)

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -3,12 +3,13 @@
 import json
 import os
 import stat
+import threading
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from keboola_agent_cli.config_store import CURRENT_CONFIG_VERSION, ConfigStore
+from keboola_agent_cli.config_store import _HAS_FCNTL, CURRENT_CONFIG_VERSION, ConfigStore
 from keboola_agent_cli.errors import ConfigError
 from keboola_agent_cli.models import AppConfig, DeveloperPortalIdentity, ProjectConfig
 
@@ -978,3 +979,147 @@ class TestEnvProjectInjection:
 
         on_disk = json.loads((tmp_config_dir / "config.json").read_text())
         assert on_disk["default_project"] == ""
+
+
+class TestBackupOnSave:
+    """Tests for the config.json.bak safety net written before every rewrite (issue #477)."""
+
+    def _project(self, name: str = "P") -> ProjectConfig:
+        return ProjectConfig(
+            stack_url="https://connection.keboola.com",
+            token="901-55555-fakeTestTokenDoNotUseXXXXXXXX",
+            project_name=name,
+        )
+
+    def test_first_save_creates_no_backup(self, tmp_config_dir: Path) -> None:
+        """With no pre-existing config there is nothing to back up."""
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.save(AppConfig(projects={"a": self._project()}))
+
+        assert not (tmp_config_dir / "config.json.bak").exists()
+
+    def test_save_backs_up_previous_state(self, tmp_config_dir: Path) -> None:
+        """The backup holds the pre-rewrite state, not the freshly written one."""
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.save(AppConfig(projects={"a": self._project("First")}))
+        store.save(AppConfig(projects={"a": self._project("First"), "b": self._project("Second")}))
+
+        backup = json.loads((tmp_config_dir / "config.json.bak").read_text())
+        assert set(backup["projects"]) == {"a"}
+        current = json.loads((tmp_config_dir / "config.json").read_text())
+        assert set(current["projects"]) == {"a", "b"}
+
+    def test_backup_has_owner_only_permissions(self, tmp_config_dir: Path) -> None:
+        """The backup contains tokens, so it must be 0600 like config.json."""
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.save(AppConfig(projects={"a": self._project()}))
+        store.save(AppConfig(projects={}))
+
+        mode = stat.S_IMODE(os.stat(tmp_config_dir / "config.json.bak").st_mode)
+        assert mode == 0o600
+
+
+class TestFailedSaveLeavesNoArtifact:
+    """A failed save must never leave an empty config.json or a stray temp file (issue #477)."""
+
+    def test_failed_replace_leaves_no_config_or_tmp(
+        self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pre-fix, the lock's O_CREAT left a 0-byte config.json behind on failure."""
+        store = ConfigStore(config_dir=tmp_config_dir)
+
+        def boom(src: str, dst: str) -> None:
+            raise OSError("simulated disk failure")
+
+        monkeypatch.setattr("keboola_agent_cli.config_store.os.replace", boom)
+        with pytest.raises(ConfigError, match="Cannot write config file"):
+            store.save(AppConfig())
+
+        assert not (tmp_config_dir / "config.json").exists()
+        assert not (tmp_config_dir / "config.tmp").exists()
+
+    def test_existing_config_survives_failed_save(
+        self, tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed rewrite leaves the previous config.json fully intact."""
+        store = ConfigStore(config_dir=tmp_config_dir)
+        store.save(
+            AppConfig(
+                projects={
+                    "keep": ProjectConfig(
+                        stack_url="https://connection.keboola.com",
+                        token="901-55555-fakeTestTokenDoNotUseXXXXXXXX",
+                    )
+                }
+            )
+        )
+
+        def boom(src: str, dst: str) -> None:
+            raise OSError("simulated disk failure")
+
+        monkeypatch.setattr("keboola_agent_cli.config_store.os.replace", boom)
+        with pytest.raises(ConfigError):
+            store.save(AppConfig())
+
+        loaded = ConfigStore(config_dir=tmp_config_dir).load()
+        assert "keep" in loaded.projects
+
+
+class TestTransaction:
+    """Tests for the exclusive lock held across load -> mutate -> save (issue #477)."""
+
+    def _project(self) -> ProjectConfig:
+        return ProjectConfig(
+            stack_url="https://connection.keboola.com",
+            token="901-55555-fakeTestTokenDoNotUseXXXXXXXX",
+        )
+
+    def test_mutations_inside_transaction_are_reentrant(self, tmp_config_dir: Path) -> None:
+        """Nested load()/save() inside a transaction must not self-deadlock."""
+        store = ConfigStore(config_dir=tmp_config_dir)
+        with store.transaction():
+            store.add_project("a", self._project())
+            store.add_project("b", self._project())
+
+        loaded = store.load()
+        assert set(loaded.projects) == {"a", "b"}
+
+    @pytest.mark.skipif(not _HAS_FCNTL, reason="flock is POSIX-only; no locking on Windows")
+    def test_concurrent_add_project_loses_no_updates(self, tmp_config_dir: Path) -> None:
+        """Parallel read-modify-write cycles serialize on the sidecar lock.
+
+        Each thread uses its own ConfigStore instance, mimicking separate
+        kbagent processes. Pre-fix, concurrent load->mutate->save cycles
+        overwrote each other and freshly added projects vanished.
+        """
+        errors: list[Exception] = []
+
+        def add(i: int) -> None:
+            try:
+                ConfigStore(config_dir=tmp_config_dir).add_project(f"p{i}", self._project())
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=add, args=(i,)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        loaded = ConfigStore(config_dir=tmp_config_dir).load()
+        assert set(loaded.projects) == {f"p{i}" for i in range(8)}
+
+
+class TestProjectNotFoundError:
+    """The canonical not-found error names the resolved config path and source (issue #477)."""
+
+    def test_error_names_resolved_path_and_source(self, tmp_config_dir: Path) -> None:
+        store = ConfigStore(config_dir=tmp_config_dir, source="local")
+        with pytest.raises(ConfigError) as excinfo:
+            store.remove_project("ghost")
+
+        message = str(excinfo.value)
+        assert "Project 'ghost' not found" in message
+        assert str(tmp_config_dir / "config.json") in message
+        assert "(source: local)" in message

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "keboola-cli"
-version = "0.70.0"
+version = "0.70.1"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Addresses #477 (config.json reported as "disappearing" on macOS). Full diagnosis is in [this issue comment](https://github.com/keboola/cli/issues/477#issuecomment-5022394744) — TL;DR: no code path can delete `config.json` (the only writer is an atomic temp-file + rename), nothing in the 0.65.1→0.66.0 diff touches the config write path, and the reporter's key clue actually points at **split-brain config resolution** (`version_cache.json` is always written to the global dir, while `config.json` follows the `--config-dir` → `KBAGENT_CONFIG_DIR` → local `.kbagent` walk-up → global chain). The issue stays open pending the reporter's confirmation; this PR ships the hardening that is right regardless of the final root cause, including the reporter's explicit ask (a backup).

## Changes (0.70.1)

1. **`config.json.bak` before every rewrite.** `save()` copies the previous `config.json` to `config.json.bak` (0600, same directory) right before the atomic rename, under the exclusive lock. Best-effort: a backup failure never blocks the save. Stored tokens are now recoverable without re-entry.
2. **Sidecar lock file.** Locking moved from `config.json` itself (opened with `O_CREAT`) to `config.json.lock`. Pre-fix, a save failing before the rename left an empty 0-byte `config.json` that broke the next load with "not valid JSON". Now a failed save leaves no artifact (the temp file is unlinked too) and the previous config survives intact. Side effect: the Windows close-before-replace special case is gone — the lock fd never points at `config.json` or the temp file.
3. **Transactional mutations.** New `ConfigStore.transaction()` holds the exclusive flock across the whole load → mutate → save cycle (reentrant per thread via `threading.local`), closing the lost-update race where two concurrent kbagent processes doing read-modify-write silently dropped each other's changes — a freshly added project could vanish from `config.json` when another command saved a stale snapshot. Wrapped: all `ConfigStore` mutation methods (projects + dev-portal identities), `permissions set/reset`, the default-project pin, and the org-metadata backfill.
4. **Split-brain made visible.** `Project '<alias>' not found` now names the resolved config file and source label, e.g. `Project 'x' not found in /home/u/.kbagent/config.json (source: local). Run 'kbagent project list' to see configured projects.` Built by a module-level `project_not_found_error()` helper (reads `config_path`/`source` as plain attributes, so services raise a real `ConfigError` even when tests inject a mock store).

## Tests

- 8 new tests in `tests/test_config_store.py`: backup content/permissions/first-save, failed-save-leaves-no-artifact (config + temp file), previous-config-survives-failed-save, transaction reentrancy, 8-thread concurrent `add_project` lost-update race (skipped on platforms without `fcntl`), and the enriched not-found message.
- `make check` green: lint, format, typecheck, skill/version/command-sync/changelog/error-code checks, 4322 tests passed.

## Notes for review

- The concurrency test uses separate `ConfigStore` instances per thread to mimic separate processes; flock on the sidecar serializes them (per open file description, so it also serializes within one process).
- `load()` takes a shared lock on the sidecar (skipped inside an active transaction, which already holds the exclusive one). On Windows (`fcntl` unavailable) locking remains a no-op, exactly as before.
- `config.json.bak` and `config.json.lock` are covered by the config dir's auto-generated `.gitignore` (`*`) and carry 0600/0600 permissions.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->