### PR TITLE
fix(release): freeze linux binaries on ubuntu-22.04 to restore glibc 2.35 compatibility

### DIFF
--- a/.github/workflows/release-kbagent.yml
+++ b/.github/workflows/release-kbagent.yml
@@ -151,9 +151,19 @@ jobs:
       matrix:
         # `platform` is the OS name baked into artifact/zip filenames (darwin/linux/
         # windows) — Homebrew/Chocolatey/WinGet URLs depend on these exact values.
+        #
+        # Linux legs are PINNED to the OLDEST GA runner, NOT ubuntu-latest: a
+        # PyInstaller binary requires the build machine's glibc (or newer) at
+        # runtime, so the build runner sets the compatibility floor for every
+        # end user. ubuntu-latest (24.04, glibc 2.39) produced a v0.71.0 binary
+        # that failed with "GLIBC_2.38 not found" on Ubuntu 22.04-era systems
+        # (caught by test-install's Homebrew leg, run 29752342509). Building on
+        # ubuntu-22.04 (glibc 2.35) keeps Ubuntu 22.04 / Debian 12 installable.
+        # Bump these only when the OS baseline is consciously dropped — never
+        # back to -latest.
         include:
-          - { os: ubuntu-latest, platform: linux, arch: amd64 }
-          - { os: ubuntu-24.04-arm, platform: linux, arch: arm64 }
+          - { os: ubuntu-22.04, platform: linux, arch: amd64 }
+          - { os: ubuntu-22.04-arm, platform: linux, arch: arm64 }
           # Single macOS environment (Apple Silicon). PyInstaller can't cross-compile,
           # so there's no Intel leg; Intel Macs use `uv tool install`. Re-add a
           # `{ os: macos-13, platform: darwin, arch: amd64 }` entry if native Intel is needed.


### PR DESCRIPTION
## Why

A PyInstaller binary requires the build machine's glibc (or newer) at runtime, so the freeze runner sets the compatibility floor for every end user. The linux amd64 freeze leg runs on `ubuntu-latest`, which is 24.04 (glibc 2.39) — the v0.71.0 binary fails on any glibc < 2.38 system:

```
[PYI-2687:ERROR] Failed to load Python shared library '/tmp/_MEI188JGu/libpython3.12.so.1.0':
dlopen: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found
```

Caught by `test-install`'s Homebrew (Linux) leg in the v0.71.0 release run (29752342509), which runs the binary inside the `homebrew/brew` image (Ubuntu 22.04-era glibc). The apt/rpm legs passed only because `ubuntu:latest` and `fedora` carry new-enough glibc. This is an end-user regression, not a CI quirk: Ubuntu 22.04 / Debian 12 systems cannot run the frozen binary at all. It was previously masked because the v0.66.1 Homebrew leg failed earlier on the missing `brew trust` step (fixed in #483).

## What

Pin both linux freeze legs to the oldest GA runners — `ubuntu-22.04` (amd64) and `ubuntu-22.04-arm` (arm64), glibc 2.35 — and document in the matrix why `-latest` must never be used for freeze legs. Both runner labels are GA per actions/runner-images (no deprecation scheduled).

## Verification

- The released v0.71.0 linux binary demonstrably requires `GLIBC_2.38` (release-run failure above).
- Workflow YAML validates; no other pipeline change.
- Full proof comes from the next release run's `test-install` Homebrew leg, which now exercises exactly the old-glibc scenario. A `workflow_dispatch` dry run of `release-kbagent` on this branch builds the binary on the pinned runners without publishing anything.

## Relation to #503

Refs #503 — this is the "mechanical change" the issue describes (option A: pin to `ubuntu-22.04`, glibc 2.35 floor). It restores Ubuntu 22.04 LTS and Debian 12. It does **not** cover RHEL 9 / Amazon Linux 2023 (glibc 2.34) — if that class of distro should run the native binary, the freeze has to move into an older container (debian 11 / manylinux-style base), which is the floor decision #503 leaves to the maintainers. Keeping #503 open for that call is reasonable; this PR removes the immediate 2.38 regression either way.
