### PR TITLE
feat: MCP passthrough deprecation -- parity map, warnings, CI canary (0.74.0, #478 phase 2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.73.0",
+      "version": "0.74.0",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/.github/workflows/mcp-parity-canary.yml
+++ b/.github/workflows/mcp-parity-canary.yml
@@ -1,0 +1,30 @@
+# MCP parity canary (epic #390 phase 2).
+#
+# Weekly diff of the live keboola-mcp-server tool catalog (TOOLS.md on main)
+# against src/keboola_agent_cli/mcp_parity.py. A new upstream tool without a
+# parity-map entry turns this workflow red -- decide its native equivalent
+# (or port it) before the MCP passthrough removal widens the gap.
+#
+# Deliberately NOT part of the PR-blocking test job: it needs the network and
+# upstream can change under us. Offline invariants run in the normal suite
+# (tests/test_mcp_parity_map.py).
+name: mcp-parity-canary
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Diff upstream tool catalog vs parity map
+        # stdlib-only by design (mcp_parity.py loaded straight from file,
+        # no package import) -- no dependency install needed.
+        run: python3 scripts/check_mcp_parity.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -410,6 +410,11 @@ kbagent permissions check OPERATION
 
 kbagent tool list [--project NAME] [--branch ID]
 kbagent tool call TOOL_NAME [--project NAME] [--input JSON|@file|-] [--branch ID]
+# tool group DEPRECATED (0.74.0+, epic #390): every catalog tool has a native command -- tool list
+#   prints a cli_equivalent column, tool call warns with the exact replacement (stderr; --json adds
+#   an additive "deprecation" key). Parity map = src/keboola_agent_cli/mcp_parity.py; weekly
+#   mcp-parity-canary workflow (make parity-check) diffs it against upstream TOOLS.md. The group
+#   (and `agent --type mcp_tool`) will be removed after the deprecation window.
 
 kbagent branch list [--project NAME]
 kbagent branch create --project ALIAS --name "..." [--description "..."]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help install install-mcp install-server sync test test-unit test-integration test-e2e test-e2e-local test-e2e-invite test-e2e-feature test-e2e-stream test-file test-cov lint lint-fix format format-check typecheck typecheck-warn skill-check skill-gen version-sync version-check changelog changelog-check check-error-codes command-sync-check gen-command-reference check clean hooks web-install web-dev-backend web-dev-frontend web-build web-clean
+.PHONY: help install install-mcp install-server sync test test-unit test-integration test-e2e test-e2e-local test-e2e-invite test-e2e-feature test-e2e-stream test-file test-cov lint lint-fix format format-check typecheck typecheck-warn skill-check skill-gen version-sync version-check changelog changelog-check check-error-codes parity-check command-sync-check gen-command-reference check clean hooks web-install web-dev-backend web-dev-frontend web-build web-clean
 
 help: ## Show this help message
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
@@ -100,6 +100,9 @@ changelog-check: ## Check all releases have changelog entries
 
 check-error-codes: ## Reject raw error_code string literals in source (use ErrorCode enum)
 	uv run python scripts/check_error_codes.py
+
+parity-check: ## Diff live keboola-mcp-server tool catalog vs the parity map (network; not part of `check`)
+	python3 scripts/check_mcp_parity.py
 
 command-sync-check: ## Verify every CLI command is registered + documented (silent-drift gate)
 	uv run python scripts/check_command_sync.py

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.73.0",
+  "version": "0.74.0",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/plugins/kbagent/agents/keboola-expert.md
+++ b/plugins/kbagent/agents/keboola-expert.md
@@ -228,7 +228,7 @@ read it when a trigger fires. Each `(X.Y.Z+)` tag is the version floor.
   dirs; `is_disabled: true` in `_config.yml` = config disabled (absent =
   enabled); a `never_fetched` warning on diff/push = run `sync pull` first.
   `sync status` is local-only -- audit real drift with `sync diff`.
-- **MCP passthrough is deprecating; firewall is fail-closed** (0.73.0+):
+- **MCP passthrough is DEPRECATED (0.74.0+); firewall fail-closed since 0.73.0**:
   prefer native parity commands over `tool call` -- `docs query`,
   `config examples`, `semantic-layer schema`, `component sync-action`,
   `transformation create|show|edit`, `flow examples`; `workspace query`

--- a/plugins/kbagent/skills/kbagent/references/commands-reference.md
+++ b/plugins/kbagent/skills/kbagent/references/commands-reference.md
@@ -203,9 +203,10 @@ Lifecycle for `keboola.data-apps`. Combines Storage API (config body, git block,
 - `data-app git-credentials --project NAME --app-id ID` (since 0.63.3) -- list the credentials of the app's MANAGED git repo (`id`, `type`, `permissions`, `name`, `owner_admin_id`, `created_at`). The secret is NEVER returned here. Needs an admin storage token; external repos have none.
 - `data-app git-credentials-create --project NAME --app-id ID --type ssh_key|http_token --permissions readOnly|readWrite [--public-key KEY | --public-key-file PATH] [--name LABEL] [--yes]` (since 0.63.3) -- mint a git credential for the app's MANAGED git repo. `ssh_key` requires a public key; `http_token` returns a ONE-TIME secret (shown once, never retrievable again -- mirrors `data-app password`). Needs an admin storage token. Apps from `data-app create --git-repo` are EXTERNAL => 409 `no managed Git repository`. Confirmation unless `--yes`/`--json`. For a managed-repo app this credential authenticates YOUR `git push` of the code; the deploy itself uses the platform's injected clone credentials -- no further wiring needed.
 
-## MCP Tools
-- `tool list [--project NAME] [--branch ID]` -- list available MCP tools (multi_project annotation)
-- `tool call TOOL_NAME [--project NAME] [--input JSON|@file|-] [--branch ID]` -- call MCP tool (read = all projects, write = single). `--input` accepts inline JSON, `@file.json`, or `-` (stdin)
+## MCP Tools (DEPRECATED since v0.74.0 -- epic #390)
+Every catalog tool has a native command; `tool list` prints a `cli_equivalent` column and `tool call` warns with the exact replacement. The group will be removed after the deprecation window. Prefer native commands in all new workflows.
+- `tool list [--project NAME] [--branch ID]` -- list available MCP tools (multi_project annotation + `cli_equivalent` since 0.74.0)
+- `tool call TOOL_NAME [--project NAME] [--input JSON|@file|-] [--branch ID]` -- call MCP tool (read = all projects, write = single). `--input` accepts inline JSON, `@file.json`, or `-` (stdin). Emits a deprecation warning naming the native equivalent (stderr in human mode, additive `deprecation` key in `--json`)
 
 ## SQL Transformations (since v0.73.0)
 Ports the MCP `create_sql_transformation` / `update_sql_transformation` tools (#396). See [transformation-workflow.md](transformation-workflow.md) for the show-before-edit recipe.

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -11,6 +11,24 @@ Versioning convention:
   behavior; the inline `(updated vX.Y.Z)` records when the refinement landed.
 -->
 
+## MCP passthrough is DEPRECATED; parity map + canary (since v0.74.0)
+
+- **`tool call` / `tool list` / `agent --type mcp_tool` are on a removal
+  track** (epic #390 phase 2). `tool call` warns with the exact native
+  replacement (stderr in human mode; additive `deprecation` key in the
+  `--json` envelope -- parse-safe, no existing key changed). `tool list`
+  gains a `cli_equivalent` column/field. Serve `/mcp/tools*` routes are
+  marked `deprecated` in OpenAPI (`/mcp/server-status` stays).
+- **The parity map is code**: `src/keboola_agent_cli/mcp_parity.py` --
+  one entry per upstream tool; offline tests pin every entry to a real
+  OPERATION_REGISTRY key, and the weekly `mcp-parity-canary` workflow
+  (also `make parity-check`) diffs the live keboola-mcp-server `TOOLS.md`
+  against it, so a new upstream tool turns the canary red instead of
+  silently widening the gap.
+- **`agent --type mcp_tool` tasks keep working** through the deprecation
+  window -- creation just warns; migrate to `--type cli_command` with the
+  native command at your own pace before the removal release.
+
 ## MCP tool classification is FAIL-CLOSED; parity commands replace `tool call` (since v0.73.0)
 
 - **Unknown MCP tool names classify as `destructive`** -- blocked by BOTH

--- a/plugins/kbagent/skills/kbagent/references/mcp-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/mcp-workflow.md
@@ -1,5 +1,12 @@
 # MCP Tools Workflow
 
+> **DEPRECATED (since v0.74.0, epic #390).** The MCP passthrough (`tool list`,
+> `tool call`, `agent --type mcp_tool`) is on a removal track: every catalog
+> tool has a native CLI command. Run `kbagent tool list` and use the
+> `cli_equivalent` column, or see the parity map in
+> `src/keboola_agent_cli/mcp_parity.py`. Prefer native commands in ALL new
+> workflows; this document remains only for reading existing setups.
+
 MCP tools let you interact with Keboola components directly -- creating configs,
 running components, fetching schemas -- through the keboola-mcp-server.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-cli"
-version = "0.73.0"
+version = "0.74.0"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/check_mcp_parity.py
+++ b/scripts/check_mcp_parity.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""CI canary: diff the live keboola-mcp-server tool catalog against the parity map.
+
+Fetches ``TOOLS.md`` from the keboola/mcp-server default branch, extracts the
+tool index (``- [tool_name](#tool_name): ...`` lines), and compares it with
+``keboola_agent_cli.mcp_parity.MCP_TOOL_PARITY``:
+
+- a catalog tool MISSING from the map -> exit 1 (a new server tool shipped;
+  port it or map it to an existing command BEFORE the passthrough removal
+  widens the gap -- epic #390),
+- a mapped tool gone from the catalog -> warning only (upstream removed it;
+  prune the entry at leisure).
+
+Runs from the weekly ``mcp-parity-canary`` workflow and ``make parity-check``.
+Network-dependent by design -- deliberately NOT part of ``make check`` / the
+PR-blocking test job. Offline invariants live in tests/test_mcp_parity_map.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+
+def _load_parity_map() -> dict:
+    """Load MCP_TOOL_PARITY straight from the module file.
+
+    Bypasses ``keboola_agent_cli/__init__.py`` (which imports the SDK facade
+    and its third-party deps) so the canary runs on a bare python3 in CI --
+    ``mcp_parity.py`` itself is stdlib-only.
+    """
+    module_path = Path(__file__).parent.parent / "src" / "keboola_agent_cli" / "mcp_parity.py"
+    spec = importlib.util.spec_from_file_location("mcp_parity", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # dataclasses resolves cls.__module__ through sys.modules at class-creation
+    # time -- exec without registration crashes on python >= 3.13.
+    sys.modules["mcp_parity"] = module
+    spec.loader.exec_module(module)
+    return module.MCP_TOOL_PARITY
+
+
+MCP_TOOL_PARITY = _load_parity_map()
+
+TOOLS_MD_URL = "https://raw.githubusercontent.com/keboola/mcp-server/main/TOOLS.md"
+_INDEX_LINE = re.compile(r"^- \[(?P<name>[a-z0-9_]+)\]\(#(?P=name)\):", re.MULTILINE)
+
+
+def fetch_catalog() -> set[str]:
+    with urllib.request.urlopen(TOOLS_MD_URL, timeout=30) as resp:
+        body = resp.read().decode("utf-8")
+    names = set(_INDEX_LINE.findall(body))
+    if not names:
+        raise RuntimeError(
+            "No tool index lines matched in TOOLS.md -- the upstream format "
+            "changed; fix _INDEX_LINE in scripts/check_mcp_parity.py."
+        )
+    return names
+
+
+def main() -> int:
+    catalog = fetch_catalog()
+    mapped = set(MCP_TOOL_PARITY)
+
+    unmapped = sorted(catalog - mapped)
+    stale = sorted(mapped - catalog)
+
+    print(f"catalog: {len(catalog)} tools, parity map: {len(mapped)} entries")
+    if stale:
+        print(
+            "\nWARNING: mapped tools no longer in the upstream catalog "
+            "(prune from mcp_parity.py when convenient):"
+        )
+        for name in stale:
+            print(f"  - {name}")
+    if unmapped:
+        print(
+            "\nFAIL: upstream tools with NO parity-map entry -- decide the "
+            "native equivalent (or port) and add it to "
+            "src/keboola_agent_cli/mcp_parity.py (epic #390):"
+        )
+        for name in unmapped:
+            print(f"  - {name}")
+        return 1
+
+    print("OK: every upstream tool has a parity-map entry.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -24,6 +24,23 @@ from .constants import CHANGELOG_HEADLINE_MAX_CHARS
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.74.0": [
+        "MCP passthrough deprecation (#478 phase 2, epic #390): `tool call` / `tool list` "
+        "/ `agent --type mcp_tool` are now formally deprecated in favor of native commands. "
+        "Nothing breaks yet -- everything keeps working through the deprecation window.",
+        "`tool call` warns with the EXACT native replacement for the tool being called "
+        "(stderr in human mode; additive `deprecation` key in the `--json` envelope). "
+        "`tool list` gains a `cli_equivalent` column/field sourced from the new parity map.",
+        "New: `src/keboola_agent_cli/mcp_parity.py` -- the tool->command parity map as code, "
+        "with offline tests pinning every entry to a registered CLI operation, and a weekly "
+        "`mcp-parity-canary` GitHub workflow (`make parity-check`) that diffs the live "
+        "keboola-mcp-server catalog against it so a new upstream tool turns the canary red "
+        "instead of silently widening the gap.",
+        "`agent create/update/test --type mcp_tool` warn and point at `--type cli_command` "
+        "with the native command; existing mcp_tool tasks keep running unchanged.",
+        "Serve: `/mcp/tools*` routes are marked deprecated in OpenAPI "
+        "(`/mcp/server-status` stays -- it reports embedded-server health).",
+    ],
     "0.73.0": [
         "MCP parity + fail-closed firewall (#478 phase 0, epic #390 phase 1): six native "
         "commands port the remaining keboola-mcp-server tools, and MCP tool classification "

--- a/src/keboola_agent_cli/commands/agent.py
+++ b/src/keboola_agent_cli/commands/agent.py
@@ -30,6 +30,17 @@ from ._helpers import check_cli_permission, get_formatter, get_service
 
 agent_app = typer.Typer(help="Scheduled agent tasks (cron / manual / chained)")
 
+# The mcp_tool action flavour rides the deprecated MCP passthrough (epic
+# #390 phase 2). Tasks keep running -- this only surfaces the deprecation:
+# stderr warning in human mode, additive "deprecation" envelope key in
+# JSON mode. Creation is never blocked; agents.json / REST payloads are
+# unchanged.
+MCP_TOOL_ACTION_DEPRECATION = (
+    "agent action type 'mcp_tool' is deprecated (epic #390); prefer --type "
+    "cli_command with the native kbagent command (see `kbagent tool list` "
+    "cli_equivalent column)."
+)
+
 
 @agent_app.callback(invoke_without_command=True)
 def _agent_permission_check(ctx: typer.Context) -> None:
@@ -594,6 +605,8 @@ def agent_create(
         input_payload=input_payload,
         timeout=timeout,
     )
+    if action.type == "mcp_tool":
+        formatter.warning(MCP_TOOL_ACTION_DEPRECATION)
     trigger = _trigger_from_flags(trigger_task_id, trigger_on)
     try:
         task = service.create_task(
@@ -608,7 +621,10 @@ def agent_create(
     except ConfigError as exc:
         formatter.error(message=exc.message, error_code=ErrorCode.CONFIG_ERROR)
         raise typer.Exit(code=5) from None
-    formatter.output(task.model_dump(mode="json"), _render_created_task)
+    payload = task.model_dump(mode="json")
+    if action.type == "mcp_tool" and formatter.json_mode:
+        payload["deprecation"] = MCP_TOOL_ACTION_DEPRECATION
+    formatter.output(payload, _render_created_task)
 
 
 @agent_app.command("update")
@@ -658,7 +674,15 @@ def agent_update(
     except ConfigError as exc:
         formatter.error(message=exc.message, error_code=ErrorCode.CONFIG_ERROR)
         raise typer.Exit(code=5) from None
-    formatter.output(task.model_dump(mode="json"), _render_updated_task)
+    # `update` cannot change the action, so warn based on the task's
+    # persisted flavour: touching an mcp_tool task keeps it on the
+    # deprecated MCP passthrough (epic #390).
+    payload = task.model_dump(mode="json")
+    if task.action.type == "mcp_tool":
+        formatter.warning(MCP_TOOL_ACTION_DEPRECATION)
+        if formatter.json_mode:
+            payload["deprecation"] = MCP_TOOL_ACTION_DEPRECATION
+    formatter.output(payload, _render_updated_task)
 
 
 @agent_app.command("delete")
@@ -878,11 +902,18 @@ def agent_test(
         input_payload=input_payload,
         timeout=timeout,
     )
+    if action.type == "mcp_tool":
+        formatter.warning(MCP_TOOL_ACTION_DEPRECATION)
     if stream:
+        # NDJSON event lines mirror the SSE surface byte-for-byte; the
+        # deprecation is not injected into stream events on purpose.
         _stream_to_stdout(formatter, service.stream_test_action(action, name=name))
         return
     run = asyncio.run(service.test_action(action, name=name))
-    formatter.output(run.model_dump(mode="json"), _render_test_result)
+    payload = run.model_dump(mode="json")
+    if action.type == "mcp_tool" and formatter.json_mode:
+        payload["deprecation"] = MCP_TOOL_ACTION_DEPRECATION
+    formatter.output(payload, _render_test_result)
 
 
 @agent_app.command("cron-preview")

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -1251,10 +1251,16 @@ with `metastore.`. Auth: same `X-StorageApi-Token` as Storage. Alias:
 
   See agent-tasks-cli-workflow.md skill reference for full walkthroughs.
 
-### MCP Tools (Multi-Project)
+### MCP Tools (Multi-Project) -- DEPRECATED since 0.74.0
+
+  The MCP passthrough is on a removal track (epic #390): every catalog tool
+  has a native command. Prefer the native command in ALL new work -- `tool
+  list` prints the replacement in the cli_equivalent column and `tool call`
+  warns with it (stderr in human mode; additive "deprecation" key in --json).
 
   kbagent tool list [--project NAME] [--branch ID]
-    List MCP tools with inputSchema. Use --json to inspect accepted parameters.
+    List MCP tools with inputSchema + cli_equivalent. Use --json to inspect
+    accepted parameters.
 
   kbagent tool call TOOL_NAME [--project NAME] [--input JSON|@file|-] [--branch ID]
     Call an MCP tool. Read tools auto-query all projects. Write tools need --project.

--- a/src/keboola_agent_cli/commands/tool.py
+++ b/src/keboola_agent_cli/commands/tool.py
@@ -2,6 +2,11 @@
 
 Thin CLI layer: parses arguments, calls McpService, formats output.
 No business logic belongs here.
+
+The whole ``tool`` group is DEPRECATED (epic #390 phase 2): every MCP tool
+has a native kbagent command (see ``mcp_parity.MCP_TOOL_PARITY``). Both
+subcommands surface the deprecation -- human mode on stderr, JSON mode via
+an additive ``deprecation`` key -- without changing behavior.
 """
 
 import json
@@ -12,6 +17,7 @@ import typer
 
 from ..config_store import ConfigStore
 from ..errors import ConfigError, ErrorCode, PermissionDeniedError
+from ..mcp_parity import deprecation_message, native_equivalent
 from ..output import OutputFormatter, format_tool_result, format_tools_table
 from ._helpers import (
     EXIT_PERMISSION_DENIED,
@@ -24,6 +30,13 @@ from ._helpers import (
 )
 
 tool_app = typer.Typer(help="MCP tools - interact with Keboola via MCP server")
+
+# Generic deprecation banner for `tool list` (epic #390 phase 2). Per-tool
+# messages for `tool call` come from mcp_parity.deprecation_message().
+TOOL_LIST_DEPRECATION = (
+    "The MCP passthrough is deprecated (epic #390); every tool has a native "
+    "command -- see the cli_equivalent column."
+)
 
 
 @tool_app.callback(invoke_without_command=True)
@@ -80,7 +93,11 @@ def tool_list(
         help="Development branch ID (requires --project or active branch)",
     ),
 ) -> None:
-    """List available MCP tools from the keboola-mcp-server."""
+    """List available MCP tools from the keboola-mcp-server.
+
+    DEPRECATED (epic #390): every tool maps to a native kbagent command --
+    see the cli_equivalent column in the output.
+    """
     formatter = get_formatter(ctx)
     service = get_service(ctx, "mcp_service")
     config_store: ConfigStore = ctx.obj["config_store"]
@@ -105,10 +122,20 @@ def tool_list(
         formatter.error(message=exc.message, error_code=ErrorCode.CONFIG_ERROR)
         raise typer.Exit(code=5) from None
 
+    # Enrich each tool with its native CLI equivalent (epic #390). Done in the
+    # command layer on purpose: the service dict stays byte-identical to what
+    # the MCP server reports; cli_equivalent / deprecation are additive keys.
+    for tool in result.get("tools", []):
+        entry = native_equivalent(tool.get("name", ""))
+        tool["cli_equivalent"] = entry.command if entry is not None else ""
+
     if formatter.json_mode:
+        result["deprecation"] = TOOL_LIST_DEPRECATION
         formatter.output(result)
     else:
         format_tools_table(formatter.console, result)
+        if result.get("tools"):
+            formatter.console.print(f"[bold yellow]{TOOL_LIST_DEPRECATION}[/bold yellow]")
         emit_project_warnings(formatter, result)
 
 
@@ -133,6 +160,9 @@ def tool_call(
     ),
 ) -> None:
     """Call an MCP tool on keboola-mcp-server.
+
+    DEPRECATED (epic #390): prefer the native kbagent command for the tool
+    (run `kbagent tool list` and read the cli_equivalent column).
 
     Read tools (list_*, get_*, search, docs_query, find_*) run across ALL
     connected projects in parallel and return aggregated results.
@@ -160,6 +190,12 @@ def tool_call(
         except PermissionDeniedError as exc:
             formatter.error(message=exc.message, error_code=ErrorCode.PERMISSION_DENIED)
             raise typer.Exit(code=EXIT_PERMISSION_DENIED) from None
+
+    # Deprecation surface (epic #390): stderr warning in human mode (never
+    # pollutes stdout); JSON mode injects the message into the success
+    # envelope below instead (error paths carry no deprecation key).
+    deprecation = deprecation_message(tool_name)
+    formatter.warning(deprecation)
 
     validate_branch_requires_project(formatter, branch, project)
 
@@ -215,6 +251,7 @@ def tool_call(
         raise typer.Exit(code=exit_code) from None
 
     if formatter.json_mode:
+        result["deprecation"] = deprecation
         formatter.output(result)
     else:
         format_tool_result(formatter.console, result)

--- a/src/keboola_agent_cli/mcp_parity.py
+++ b/src/keboola_agent_cli/mcp_parity.py
@@ -1,0 +1,144 @@
+"""MCP tool -> native CLI command parity map (epic #390, issue #478 phase 2).
+
+The MCP passthrough (``tool call`` / ``tool list`` / ``agent --type
+mcp_tool``) is deprecated in favor of native commands. This module is the
+single source of truth for the mapping, consumed by:
+
+- the deprecation warnings printed by ``tool call`` / ``tool list``
+  (each names the native equivalent for the exact tool being used),
+- ``scripts/check_mcp_parity.py`` -- the CI canary that diffs the live
+  keboola-mcp-server catalog (``TOOLS.md``) against this map, so a new
+  server tool opens a red run instead of silently widening the gap,
+- ``tests/test_mcp_parity_map.py`` -- offline invariants (every mapped
+  command resolves to a registered CLI operation).
+
+Keep entries in sync with the CATALOG the canary fetches; an unmapped tool
+is a parity BUG by definition (that is the point of the canary).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ParityEntry:
+    """Native-CLI equivalent of one MCP tool.
+
+    ``command`` is the canonical replacement in CLI notation (also used to
+    derive the ``group.subcommand`` operation key for registry checks).
+    ``note`` carries display-only context (alternatives, caveats).
+    """
+
+    command: str
+    note: str = ""
+
+
+# Every tool in the keboola-mcp-server catalog -> its native replacement.
+# Display strings; the FIRST TWO tokens of ``command`` must form a valid
+# OPERATION_REGISTRY key (enforced by tests/test_mcp_parity_map.py).
+MCP_TOOL_PARITY: dict[str, ParityEntry] = {
+    # -- Component tools ---------------------------------------------------
+    "add_config_row": ParityEntry("config row-create"),
+    "create_config": ParityEntry("config new", note="use --push for one-shot remote create"),
+    "create_sql_transformation": ParityEntry("transformation create"),
+    "get_components": ParityEntry("component list", note="or `component detail`"),
+    "get_config_examples": ParityEntry("config examples"),
+    "get_configs": ParityEntry("config list", note="or `config detail`"),
+    "run_sync_action": ParityEntry("component sync-action"),
+    "update_config": ParityEntry("config update"),
+    "update_config_row": ParityEntry("config row-update"),
+    "update_sql_transformation": ParityEntry("transformation edit"),
+    # -- Documentation -----------------------------------------------------
+    "docs_query": ParityEntry("docs query"),
+    # -- Flows ---------------------------------------------------------------
+    "create_conditional_flow": ParityEntry("flow new"),
+    "create_flow": ParityEntry(
+        "flow new",
+        note="legacy keboola.orchestrator flows were dropped in 0.57.0; "
+        "kbagent creates conditional flows (keboola.flow) only",
+    ),
+    "get_flow_examples": ParityEntry("flow examples"),
+    "get_flow_schema": ParityEntry("flow schema", note="--full for the JSON Schema"),
+    "get_flows": ParityEntry("flow list", note="or `flow detail`"),
+    "modify_flow": ParityEntry("flow update"),
+    "update_flow": ParityEntry("flow update"),
+    # -- Jobs ----------------------------------------------------------------
+    "get_jobs": ParityEntry("job list", note="or `job detail`"),
+    "run_job": ParityEntry("job run", note="add --wait to collect the result"),
+    # -- OAuth ---------------------------------------------------------------
+    "create_oauth_url": ParityEntry("config oauth-url"),
+    # -- Data apps -----------------------------------------------------------
+    "create_python_js_data_app_git_credential": ParityEntry("data-app git-credentials-create"),
+    "delete_python_js_data_app_draft": ParityEntry("data-app delete"),
+    "deploy_data_app": ParityEntry("data-app deploy", note="or `data-app stop`"),
+    "get_data_apps": ParityEntry("data-app list", note="or `data-app detail`"),
+    "modify_python_js_data_app": ParityEntry(
+        "data-app create", note="update via `config update` + `data-app secrets-set`"
+    ),
+    "modify_streamlit_data_app": ParityEntry(
+        "data-app create", note="update via `config update` + `data-app secrets-set`"
+    ),
+    # -- Project -------------------------------------------------------------
+    "get_project_info": ParityEntry("project info"),
+    "update_project_description": ParityEntry("project description-set"),
+    # -- SQL -----------------------------------------------------------------
+    "query_data": ParityEntry(
+        "workspace query",
+        note="intentionally unported (#390): workspace query composes multi-step "
+        "SQL over a persistent workspace instead of an implicit one-shot SELECT",
+    ),
+    # -- Search --------------------------------------------------------------
+    "find_component_id": ParityEntry("component list", note="use --query"),
+    "search": ParityEntry("search"),
+    # -- Semantic layer ------------------------------------------------------
+    "get_semantic_context": ParityEntry(
+        "semantic-layer show", note="or `semantic-layer get-context`"
+    ),
+    "get_semantic_schema": ParityEntry("semantic-layer schema"),
+    "search_semantic_context": ParityEntry("semantic-layer search-context"),
+    "validate_semantic_query": ParityEntry(
+        "semantic-layer validate",
+        note="intentionally unported (#390): model-level validation; the MCP "
+        "tool's per-query string heuristics were rejected as drift-prone",
+    ),
+    # -- Storage -------------------------------------------------------------
+    "get_buckets": ParityEntry("storage buckets", note="or `storage bucket-detail`"),
+    "get_tables": ParityEntry("storage tables", note="or `storage table-detail`"),
+    "update_descriptions": ParityEntry(
+        "storage describe-batch",
+        note="or describe-table / describe-bucket / describe-column",
+    ),
+}
+
+# Single-token commands whose registry key is just the command name.
+_SINGLE_TOKEN_OPERATIONS: frozenset[str] = frozenset({"search"})
+
+
+def parity_operation_key(entry: ParityEntry) -> str:
+    """Derive the OPERATION_REGISTRY key for an entry's canonical command."""
+    tokens = entry.command.split()
+    if tokens[0] in _SINGLE_TOKEN_OPERATIONS:
+        return tokens[0]
+    return f"{tokens[0]}.{tokens[1]}"
+
+
+def native_equivalent(tool_name: str) -> ParityEntry | None:
+    """Native replacement for *tool_name*, or None for an unmapped tool."""
+    return MCP_TOOL_PARITY.get(tool_name)
+
+
+def deprecation_message(tool_name: str) -> str:
+    """One-line deprecation warning for ``tool call`` (human + JSON envelope)."""
+    entry = native_equivalent(tool_name)
+    if entry is None:
+        return (
+            f"MCP passthrough is deprecated (epic #390) and tool {tool_name!r} has "
+            f"no native equivalent yet -- please report it at "
+            f"https://github.com/keboola/cli/issues/390."
+        )
+    suffix = f" ({entry.note})" if entry.note else ""
+    return (
+        f"MCP passthrough is deprecated (epic #390); use `kbagent {entry.command}` "
+        f"instead{suffix}. The `tool` group will be removed in a future release."
+    )

--- a/src/keboola_agent_cli/output.py
+++ b/src/keboola_agent_cli/output.py
@@ -483,6 +483,7 @@ def format_tools_table(console: Console, data: dict[str, Any]) -> None:
 
     table = Table(title="MCP Tools")
     table.add_column("Tool Name", style="bold cyan")
+    table.add_column("CLI equivalent", style="green")
     table.add_column("Parameters")
     table.add_column("Multi-Project", justify="center")
     table.add_column("Description", max_width=60)
@@ -492,6 +493,7 @@ def format_tools_table(console: Console, data: dict[str, Any]) -> None:
         params_str = _format_tool_params(tool.get("inputSchema", {}))
         table.add_row(
             tool["name"],
+            tool.get("cli_equivalent", ""),
             params_str,
             multi,
             tool.get("description", ""),

--- a/src/keboola_agent_cli/server/routers/mcp.py
+++ b/src/keboola_agent_cli/server/routers/mcp.py
@@ -1,4 +1,11 @@
-"""MCP tool endpoints (list, call across projects)."""
+"""MCP tool endpoints (list, call across projects).
+
+DEPRECATED surface (epic #390 phase 2): every catalog tool has a native
+CLI command and serve route -- see ``keboola_agent_cli.mcp_parity``. The
+``/mcp/tools*`` operations are marked ``deprecated`` in OpenAPI and will
+be removed together with the CLI ``tool`` group. ``/mcp/server-status``
+stays (it reports embedded-server health, not tool passthrough).
+"""
 
 from __future__ import annotations
 
@@ -18,7 +25,7 @@ class ToolCall(BaseModel):
     branch_id: str | None = None
 
 
-@router.get("/tools", summary="List MCP tools")
+@router.get("/tools", summary="List MCP tools", deprecated=True)
 def list_tools(
     project: str | None = None,
     branch_id: str | None = None,
@@ -31,7 +38,7 @@ def list_tools(
     return registry.mcp.list_tools(aliases=aliases, branch_id=branch_id)
 
 
-@router.get("/tools/{tool_name}/schema", summary="Fetch a tool's input schema")
+@router.get("/tools/{tool_name}/schema", summary="Fetch a tool's input schema", deprecated=True)
 def tool_schema(
     tool_name: str,
     project: str | None = None,
@@ -46,7 +53,7 @@ def tool_schema(
     return {"tool": tool_name, "input_schema": schema or {}}
 
 
-@router.post("/tools/{tool_name}/call", summary="Call an MCP tool")
+@router.post("/tools/{tool_name}/call", summary="Call an MCP tool", deprecated=True)
 def call_tool(
     tool_name: str, body: ToolCall, registry: ServiceRegistry = Depends(get_registry)
 ) -> dict[str, Any]:

--- a/tests/test_mcp_deprecation_warnings.py
+++ b/tests/test_mcp_deprecation_warnings.py
@@ -1,0 +1,405 @@
+"""Deprecation warnings for the MCP passthrough (epic #390 phase 2).
+
+The whole ``tool`` group and the ``agent --type mcp_tool`` action flavour
+are deprecated in favor of native commands (``mcp_parity.MCP_TOOL_PARITY``).
+These tests pin the surfacing contract:
+
+- human mode: yellow warning on STDERR only -- stdout stays byte-clean,
+- JSON mode: additive ``deprecation`` key inside the success envelope's
+  data payload (no key renamed/removed; error paths carry no key),
+- ``tool list`` tools gain an additive ``cli_equivalent`` key / column.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from keboola_agent_cli.cli import app
+
+from .helpers import setup_single_project
+
+runner = CliRunner()
+
+
+def _flat(text: str) -> str:
+    """Collapse whitespace so Rich line-wrapping cannot break substring asserts."""
+    return " ".join(text.split())
+
+
+def _config_dir(tmp_path: Path) -> Path:
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    setup_single_project(config_dir, token="901-55555-fakeTestTokenDoNotUseXXXXXXXX")
+    return config_dir
+
+
+SAMPLE_TOOL_RESULT = {
+    "results": [
+        {
+            "content": [{"name": "bucket-a"}],
+            "isError": False,
+            "project_alias": "prod",
+        },
+    ],
+    "errors": [],
+}
+
+SAMPLE_TOOLS = [
+    {
+        "name": "get_buckets",
+        "description": "B",
+        "inputSchema": {},
+        "multi_project": True,
+    },
+    {
+        "name": "totally_unknown_tool",
+        "description": "U",
+        "inputSchema": {},
+        "multi_project": False,
+    },
+]
+
+
+class TestToolCallDeprecation:
+    """`tool call` surfaces the per-tool deprecation message."""
+
+    def test_human_mode_warns_on_stderr_stdout_clean(self, tmp_path: Path) -> None:
+        with patch("keboola_agent_cli.cli.McpService") as MockMcpService:
+            mock_mcp = MagicMock()
+            mock_mcp.validate_and_call_tool.return_value = SAMPLE_TOOL_RESULT
+            MockMcpService.return_value = mock_mcp
+
+            result = runner.invoke(
+                app,
+                ["--config-dir", str(_config_dir(tmp_path)), "tool", "call", "get_buckets"],
+            )
+
+        assert result.exit_code == 0, result.output
+        stderr = _flat(result.stderr)
+        assert "Warning:" in stderr
+        assert "MCP passthrough is deprecated (epic #390)" in stderr
+        assert "use `kbagent storage buckets` instead" in stderr
+        # stdout must stay clean: result rendering only, no deprecation noise
+        stdout = _flat(result.stdout)
+        assert "deprecated" not in stdout
+        assert "bucket-a" in stdout
+
+    def test_json_mode_envelope_gains_deprecation_key(self, tmp_path: Path) -> None:
+        with patch("keboola_agent_cli.cli.McpService") as MockMcpService:
+            mock_mcp = MagicMock()
+            mock_mcp.validate_and_call_tool.return_value = SAMPLE_TOOL_RESULT
+            MockMcpService.return_value = mock_mcp
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "--config-dir",
+                    str(_config_dir(tmp_path)),
+                    "tool",
+                    "call",
+                    "get_buckets",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        # stdout must be a single valid JSON document
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "ok"
+        data = payload["data"]
+        # additive key only: existing keys untouched
+        assert data["results"][0]["project_alias"] == "prod"
+        assert data["errors"] == []
+        assert "storage buckets" in data["deprecation"]
+        assert "epic #390" in data["deprecation"]
+        # JSON mode never prints the warning separately
+        assert "deprecated" not in result.stderr
+
+    def test_json_mode_unmapped_tool_still_gets_message(self, tmp_path: Path) -> None:
+        with patch("keboola_agent_cli.cli.McpService") as MockMcpService:
+            mock_mcp = MagicMock()
+            mock_mcp.validate_and_call_tool.return_value = SAMPLE_TOOL_RESULT
+            MockMcpService.return_value = mock_mcp
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "--config-dir",
+                    str(_config_dir(tmp_path)),
+                    "tool",
+                    "call",
+                    "totally_unknown_tool",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert "no native equivalent yet" in payload["data"]["deprecation"]
+
+    def test_error_path_carries_no_deprecation_key(self, tmp_path: Path) -> None:
+        from keboola_agent_cli.errors import ConfigError
+
+        with patch("keboola_agent_cli.cli.McpService") as MockMcpService:
+            mock_mcp = MagicMock()
+            mock_mcp.validate_and_call_tool.side_effect = ConfigError("Unknown MCP tool: nope")
+            MockMcpService.return_value = mock_mcp
+
+            result = runner.invoke(
+                app,
+                [
+                    "--json",
+                    "--config-dir",
+                    str(_config_dir(tmp_path)),
+                    "tool",
+                    "call",
+                    "get_buckets",
+                ],
+            )
+
+        assert result.exit_code == 5
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert "deprecation" not in payload
+        assert "deprecation" not in payload["error"]
+
+
+class TestToolListDeprecation:
+    """`tool list` enriches tools with cli_equivalent + generic banner."""
+
+    def test_json_tools_carry_cli_equivalent_and_envelope_deprecation(self, tmp_path: Path) -> None:
+        with patch("keboola_agent_cli.cli.McpService") as MockMcpService:
+            mock_mcp = MagicMock()
+            mock_mcp.list_tools.return_value = {"tools": SAMPLE_TOOLS, "errors": []}
+            MockMcpService.return_value = mock_mcp
+
+            result = runner.invoke(
+                app,
+                ["--json", "--config-dir", str(_config_dir(tmp_path)), "tool", "list"],
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "ok"
+        data = payload["data"]
+        tools = {t["name"]: t for t in data["tools"]}
+        assert tools["get_buckets"]["cli_equivalent"] == "storage buckets"
+        assert tools["totally_unknown_tool"]["cli_equivalent"] == ""
+        # pre-existing keys untouched
+        assert tools["get_buckets"]["multi_project"] is True
+        assert data["errors"] == []
+        assert "MCP passthrough is deprecated" in data["deprecation"]
+        assert "cli_equivalent" in data["deprecation"]
+
+    def test_human_mode_shows_column_and_banner(self, tmp_path: Path) -> None:
+        with patch("keboola_agent_cli.cli.McpService") as MockMcpService:
+            mock_mcp = MagicMock()
+            # single short tool keeps the Rich table narrow enough that no
+            # cell/header wraps at the default 80-column test console
+            mock_mcp.list_tools.return_value = {
+                "tools": [SAMPLE_TOOLS[0]],
+                "errors": [],
+            }
+            MockMcpService.return_value = mock_mcp
+
+            result = runner.invoke(
+                app,
+                ["--config-dir", str(_config_dir(tmp_path)), "tool", "list"],
+            )
+
+        assert result.exit_code == 0, result.output
+        stdout = _flat(result.stdout)
+        assert "CLI equivalent" in stdout
+        assert "storage buckets" in stdout
+        assert "MCP passthrough is deprecated" in stdout
+        assert "see the cli_equivalent column" in stdout
+
+
+class TestAgentMcpToolDeprecation:
+    """`agent create/update` with an mcp_tool action warns without blocking."""
+
+    def test_create_mcp_tool_human_warns_on_stderr(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "--config-dir",
+                str(tmp_path),
+                "agent",
+                "create",
+                "--name",
+                "T-mcp",
+                "--type",
+                "mcp_tool",
+                "--tool",
+                "get_buckets",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        stderr = _flat(result.stderr)
+        assert "Warning:" in stderr
+        assert "agent action type 'mcp_tool' is deprecated (epic #390)" in stderr
+        assert "--type cli_command" in stderr
+        # creation is NOT blocked
+        assert "Created" in result.stdout
+
+    def test_create_mcp_tool_json_gains_deprecation_key(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--config-dir",
+                str(tmp_path),
+                "agent",
+                "create",
+                "--name",
+                "T-mcp",
+                "--type",
+                "mcp_tool",
+                "--tool",
+                "get_buckets",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "ok"
+        task = payload["data"]
+        assert task["action"]["type"] == "mcp_tool"
+        assert "mcp_tool' is deprecated" in task["deprecation"]
+        assert "deprecated" not in result.stderr
+
+        # agents.json schema is unchanged: re-reading the task shows no
+        # deprecation field was persisted
+        shown = runner.invoke(
+            app,
+            ["--json", "--config-dir", str(tmp_path), "agent", "show", task["id"]],
+        )
+        assert shown.exit_code == 0, shown.output
+        assert "deprecation" not in json.loads(shown.stdout)["data"]
+
+    def test_create_cli_command_has_no_warning(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "--json",
+                "--config-dir",
+                str(tmp_path),
+                "agent",
+                "create",
+                "--name",
+                "T-cli",
+                "--type",
+                "cli_command",
+                "--argv",
+                "version",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)
+        assert "deprecation" not in payload["data"]
+        assert "deprecated" not in result.stderr
+
+        human = runner.invoke(
+            app,
+            [
+                "--config-dir",
+                str(tmp_path),
+                "agent",
+                "create",
+                "--name",
+                "T-cli-2",
+                "--type",
+                "cli_command",
+                "--argv",
+                "version",
+            ],
+        )
+        assert human.exit_code == 0, human.output
+        assert "deprecated" not in human.stderr
+
+    def test_update_mcp_tool_task_warns(self, tmp_path: Path) -> None:
+        created = runner.invoke(
+            app,
+            [
+                "--json",
+                "--config-dir",
+                str(tmp_path),
+                "agent",
+                "create",
+                "--name",
+                "T-upd",
+                "--type",
+                "mcp_tool",
+                "--tool",
+                "get_buckets",
+            ],
+        )
+        task_id = json.loads(created.stdout)["data"]["id"]
+
+        updated = runner.invoke(
+            app,
+            [
+                "--json",
+                "--config-dir",
+                str(tmp_path),
+                "agent",
+                "update",
+                task_id,
+                "--name",
+                "T-upd-renamed",
+            ],
+        )
+        assert updated.exit_code == 0, updated.output
+        payload = json.loads(updated.stdout)
+        assert "mcp_tool' is deprecated" in payload["data"]["deprecation"]
+
+        human = runner.invoke(
+            app,
+            [
+                "--config-dir",
+                str(tmp_path),
+                "agent",
+                "update",
+                task_id,
+                "--name",
+                "T-upd-again",
+            ],
+        )
+        assert human.exit_code == 0, human.output
+        assert "mcp_tool' is deprecated" in _flat(human.stderr)
+
+    def test_update_cli_command_task_has_no_warning(self, tmp_path: Path) -> None:
+        created = runner.invoke(
+            app,
+            [
+                "--json",
+                "--config-dir",
+                str(tmp_path),
+                "agent",
+                "create",
+                "--name",
+                "T-plain",
+                "--type",
+                "cli_command",
+                "--argv",
+                "version",
+            ],
+        )
+        task_id = json.loads(created.stdout)["data"]["id"]
+
+        updated = runner.invoke(
+            app,
+            [
+                "--json",
+                "--config-dir",
+                str(tmp_path),
+                "agent",
+                "update",
+                task_id,
+                "--name",
+                "T-plain-renamed",
+            ],
+        )
+        assert updated.exit_code == 0, updated.output
+        assert "deprecation" not in json.loads(updated.stdout)["data"]

--- a/tests/test_mcp_parity_map.py
+++ b/tests/test_mcp_parity_map.py
@@ -1,0 +1,57 @@
+"""Offline invariants for the MCP tool -> CLI parity map (epic #390 phase 2)."""
+
+from keboola_agent_cli.mcp_parity import (
+    MCP_TOOL_PARITY,
+    deprecation_message,
+    native_equivalent,
+    parity_operation_key,
+)
+from keboola_agent_cli.permissions import OPERATION_REGISTRY
+
+
+class TestParityMapInvariants:
+    def test_every_entry_resolves_to_a_registered_operation(self) -> None:
+        """The canonical command of every entry must be a real CLI operation.
+
+        This is the anti-drift lock: renaming or removing a native command
+        without updating the parity map fails here, offline, in regular CI.
+        """
+        missing = {
+            tool: parity_operation_key(entry)
+            for tool, entry in MCP_TOOL_PARITY.items()
+            if parity_operation_key(entry) not in OPERATION_REGISTRY
+        }
+        assert not missing, f"parity entries pointing at unknown operations: {missing}"
+
+    def test_known_catalog_tools_are_mapped(self) -> None:
+        """Spot-check the six freshly ported tools plus the two intentional
+        non-ports -- the canary (scripts/check_mcp_parity.py) covers the full
+        live catalog online."""
+        for tool in (
+            "docs_query",
+            "get_config_examples",
+            "get_semantic_schema",
+            "run_sync_action",
+            "create_sql_transformation",
+            "update_sql_transformation",
+            "get_flow_examples",
+            "query_data",
+            "validate_semantic_query",
+        ):
+            assert native_equivalent(tool) is not None, tool
+
+    def test_unmapped_tool_message_points_at_the_epic(self) -> None:
+        msg = deprecation_message("frobnicate_project")
+        assert "no native equivalent" in msg
+        assert "issues/390" in msg
+
+    def test_mapped_tool_message_names_the_command(self) -> None:
+        msg = deprecation_message("run_job")
+        assert "kbagent job run" in msg
+        assert "deprecated" in msg
+
+    def test_notes_do_not_leak_into_operation_keys(self) -> None:
+        for tool, entry in MCP_TOOL_PARITY.items():
+            key = parity_operation_key(entry)
+            assert " " not in key, (tool, key)
+            assert "`" not in key, (tool, key)

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "keboola-cli"
-version = "0.73.0"
+version = "0.74.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary

Phase 2 of the [#478 plan](https://github.com/keboola/cli/issues/478#issuecomment-5027449054) — the MCP passthrough deprecation track (0.74.0). **Stacked on #508** (phase 0+1); merge that first, this PR's base then retargets to `main`.

Nothing breaks: `tool call` / `tool list` / `agent --type mcp_tool` keep working through the deprecation window — they just tell you exactly what to use instead.

### Parity map as code
`src/keboola_agent_cli/mcp_parity.py` — one entry per upstream tool (39/39 live catalog coverage, verified), including notes for the two intentional non-ports (`query_data` → `workspace query`, `validate_semantic_query` → `semantic-layer validate`). Offline tests pin every entry to a registered CLI operation, so renaming a native command without updating the map fails regular CI.

### Deprecation warnings (additive-only envelopes)
- `tool call NAME`: per-tool message naming the exact replacement — stderr in human mode, additive `deprecation` key inside the `data` payload in `--json` (error envelopes untouched, test-pinned).
- `tool list`: `cli_equivalent` column (human) / field (JSON) + a banner; unmapped tools get `""`.
- `agent create/update/test --type mcp_tool`: warning pointing at `--type cli_command`; persisted `agents.json` and REST payloads byte-identical (test proves `agent show` carries no new key).
- Serve: `/mcp/tools*` routes marked `deprecated: true` in OpenAPI (`/mcp/server-status` stays — embedded-server health, used by doctor/UI).

### CI canary
`.github/workflows/mcp-parity-canary.yml` (weekly cron + manual) runs `scripts/check_mcp_parity.py` — stdlib-only (loads the map straight from the module file, no package import → bare `python3`, no dependency install), diffs the live keboola-mcp-server `TOOLS.md` against the map: new upstream tool → red run; removed upstream tool → warning. Local: `make parity-check`. Deliberately NOT in the PR-blocking test job (network).

### Docs flipped CLI-first
Deprecation banner atop `mcp-workflow.md`; `gotchas.md` `(since v0.74.0)` section; CLAUDE.md, `AGENT_CONTEXT`, `commands-reference.md`, `keboola-expert.md` updated.

## Verification

- `make check` green: 4613 passed (16 new tests: 5 parity-map invariants + 11 warning/envelope tests).
- Canary live run: `catalog: 39 tools, parity map: 39 entries — OK`.
- Live smoke on a real project: `tool call get_buckets` returns data + the `storage buckets` hint in both modes (stderr / JSON key); `tool list` maps `get_buckets→storage buckets`, `run_job→job run`, `docs_query→docs query`, `create_sql_transformation→transformation create`.

Remaining phase 3 (tracked in #390/#478): passthrough removal + `agents.json` mcp_tool migration story, after a deprecation window.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

> **CI note:** the `CI` workflow triggers only on PRs targeting `main` — it will run automatically once #508 merges and this PR's base retargets. Until then the local equivalent (`make check`, the CI mirror) is green: 4613 passed. Devin Review ran and passed with zero findings.
