### PR TITLE
feat(release): generate command-reference.md release asset from the Typer app (#498)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,15 @@ jobs:
         # the released CLI. Downstream consumers (help.keboola.com CLI section,
         # the Claude Code plugin) fetch it pinned to the release tag instead of
         # hand-copying command lists.
+        #
+        # The job checks out the release tag, so a workflow_dispatch backfill
+        # of a tag that predates this script has no generator to run -- skip
+        # instead of failing, or backfills could never attach their wheel.
         run: |
+          if [ ! -f scripts/gen_command_reference.py ]; then
+            echo "scripts/gen_command_reference.py not present at $TAG (pre-existing release backfill); skipping the reference asset."
+            exit 0
+          fi
           tag="$TAG"
           version="${tag#v}"
           uv run --no-project --with "dist/keboola_cli-${version}-py3-none-any.whl" \
@@ -133,5 +141,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # --clobber makes a re-run idempotent (overwrites instead of erroring on
-        # "asset already exists").
-        run: gh release upload "$TAG" dist/*.whl dist/command-reference.md --clobber
+        # "asset already exists"). command-reference.md uploads only when the
+        # generation step produced it (skipped on pre-existing-tag backfills).
+        run: |
+          gh release upload "$TAG" dist/*.whl --clobber
+          if [ -f dist/command-reference.md ]; then
+            gh release upload "$TAG" dist/command-reference.md --clobber
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,9 +117,21 @@ jobs:
           fi
           echo "OK: legacy compat wheel $expected present"
 
+      - name: Generate command-reference.md from the built wheel
+        # Introspects the Typer command tree of the EXACT artifact being
+        # shipped (issue #498), so the reference asset can never disagree with
+        # the released CLI. Downstream consumers (help.keboola.com CLI section,
+        # the Claude Code plugin) fetch it pinned to the release tag instead of
+        # hand-copying command lists.
+        run: |
+          tag="$TAG"
+          version="${tag#v}"
+          uv run --no-project --with "dist/keboola_cli-${version}-py3-none-any.whl" \
+            python scripts/gen_command_reference.py --output dist/command-reference.md
+
       - name: Upload the wheel to the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # --clobber makes a re-run idempotent (overwrites instead of erroring on
         # "asset already exists").
-        run: gh release upload "$TAG" dist/*.whl --clobber
+        run: gh release upload "$TAG" dist/*.whl dist/command-reference.md --clobber

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help install install-mcp install-server sync test test-unit test-integration test-e2e test-e2e-local test-e2e-invite test-e2e-feature test-e2e-stream test-file test-cov lint lint-fix format format-check typecheck typecheck-warn skill-check skill-gen version-sync version-check changelog changelog-check check-error-codes command-sync-check check clean hooks web-install web-dev-backend web-dev-frontend web-build web-clean
+.PHONY: help install install-mcp install-server sync test test-unit test-integration test-e2e test-e2e-local test-e2e-invite test-e2e-feature test-e2e-stream test-file test-cov lint lint-fix format format-check typecheck typecheck-warn skill-check skill-gen version-sync version-check changelog changelog-check check-error-codes command-sync-check gen-command-reference check clean hooks web-install web-dev-backend web-dev-frontend web-build web-clean
 
 help: ## Show this help message
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
@@ -103,6 +103,9 @@ check-error-codes: ## Reject raw error_code string literals in source (use Error
 
 command-sync-check: ## Verify every CLI command is registered + documented (silent-drift gate)
 	uv run python scripts/check_command_sync.py
+
+gen-command-reference: ## Generate command-reference.md from the live Typer app (release asset)
+	uv run python scripts/gen_command_reference.py --output command-reference.md
 
 hooks: ## Install git pre-commit hook (lint + format on staged files)
 	cp scripts/pre-commit .git/hooks/pre-commit

--- a/scripts/gen_command_reference.py
+++ b/scripts/gen_command_reference.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 import click
@@ -81,11 +82,20 @@ def _render_command(path: tuple[str, ...], cmd: click.Command, ctx: click.Contex
     return lines
 
 
+@dataclass(frozen=True)
+class LeafCommand:
+    """One visible leaf command with the context it renders under."""
+
+    path: tuple[str, ...]
+    command: click.Command
+    ctx: click.Context
+
+
 def _walk(
     group: click.Group, ctx: click.Context, prefix: tuple[str, ...] = ()
-) -> list[tuple[tuple[str, ...], click.Command, click.Context]]:
-    """Collect (path, command, ctx) for every visible leaf, depth-first."""
-    leaves: list[tuple[tuple[str, ...], click.Command, click.Context]] = []
+) -> list[LeafCommand]:
+    """Collect every visible leaf command, depth-first."""
+    leaves: list[LeafCommand] = []
     for name in group.list_commands(ctx):
         cmd = group.get_command(ctx, name)
         if cmd is None or cmd.hidden:
@@ -95,7 +105,7 @@ def _walk(
             with click.Context(cmd, parent=ctx, info_name=name) as sub_ctx:
                 leaves.extend(_walk(cmd, sub_ctx, path))
         else:
-            leaves.append((path, cmd, ctx))
+            leaves.append(LeafCommand(path=path, command=cmd, ctx=ctx))
     return leaves
 
 
@@ -128,8 +138,8 @@ def build_reference() -> str:
                 if group_help:
                     out += [group_help, ""]
                 with click.Context(cmd, parent=root_ctx, info_name=name) as group_ctx:
-                    for path, leaf, leaf_ctx in _walk(cmd, group_ctx, (name,)):
-                        out += _render_command(path, leaf, leaf_ctx)
+                    for leaf in _walk(cmd, group_ctx, (name,)):
+                        out += _render_command(leaf.path, leaf.command, leaf.ctx)
             else:
                 top_level += [_render_command((name,), cmd, root_ctx)]
         if top_level:

--- a/scripts/gen_command_reference.py
+++ b/scripts/gen_command_reference.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Generate command-reference.md by introspecting the live Typer app.
+
+Zero-drift by construction: the output is derived from the same Click command
+tree that renders ``--help``, so it cannot disagree with the shipped CLI. The
+release workflow attaches the result as a GitHub Release asset next to the
+wheel; downstream consumers (help.keboola.com CLI section, the Claude Code
+plugin, third parties) fetch it pinned to a released version instead of
+hand-copying command lists. See issue #498 and CONTRIBUTING.md
+"Plugin synchronization map" for the drift problem this solves.
+
+Hidden commands and groups (e.g. the ``sl`` alias) are skipped together with
+their subtree, matching scripts/check_command_sync.py -- they are not part of
+the public documented surface.
+
+Usage (run from repo root):
+    python scripts/gen_command_reference.py                    # print to stdout
+    python scripts/gen_command_reference.py --output PATH      # write to file
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import click
+import typer.main
+
+from keboola_agent_cli import __version__
+from keboola_agent_cli.cli import app
+from keboola_agent_cli.commands.repl import _is_group
+
+PROG = "kbagent"
+
+# NOTE on typing: Typer >=0.25 vendors Click (typer._click), so isinstance
+# checks against the plain `click` classes FAIL for the objects returned by
+# typer.main.get_command(). Everything below is duck-typed, following the
+# established pattern of commands/repl.py::_is_group. Parameters are told
+# apart via `param_type_name` ("option" / "argument"), which both Click
+# lineages set.
+
+
+def _short_help(cmd: click.Command, limit: int = 120) -> str:
+    return cmd.get_short_help_str(limit=limit)
+
+
+def _metavar(param: click.Parameter, ctx: click.Context) -> str:
+    """make_metavar across Click lineages (newer requires ctx, older forbids it)."""
+    try:
+        return param.make_metavar(ctx)  # type: ignore[call-arg]
+    except TypeError:
+        return param.make_metavar()  # ty: ignore[missing-argument]
+
+
+def _format_param(param: click.Parameter, ctx: click.Context) -> str | None:
+    """Render one parameter as a markdown table row, or None if hidden/help."""
+    kind = getattr(param, "param_type_name", "")
+    if kind == "option":
+        if getattr(param, "hidden", False) or "--help" in param.opts:
+            return None
+        names = " / ".join(f"`{opt}`" for opt in [*param.opts, *param.secondary_opts])
+        metavar = "" if getattr(param, "is_flag", False) else f" `{_metavar(param, ctx)}`"
+        required = "yes" if param.required else ""
+        help_text = (getattr(param, "help", "") or "").replace("\n", " ").strip()
+        return f"| {names}{metavar} | {required} | {help_text} |"
+    if kind == "argument":
+        required = "yes" if param.required else ""
+        return f"| `{_metavar(param, ctx)}` (positional) | {required} | |"
+    return None
+
+
+def _render_command(path: tuple[str, ...], cmd: click.Command, ctx: click.Context) -> list[str]:
+    lines = [f"### `{PROG} {' '.join(path)}`", ""]
+    help_line = _short_help(cmd)
+    if help_line:
+        lines += [help_line, ""]
+    rows = [row for p in cmd.params for row in [_format_param(p, ctx)] if row]
+    if rows:
+        lines += ["| Option | Required | Description |", "|---|---|---|", *rows, ""]
+    return lines
+
+
+def _walk(
+    group: click.Group, ctx: click.Context, prefix: tuple[str, ...] = ()
+) -> list[tuple[tuple[str, ...], click.Command, click.Context]]:
+    """Collect (path, command, ctx) for every visible leaf, depth-first."""
+    leaves: list[tuple[tuple[str, ...], click.Command, click.Context]] = []
+    for name in group.list_commands(ctx):
+        cmd = group.get_command(ctx, name)
+        if cmd is None or cmd.hidden:
+            continue
+        path = (*prefix, name)
+        if _is_group(cmd):
+            with click.Context(cmd, parent=ctx, info_name=name) as sub_ctx:
+                leaves.extend(_walk(cmd, sub_ctx, path))
+        else:
+            leaves.append((path, cmd, ctx))
+    return leaves
+
+
+def build_reference() -> str:
+    click_app = typer.main.get_command(app)
+    assert _is_group(click_app), "root Typer app did not resolve to a command group"
+    out: list[str] = [
+        f"# {PROG} command reference",
+        "",
+        f"Generated from {PROG} v{__version__} by `scripts/gen_command_reference.py`.",
+        "Derived from the CLI's own command tree -- do not edit by hand.",
+        "",
+        "## Global options",
+        "",
+        "Available on every command:",
+        "",
+    ]
+    with click.Context(click_app, info_name=PROG) as root_ctx:
+        root_rows = [row for p in click_app.params for row in [_format_param(p, root_ctx)] if row]
+        out += ["| Option | Required | Description |", "|---|---|---|", *root_rows, ""]
+
+        top_level: list[list[str]] = []
+        for name in click_app.list_commands(root_ctx):
+            cmd = click_app.get_command(root_ctx, name)
+            if cmd is None or cmd.hidden:
+                continue
+            if _is_group(cmd):
+                out += [f"## `{name}`", ""]
+                group_help = _short_help(cmd)
+                if group_help:
+                    out += [group_help, ""]
+                with click.Context(cmd, parent=root_ctx, info_name=name) as group_ctx:
+                    for path, leaf, leaf_ctx in _walk(cmd, group_ctx, (name,)):
+                        out += _render_command(path, leaf, leaf_ctx)
+            else:
+                top_level += [_render_command((name,), cmd, root_ctx)]
+        if top_level:
+            out += ["## Top-level commands", ""]
+            for block in top_level:
+                out += block
+    return "\n".join(out).rstrip() + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=None, help="Write to file (default stdout)")
+    args = parser.parse_args()
+
+    reference = build_reference()
+    if args.output:
+        args.output.write_text(reference, encoding="utf-8")
+        commands = reference.count(f"### `{PROG} ")
+        print(f"Wrote {args.output} ({commands} commands, v{__version__})")
+    else:
+        sys.stdout.write(reference)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/keboola_agent_cli/cli.py
+++ b/src/keboola_agent_cli/cli.py
@@ -253,7 +253,7 @@ def main(
         "--allow-env-manage-token",
         help="Read KBC_MANAGE_API_TOKEN from the environment. Without this "
         "flag the env var is ignored (with a warning) and an interactive "
-        "TTY prompt is required. Default-deny since 0.28.0; closes the "
+        "TTY prompt is required. Default-deny since 0.29.0; closes the "
         "AI-exfiltration risk where subprocesses inherit the manage token.",
     ),
 ) -> None:

--- a/tests/test_gen_command_reference.py
+++ b/tests/test_gen_command_reference.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
@@ -14,6 +15,10 @@ def _load_script():
     )
     assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
+    # Register BEFORE exec: the script's @dataclass under
+    # `from __future__ import annotations` resolves its module via
+    # sys.modules[cls.__module__] at class-creation time.
+    sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
     return mod
 

--- a/tests/test_gen_command_reference.py
+++ b/tests/test_gen_command_reference.py
@@ -1,0 +1,64 @@
+"""Tests for scripts/gen_command_reference.py (release-asset reference generator)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location(
+        "gen_command_reference", Path("scripts") / "gen_command_reference.py"
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def reference() -> str:
+    return _load_script().build_reference()
+
+
+class TestGenCommandReference:
+    def test_deterministic(self, reference: str) -> None:
+        """Two runs produce byte-identical output (reviewable release-asset diffs)."""
+        assert reference == _load_script().build_reference()
+
+    def test_contains_every_visible_group_and_leaf(self, reference: str) -> None:
+        """Cross-check against the command-sync walker: no visible command missing."""
+        spec = importlib.util.spec_from_file_location(
+            "check_command_sync", Path("scripts") / "check_command_sync.py"
+        )
+        assert spec is not None and spec.loader is not None
+        sync = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(sync)
+        leaves, _groups = sync.collect_commands()
+        missing = [p for p in leaves if f"### `kbagent {' '.join(p)}`" not in reference]
+        assert missing == [], f"generated reference is missing {len(missing)} commands"
+
+    def test_global_options_present(self, reference: str) -> None:
+        for flag in ("--json", "--deny-writes", "--deny-destructive", "--allow-env-manage-token"):
+            assert f"`{flag}`" in reference
+
+    def test_required_flags_marked(self, reference: str) -> None:
+        """job run's --project row carries the required marker."""
+        section = reference.split("### `kbagent job run`", 1)[1].split("### ", 1)[0]
+        project_row = next(line for line in section.splitlines() if "`--project`" in line)
+        assert "| yes |" in project_row
+
+    def test_hidden_alias_excluded(self, reference: str) -> None:
+        """The hidden `sl` alias (and its subtree) is not documented."""
+        assert "### `kbagent sl " not in reference
+        assert "## `sl`" not in reference
+
+    def test_help_option_excluded(self, reference: str) -> None:
+        assert "`--help`" not in reference
+
+    def test_header_carries_version(self, reference: str) -> None:
+        from keboola_agent_cli import __version__
+
+        assert f"Generated from kbagent v{__version__}" in reference


### PR DESCRIPTION
## Why — and why now

@jordanrburger raised the canonical-source question on the help-docs CLI section (keboola/connection-docs#1015): the new public docs hand-copy the command reference, and every existing reference surface in this repo (`kbagent context`, `CLAUDE.md`, `commands-reference.md`) is also hand-maintained — convention #17's documented silent-drift list. A release is about to be cut (main is at 0.70.1, last release v0.66.1), which is exactly when the help docs start drifting. Landing this before the tag means **the very first release the docs describe already carries the zero-drift asset**.

Closes #498.

## What

- **`scripts/gen_command_reference.py`** — introspects the live Typer/Click command tree and emits deterministic markdown: global options, one section per command group, per-command option tables with required markers and positional args. Hidden commands and aliases (`sl`) are skipped, matching `check_command_sync.py`. Output at v0.70.1: **238 commands, 27 groups**. Duck-typed via `commands/repl._is_group` — Typer ≥0.25 vendors Click, so `isinstance` against plain `click` classes fails (learned the hard way).
- **`release.yml`** — after the wheel build, the reference is generated **from the built wheel** (`uv run --no-project --with dist/*.whl`, same pattern as ci.yml's wheel smoke test) and uploaded as `command-reference.md` next to the wheel. The asset describes the exact artifact being shipped, by construction.
- **`Makefile`** — `make gen-command-reference` for local use.
- **Drive-by fix (`cli.py`)** — `--allow-env-manage-token` help said "Default-deny since 0.28.0"; the changelog is unambiguous that both the flag and the default-deny shipped in **0.29.0**. This exact help string was the source of the wrong version that surfaced in the help-docs review, which is a neat demonstration of why generated-from-source references matter: they propagate fixes too, not just drift.

## Tests

`tests/test_gen_command_reference.py` (7): byte-identical determinism; **completeness cross-checked against `check_command_sync.collect_commands()`** (every visible leaf must appear); required-flag markers; hidden-alias and `--help` exclusion; version header.

## Verification

- `uv run pytest tests/test_gen_command_reference.py` → 7 passed
- `ruff check` / `ruff format --check` / `ty check` clean; pre-commit hook passed
- Local simulation of the release-job invocation: `KBAGENT_SKIP_UI_BUILD=1 uv run --no-project --with . python scripts/gen_command_reference.py` → correct output from the installed-package path
- Two consecutive runs diff-identical

## Out of scope (follow-ups)

- The connection-docs side of the loop (scheduled action pulling the asset from the latest release into an auto-PR) — tracked in the PR #1015 discussion.
- Retiring/regenerating the hand-maintained surfaces (`context`, `commands-reference.md`) from this generator — worth its own design pass.

No version bump: release tooling + a help-text fix; the user cutting the release owns the version/notes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->