### PR TITLE
feat(release): generate GitHub release notes from changelog.py

### DIFF
--- a/.github/workflows/release-kbagent.yml
+++ b/.github/workflows/release-kbagent.yml
@@ -128,18 +128,23 @@ jobs:
       # travels to github-release as an artifact. This is also the FORWARD gate:
       # a stable tag whose version has no CHANGELOG entry fails the release now,
       # before anything publishes (generate_changelog.py --check above only
-      # audits already-published releases). `--previous` is the latest stable
-      # release, so versions that were merged but never tagged ship in the next
-      # tag as one catch-up section per version.
+      # audits already-published releases). The full released-version list goes
+      # to the script, which walks the changelog from the tagged version toward
+      # older entries until it hits one that is already released — versions that
+      # were merged but never tagged ship in the next tag as one catch-up
+      # section per version, with no reliance on `gh release list` ordering (an
+      # old-line hotfix tagged after a newer release still gets exactly its own
+      # section).
       - name: Generate release notes from changelog.py
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.version.outputs.VERSION }}
           IS_PRERELEASE: ${{ needs.version.outputs.IS_PRERELEASE }}
         run: |
-          prev="$(gh release list --limit 1 --exclude-drafts --exclude-pre-releases --json tagName --jq '.[0].tagName' || true)"
           args=(--version "$VERSION" --output release-notes.md)
-          if [ -n "$prev" ]; then args+=(--previous "${prev#v}"); fi
+          for tag in $(gh release list --limit 100 --exclude-drafts --exclude-pre-releases --json tagName --jq '.[].tagName'); do
+            args+=(--released "${tag#v}")
+          done
           if [ "$IS_PRERELEASE" = "true" ]; then args+=(--allow-missing); fi
           uv run python scripts/gen_release_notes.py "${args[@]}"
       - uses: actions/upload-artifact@v4
@@ -320,7 +325,10 @@ jobs:
             echo "::warning::no release-notes artifact (pre-release without a changelog entry?); leaving the body as-is"
             exit 0
           fi
-          body="$(gh release view "v${VERSION}" --json body --jq .body)"
+          # `.body // ""` — the API can return the body as JSON null (not ""),
+          # which --jq would print as the literal string "null" and defeat the
+          # emptiness test below.
+          body="$(gh release view "v${VERSION}" --json body --jq '.body // ""')"
           if [ -n "$body" ]; then
             echo "release v${VERSION} already has notes (authored by hand); leaving them untouched"
             exit 0

--- a/.github/workflows/release-kbagent.yml
+++ b/.github/workflows/release-kbagent.yml
@@ -121,6 +121,34 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}  # gh release list needs auth; contents:read is enough scope
         run: uv run python scripts/generate_changelog.py --check
+      # Render the GitHub Release body from changelog.py so the release page can
+      # never disagree with `kbagent changelog` (v0.66.1 shipped with an EMPTY
+      # body: nobody pre-created the release by hand and the github-release job
+      # creates it bare). Runs here because gate already has the uv env; the file
+      # travels to github-release as an artifact. This is also the FORWARD gate:
+      # a stable tag whose version has no CHANGELOG entry fails the release now,
+      # before anything publishes (generate_changelog.py --check above only
+      # audits already-published releases). `--previous` is the latest stable
+      # release, so versions that were merged but never tagged ship in the next
+      # tag as one catch-up section per version.
+      - name: Generate release notes from changelog.py
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.version.outputs.VERSION }}
+          IS_PRERELEASE: ${{ needs.version.outputs.IS_PRERELEASE }}
+        run: |
+          prev="$(gh release list --limit 1 --exclude-drafts --exclude-pre-releases --json tagName --jq '.[0].tagName' || true)"
+          args=(--version "$VERSION" --output release-notes.md)
+          if [ -n "$prev" ]; then args+=(--previous "${prev#v}"); fi
+          if [ "$IS_PRERELEASE" = "true" ]; then args+=(--allow-missing); fi
+          uv run python scripts/gen_release_notes.py "${args[@]}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-notes
+          path: release-notes.md
+          # A pre-release without a changelog entry generates nothing (see
+          # --allow-missing); the fill step downstream warns and moves on.
+          if-no-files-found: ignore
 
   # ── Build the prebuilt wheel and publish to PyPI (for the `uv`/`pipx` audience).
   #    This is ADDITIONAL to the native binary, not the primary install path.
@@ -277,6 +305,28 @@ jobs:
           tag_name: v${{ env.VERSION }}
           files: release/*
           prerelease: ${{ needs.version.outputs.IS_PRERELEASE == 'true' }}
+      # Fill the release body from the changelog-derived notes the gate job
+      # rendered — but only when the body is EMPTY. softprops above creates the
+      # release bare on a plain tag push (that is how v0.66.1 shipped without
+      # notes); a release someone pre-created by hand keeps its hand-written
+      # body untouched.
+      - name: Fill release notes when the body is empty
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          notes="artifacts/release-notes/release-notes.md"
+          if [ ! -f "$notes" ]; then
+            echo "::warning::no release-notes artifact (pre-release without a changelog entry?); leaving the body as-is"
+            exit 0
+          fi
+          body="$(gh release view "v${VERSION}" --json body --jq .body)"
+          if [ -n "$body" ]; then
+            echo "release v${VERSION} already has notes (authored by hand); leaving them untouched"
+            exit 0
+          fi
+          gh release edit "v${VERSION}" --notes-file "$notes"
+          echo "filled release notes for v${VERSION} from changelog.py"
       # Attach the pip/uv wheel too. release.yml builds + uploads it (the asset that
       # auto-update and install.sh download) on `release: published`. A release this
       # job creates with GITHUB_TOKEN does NOT emit that event, so when no one

--- a/scripts/gen_release_notes.py
+++ b/scripts/gen_release_notes.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Generate GitHub release notes from ``src/keboola_agent_cli/changelog.py``.
+
+The release pipeline (``release-kbagent.yml``) renders the Markdown body for a
+GitHub Release from the bundled ``CHANGELOG`` dict, so the release page and
+``kbagent changelog`` can never disagree: the entries are emitted verbatim.
+
+When releases are skipped (versions merged to ``main`` but never tagged), the
+next tag is a catch-up release: pass ``--previous`` (the latest *released*
+version) and every changelog entry newer than it is included, one section per
+version, so no shipped change ever goes unannounced.
+
+The script doubles as the forward changelog gate: a *stable* version without a
+``CHANGELOG`` entry is a hard error, failing the release before anything
+publishes. Pre-release tags pass ``--allow-missing`` (their entry may still
+ride on an unmerged feature branch, mirroring ``generate_changelog.py --check``).
+
+Usage:
+    uv run python scripts/gen_release_notes.py --version 0.71.0 \
+        [--previous 0.66.1] [--allow-missing] [--output release-notes.md]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+CHANGELOG_URL = "https://github.com/keboola/cli/blob/main/src/keboola_agent_cli/changelog.py"
+
+
+def collect_versions(
+    version: str, previous: str | None, changelog: Mapping[str, list[str]]
+) -> list[str]:
+    """Return the changelog versions to include, newest first.
+
+    Relies on ``CHANGELOG`` being ordered newest-first (documented invariant of
+    the dict). Includes ``version`` and everything after it down to — but
+    excluding — ``previous``. Falls back to just ``version`` when ``previous``
+    is absent, unknown, or not older than ``version`` in the dict order.
+    """
+    keys = list(changelog)
+    if version not in keys:
+        return []
+    start = keys.index(version)
+    if previous is not None and previous in keys and keys.index(previous) > start:
+        return keys[start : keys.index(previous)]
+    return [version]
+
+
+def render_notes(
+    versions: list[str],
+    changelog: Mapping[str, list[str]],
+    prefix_re: re.Pattern[str],
+) -> str:
+    """Render Markdown release notes: one section per version, entries verbatim.
+
+    ``prefix_re`` is the CLI renderer's prefix matcher
+    (``commands/changelog.py:_PREFIX_RE``) so the release page bolds exactly the
+    prefixes ``kbagent changelog`` colours.
+    """
+    lines: list[str] = []
+    if len(versions) > 1:
+        lines.append(
+            f"Catch-up release: includes previously untagged versions "
+            f"v{versions[-1]} through v{versions[0]}.\n"
+        )
+    for version in versions:
+        lines.append(f"### v{version}\n")
+        for entry in changelog[version]:
+            match = prefix_re.match(entry)
+            if match:
+                entry = f"**{match.group(0).rstrip()}** {entry[match.end() :]}"
+            lines.append(f"- {entry}")
+        lines.append("")
+    lines.append(
+        f"Generated from the bundled changelog — the same content "
+        f"`kbagent changelog --full` shows. Full history: [changelog.py]({CHANGELOG_URL})."
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="Version being released (PEP 440)")
+    parser.add_argument(
+        "--previous",
+        help="Latest already-released version; entries newer than it are included",
+    )
+    parser.add_argument(
+        "--allow-missing",
+        action="store_true",
+        help="Exit 0 (writing nothing) when the version has no changelog entry (pre-releases)",
+    )
+    parser.add_argument("--output", type=Path, help="Write to this file instead of stdout")
+    args = parser.parse_args()
+
+    from keboola_agent_cli.changelog import CHANGELOG
+    from keboola_agent_cli.commands.changelog import _PREFIX_RE
+
+    versions = collect_versions(args.version, args.previous, CHANGELOG)
+    if not versions:
+        if args.allow_missing:
+            print(
+                f"no changelog entry for {args.version}; skipping notes (pre-release)",
+                file=sys.stderr,
+            )
+            return 0
+        print(
+            f"error: no CHANGELOG entry for {args.version} in "
+            f"src/keboola_agent_cli/changelog.py — add one before tagging "
+            f"(see the authoring contract at the top of that file)",
+            file=sys.stderr,
+        )
+        return 1
+
+    notes = render_notes(versions, CHANGELOG, _PREFIX_RE)
+    if args.output:
+        args.output.write_text(notes, encoding="utf-8")
+        print(f"wrote {args.output} ({', '.join(versions)})", file=sys.stderr)
+    else:
+        print(notes, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gen_release_notes.py
+++ b/scripts/gen_release_notes.py
@@ -6,9 +6,12 @@ GitHub Release from the bundled ``CHANGELOG`` dict, so the release page and
 ``kbagent changelog`` can never disagree: the entries are emitted verbatim.
 
 When releases are skipped (versions merged to ``main`` but never tagged), the
-next tag is a catch-up release: pass ``--previous`` (the latest *released*
-version) and every changelog entry newer than it is included, one section per
-version, so no shipped change ever goes unannounced.
+next tag is a catch-up release: pass the already-released versions via
+``--released`` (repeatable) and every changelog version between the tag and the
+first already-released one is included, one section per version, so no shipped
+change ever goes unannounced. Walking the changelog beats "latest release minus
+one": it needs no ordering assumptions about ``gh release list`` and an
+old-line hotfix tagged after a newer release still gets exactly its own section.
 
 The script doubles as the forward changelog gate: a *stable* version without a
 ``CHANGELOG`` entry is a hard error, failing the release before anything
@@ -17,7 +20,8 @@ ride on an unmerged feature branch, mirroring ``generate_changelog.py --check``)
 
 Usage:
     uv run python scripts/gen_release_notes.py --version 0.71.0 \
-        [--previous 0.66.1] [--allow-missing] [--output release-notes.md]
+        [--released 0.66.1 --released 0.66.0 ...] [--allow-missing] \
+        [--output release-notes.md]
 """
 
 from __future__ import annotations
@@ -25,29 +29,36 @@ from __future__ import annotations
 import argparse
 import re
 import sys
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from pathlib import Path
 
 CHANGELOG_URL = "https://github.com/keboola/cli/blob/main/src/keboola_agent_cli/changelog.py"
 
 
 def collect_versions(
-    version: str, previous: str | None, changelog: Mapping[str, list[str]]
+    version: str, released: Collection[str], changelog: Mapping[str, list[str]]
 ) -> list[str]:
     """Return the changelog versions to include, newest first.
 
     Relies on ``CHANGELOG`` being ordered newest-first (documented invariant of
-    the dict). Includes ``version`` and everything after it down to — but
-    excluding — ``previous``. Falls back to just ``version`` when ``previous``
-    is absent, unknown, or not older than ``version`` in the dict order.
+    the dict). Starting at ``version``, walks toward older entries and stops at
+    the first one that is already in ``released`` — everything before the stop
+    is an untagged version the new release must announce. ``version`` itself is
+    always included even when it is in ``released`` (a pre-created release, or
+    a re-run of the pipeline). When no older entry is released (empty or
+    changelog-disjoint ``released``), the boundary is unknowable, so the
+    conservative answer is just ``version`` — never the entire history.
     """
     keys = list(changelog)
     if version not in keys:
         return []
     start = keys.index(version)
-    if previous is not None and previous in keys and keys.index(previous) > start:
-        return keys[start : keys.index(previous)]
-    return [version]
+    collected = [keys[start]]
+    for key in keys[start + 1 :]:
+        if key in released:
+            return collected
+        collected.append(key)
+    return [keys[start]]
 
 
 def render_notes(
@@ -86,8 +97,12 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--version", required=True, help="Version being released (PEP 440)")
     parser.add_argument(
-        "--previous",
-        help="Latest already-released version; entries newer than it are included",
+        "--released",
+        action="append",
+        default=[],
+        metavar="VERSION",
+        help="An already-released version (repeatable); the notes cover every "
+        "changelog version between --version and the first released one",
     )
     parser.add_argument(
         "--allow-missing",
@@ -100,7 +115,7 @@ def main() -> int:
     from keboola_agent_cli.changelog import CHANGELOG
     from keboola_agent_cli.commands.changelog import _PREFIX_RE
 
-    versions = collect_versions(args.version, args.previous, CHANGELOG)
+    versions = collect_versions(args.version, set(args.released), CHANGELOG)
     if not versions:
         if args.allow_missing:
             print(

--- a/tests/test_gen_release_notes.py
+++ b/tests/test_gen_release_notes.py
@@ -1,0 +1,134 @@
+"""Unit tests for release-notes generation (``scripts/gen_release_notes.py``).
+
+The script is the release pipeline's source of GitHub Release bodies AND the
+forward changelog gate (a stable tag without a ``CHANGELOG`` entry must fail
+before anything publishes) — both behaviors are pinned here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+from keboola_agent_cli.commands.changelog import _PREFIX_RE
+
+# ``scripts/`` is not an importable package; load the module by file path.
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "gen_release_notes.py"
+_spec = importlib.util.spec_from_file_location("gen_release_notes", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+gen_release_notes = importlib.util.module_from_spec(_spec)
+sys.modules["gen_release_notes"] = gen_release_notes
+_spec.loader.exec_module(gen_release_notes)
+
+
+collect_versions = gen_release_notes.collect_versions
+
+
+def render_notes(versions: list[str], changelog: dict[str, list[str]]) -> str:
+    return gen_release_notes.render_notes(versions, changelog, _PREFIX_RE)
+
+
+# Newest-first, mirroring the real CHANGELOG dict's documented ordering.
+_CHANGELOG = {
+    "0.71.0": ["New (web UI): repartition tab.", "The serve endpoint forwards new fields."],
+    "0.70.1": ["Fix: config.json hardening.", "Note: clearer not-found errors."],
+    "0.70.0": ["BREAKING: removed git-branches."],
+    "0.66.1": ["Fix (#479): schedules activate."],
+}
+
+
+class TestCollectVersions:
+    def test_single_version_without_previous(self) -> None:
+        assert collect_versions("0.70.1", None, _CHANGELOG) == ["0.70.1"]
+
+    def test_catch_up_range_excludes_previous(self) -> None:
+        assert collect_versions("0.71.0", "0.66.1", _CHANGELOG) == [
+            "0.71.0",
+            "0.70.1",
+            "0.70.0",
+        ]
+
+    def test_version_not_in_changelog_returns_empty(self) -> None:
+        assert collect_versions("9.9.9", "0.66.1", _CHANGELOG) == []
+
+    def test_unknown_previous_falls_back_to_single(self) -> None:
+        assert collect_versions("0.71.0", "0.50.0", _CHANGELOG) == ["0.71.0"]
+
+    def test_previous_newer_than_version_falls_back_to_single(self) -> None:
+        # A misordered dict (or a bad --previous) must not slice backwards.
+        assert collect_versions("0.70.0", "0.71.0", _CHANGELOG) == ["0.70.0"]
+
+    def test_previous_equal_to_version_falls_back_to_single(self) -> None:
+        assert collect_versions("0.70.1", "0.70.1", _CHANGELOG) == ["0.70.1"]
+
+
+class TestRenderNotes:
+    def test_single_version_section_and_verbatim_entry(self) -> None:
+        notes = render_notes(["0.70.0"], _CHANGELOG)
+        assert "### v0.70.0" in notes
+        assert "removed git-branches." in notes
+        assert "Catch-up release" not in notes
+
+    def test_recognised_prefix_is_bolded(self) -> None:
+        notes = render_notes(["0.70.1"], _CHANGELOG)
+        assert "- **Fix:** config.json hardening." in notes
+        assert "- **Note:** clearer not-found errors." in notes
+
+    def test_prefix_with_issue_reference_is_bolded(self) -> None:
+        notes = render_notes(["0.66.1"], _CHANGELOG)
+        assert "- **Fix (#479):** schedules activate." in notes
+
+    def test_prefix_with_freeform_decoration_is_bolded(self) -> None:
+        # `_PREFIX_RE` allows any parenthesized decoration, e.g. "New (web UI):".
+        notes = render_notes(["0.71.0"], _CHANGELOG)
+        assert "- **New (web UI):** repartition tab." in notes
+
+    def test_unprefixed_entry_stays_verbatim(self) -> None:
+        notes = render_notes(["0.71.0"], _CHANGELOG)
+        assert "- The serve endpoint forwards new fields." in notes
+
+    def test_catch_up_release_lists_range_and_all_sections(self) -> None:
+        notes = render_notes(["0.71.0", "0.70.1", "0.70.0"], _CHANGELOG)
+        assert "previously untagged versions v0.70.0 through v0.71.0" in notes
+        for version in ("v0.71.0", "v0.70.1", "v0.70.0"):
+            assert f"### {version}" in notes
+
+    def test_footer_links_the_changelog(self) -> None:
+        notes = render_notes(["0.71.0"], _CHANGELOG)
+        assert "kbagent changelog --full" in notes
+        assert "changelog.py" in notes
+
+
+class TestCli:
+    """End-to-end runs against the real CHANGELOG (the package is installed)."""
+
+    def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(_SCRIPT_PATH), *args],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_known_version_prints_notes(self) -> None:
+        result = self._run("--version", "0.66.1")
+        assert result.returncode == 0
+        assert "### v0.66.1" in result.stdout
+
+    def test_missing_stable_version_fails(self) -> None:
+        result = self._run("--version", "999.0.0")
+        assert result.returncode == 1
+        assert "no CHANGELOG entry for 999.0.0" in result.stderr
+
+    def test_missing_with_allow_missing_writes_nothing(self, tmp_path: Path) -> None:
+        out = tmp_path / "notes.md"
+        result = self._run("--version", "999.0.0b1", "--allow-missing", "--output", str(out))
+        assert result.returncode == 0
+        assert not out.exists()
+
+    def test_output_file_written(self, tmp_path: Path) -> None:
+        out = tmp_path / "notes.md"
+        result = self._run("--version", "0.66.1", "--output", str(out))
+        assert result.returncode == 0
+        assert "### v0.66.1" in out.read_text(encoding="utf-8")

--- a/tests/test_gen_release_notes.py
+++ b/tests/test_gen_release_notes.py
@@ -40,28 +40,38 @@ _CHANGELOG = {
 
 
 class TestCollectVersions:
-    def test_single_version_without_previous(self) -> None:
-        assert collect_versions("0.70.1", None, _CHANGELOG) == ["0.70.1"]
+    def test_adjacent_released_version_yields_single_section(self) -> None:
+        assert collect_versions("0.71.0", {"0.70.1", "0.66.1"}, _CHANGELOG) == ["0.71.0"]
 
-    def test_catch_up_range_excludes_previous(self) -> None:
-        assert collect_versions("0.71.0", "0.66.1", _CHANGELOG) == [
+    def test_catch_up_walk_stops_at_first_released(self) -> None:
+        assert collect_versions("0.71.0", {"0.66.1"}, _CHANGELOG) == [
             "0.71.0",
             "0.70.1",
             "0.70.0",
         ]
 
     def test_version_not_in_changelog_returns_empty(self) -> None:
-        assert collect_versions("9.9.9", "0.66.1", _CHANGELOG) == []
+        assert collect_versions("9.9.9", {"0.66.1"}, _CHANGELOG) == []
 
-    def test_unknown_previous_falls_back_to_single(self) -> None:
-        assert collect_versions("0.71.0", "0.50.0", _CHANGELOG) == ["0.71.0"]
+    def test_version_itself_released_is_still_included(self) -> None:
+        # A pre-created release (or a pipeline re-run) lists the version being
+        # released among the released set; it must not stop the walk at itself.
+        assert collect_versions("0.71.0", {"0.71.0", "0.66.1"}, _CHANGELOG) == [
+            "0.71.0",
+            "0.70.1",
+            "0.70.0",
+        ]
 
-    def test_previous_newer_than_version_falls_back_to_single(self) -> None:
-        # A misordered dict (or a bad --previous) must not slice backwards.
-        assert collect_versions("0.70.0", "0.71.0", _CHANGELOG) == ["0.70.0"]
+    def test_old_line_hotfix_ignores_newer_releases(self) -> None:
+        # Tagging 0.70.0 while 0.71.0 is already out: newer releases are
+        # irrelevant, the walk stops at the first OLDER released version.
+        assert collect_versions("0.70.0", {"0.71.0", "0.66.1"}, _CHANGELOG) == ["0.70.0"]
 
-    def test_previous_equal_to_version_falls_back_to_single(self) -> None:
-        assert collect_versions("0.70.1", "0.70.1", _CHANGELOG) == ["0.70.1"]
+    def test_no_released_boundary_falls_back_to_single(self) -> None:
+        # Empty or changelog-disjoint released set: the boundary is unknowable,
+        # so never emit the entire history.
+        assert collect_versions("0.71.0", set(), _CHANGELOG) == ["0.71.0"]
+        assert collect_versions("0.71.0", {"0.50.0"}, _CHANGELOG) == ["0.71.0"]
 
 
 class TestRenderNotes:
@@ -115,6 +125,12 @@ class TestCli:
         result = self._run("--version", "0.66.1")
         assert result.returncode == 0
         assert "### v0.66.1" in result.stdout
+
+    def test_released_flag_bounds_the_walk(self) -> None:
+        result = self._run("--version", "0.66.1", "--released", "0.66.0")
+        assert result.returncode == 0
+        assert "### v0.66.1" in result.stdout
+        assert "### v0.66.0" not in result.stdout
 
     def test_missing_stable_version_fails(self) -> None:
         result = self._run("--version", "999.0.0")


### PR DESCRIPTION
## Why

v0.66.1 shipped as a GitHub Release with an **empty body**: the tag was pushed alone, the `github-release` job created the release bare (softprops/action-gh-release is given no `body`), and nobody had pre-created the release by hand as previous releases relied on. With AI agents increasingly driving releases, "someone writes the notes by hand first" is not a process — the pipeline must produce the notes itself, and they must match what `kbagent changelog` shows.

## What

- **`scripts/gen_release_notes.py`** — renders the release body verbatim from the `CHANGELOG` dict in `src/keboola_agent_cli/changelog.py`, one `### vX.Y.Z` section per version. Reuses the CLI renderer's `_PREFIX_RE`, so the release page bolds exactly the prefixes `kbagent changelog` colours. With `--previous` (the latest stable release) it includes a section for **every version merged but never tagged** — the next tag after a gap (currently 0.67.0–0.71.0 are unreleased) announces all of them as a catch-up release.
- **Forward changelog gate** — a stable tag whose version has no `CHANGELOG` entry now fails the `gate` job before anything publishes. `generate_changelog.py --check` only audits already-published releases (backward direction); this closes the forward direction. Pre-releases pass `--allow-missing`, mirroring the existing changelog-check skip.
- **`release-kbagent.yml`** — the `gate` job (which already has the uv env) renders `release-notes.md` and ships it to `github-release` as an artifact. After softprops creates the release, a new step fills the body from the artifact **only when the body is empty** — a hand-authored release body is never overwritten.

## Consistency guarantees after this PR

| Direction | Enforced by |
|---|---|
| Every published release has a changelog entry | `generate_changelog.py --check` (existing) |
| Every tagged stable version has a changelog entry | `gen_release_notes.py` hard error in `gate` (new) |
| Release body == changelog content | body is generated verbatim from `CHANGELOG` (new) |
| Hand-written notes survive | fill step skips non-empty bodies (new) |

## Testing

- 17 new unit tests (`tests/test_gen_release_notes.py`): version-range collection (single, catch-up, misordered/unknown `--previous`), rendering (verbatim bullets, prefix bolding incl. `(#479)` / `(web UI)` decorations, footer), CLI behavior (missing stable version exits 1, `--allow-missing` writes nothing and exits 0).
- Full unit suite: 4361 passed.
- Live dry-run against the real changelog: `gen_release_notes.py --version 0.71.0 --previous 0.66.1` renders the expected 6-section catch-up body (0.67.0–0.71.0).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->