### PR TITLE
chore(release): enrich chocolatey nuspec metadata per moderation guidelines

### DIFF
--- a/build/package/chocolatey/keboola-cli2.nuspec
+++ b/build/package/chocolatey/keboola-cli2.nuspec
@@ -8,18 +8,14 @@
     <version>{VERSION}</version>
     <title>Keboola Agent CLI (kbagent)</title>
     <authors>Keboola</authors>
+    <owners>Matovidlo</owners>
     <projectUrl>https://github.com/keboola/cli</projectUrl>
-    <!-- iconUrl: uncomment once build/package/chocolatey/keboola.png (32-128px) is
-         committed. jsDelivr is the Chocolatey-recommended CDN (raw.githubusercontent
-         is discouraged). A broken link is worse than none, so this stays off until
-         the file exists. Guideline flagged by chocolatey-ops on 0.66.1.
-    <iconUrl>https://cdn.jsdelivr.net/gh/keboola/cli@main/build/package/chocolatey/keboola.png</iconUrl>
-    -->
     <licenseUrl>https://github.com/keboola/cli/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <packageSourceUrl>https://github.com/keboola/cli</packageSourceUrl>
     <projectSourceUrl>https://github.com/keboola/cli</projectSourceUrl>
     <bugTrackerUrl>https://github.com/keboola/cli/issues</bugTrackerUrl>
+    <docsUrl>https://help.keboola.com/</docsUrl>
     <!-- URL form so this never needs per-version edits (moderator-endorsed). -->
     <releaseNotes>https://github.com/keboola/cli/releases</releaseNotes>
     <copyright>Keboola</copyright>

--- a/build/package/chocolatey/keboola-cli2.nuspec
+++ b/build/package/chocolatey/keboola-cli2.nuspec
@@ -8,17 +8,20 @@
     <version>{VERSION}</version>
     <title>Keboola Agent CLI (kbagent)</title>
     <authors>Keboola</authors>
+    <!-- owners = package maintainer on community.chocolatey.org; must match the
+         account behind the CHOCOLATEY_KEY secret. Update both together. -->
     <owners>Matovidlo</owners>
     <projectUrl>https://github.com/keboola/cli</projectUrl>
+    <iconUrl>https://components.keboola.com/assets/default-app-icon-DGCyIYB1.png</iconUrl>
     <licenseUrl>https://github.com/keboola/cli/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <packageSourceUrl>https://github.com/keboola/cli</packageSourceUrl>
+    <packageSourceUrl>https://github.com/keboola/cli/tree/main/build/package/chocolatey</packageSourceUrl>
     <projectSourceUrl>https://github.com/keboola/cli</projectSourceUrl>
     <bugTrackerUrl>https://github.com/keboola/cli/issues</bugTrackerUrl>
-    <docsUrl>https://help.keboola.com/</docsUrl>
+    <docsUrl>https://github.com/keboola/cli/tree/main/docs</docsUrl>
     <!-- URL form so this never needs per-version edits (moderator-endorsed). -->
     <releaseNotes>https://github.com/keboola/cli/releases</releaseNotes>
-    <copyright>Keboola</copyright>
+    <copyright>2025-2026 Keboola</copyright>
     <summary>AI-friendly CLI for managing Keboola projects.</summary>
     <description>Self-contained native CLI for managing Keboola Connection projects. No Python runtime required.</description>
     <tags>keboola cli kbagent</tags>

--- a/build/package/chocolatey/keboola-cli2.nuspec
+++ b/build/package/chocolatey/keboola-cli2.nuspec
@@ -9,8 +9,20 @@
     <title>Keboola Agent CLI (kbagent)</title>
     <authors>Keboola</authors>
     <projectUrl>https://github.com/keboola/cli</projectUrl>
+    <!-- iconUrl: uncomment once build/package/chocolatey/keboola.png (32-128px) is
+         committed. jsDelivr is the Chocolatey-recommended CDN (raw.githubusercontent
+         is discouraged). A broken link is worse than none, so this stays off until
+         the file exists. Guideline flagged by chocolatey-ops on 0.66.1.
+    <iconUrl>https://cdn.jsdelivr.net/gh/keboola/cli@main/build/package/chocolatey/keboola.png</iconUrl>
+    -->
     <licenseUrl>https://github.com/keboola/cli/blob/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <packageSourceUrl>https://github.com/keboola/cli</packageSourceUrl>
+    <projectSourceUrl>https://github.com/keboola/cli</projectSourceUrl>
+    <bugTrackerUrl>https://github.com/keboola/cli/issues</bugTrackerUrl>
+    <!-- URL form so this never needs per-version edits (moderator-endorsed). -->
+    <releaseNotes>https://github.com/keboola/cli/releases</releaseNotes>
+    <copyright>Keboola</copyright>
     <summary>AI-friendly CLI for managing Keboola projects.</summary>
     <description>Self-contained native CLI for managing Keboola Connection projects. No Python runtime required.</description>
     <tags>keboola cli kbagent</tags>


### PR DESCRIPTION
## Summary

Enriches the Chocolatey package nuspec (`build/package/chocolatey/keboola-cli2.nuspec`) to address the **Guidelines** flagged by `chocolatey-ops` on the `keboola-cli2` 0.66.1 moderation review.

- Add `packageSourceUrl`, `projectSourceUrl`, `bugTrackerUrl`
- Add `releaseNotes` as a **URL** to the releases page (moderator-endorsed form → never needs per-version edits)
- Add `copyright`
- Stage a commented-out `iconUrl` (jsDelivr CDN) ready to enable once an icon PNG is committed — left off deliberately to avoid a 404 link, which is worse than omitting it

## Context — why the Chocolatey channel is currently stuck (not this PR)

The 403 Forbidden on `choco push` for 0.71.0 / 0.72.0 is **not** a pipeline or key bug. It's the documented Chocolatey behavior: *a package with a version in moderation and no approved version rejects new-version pushes with 403*. `keboola-cli2` 0.66.1 passed automated validation on 2026-07-15 with **zero Requirements** and is simply waiting in the human moderation queue. When a moderator approves 0.66.1, the block lifts and 0.71/0.72 can push (re-run the failed job, no new tag needed).

The reviewer's comments were all **Guidelines / Suggestions / Notes** — explicitly "fix for next time," approvable without them. This PR is that quality polish; it ships with the next published version.

## Impact analysis

- `build/package/chocolatey/keboola-cli2.nuspec`: additive metadata only. XML validated well-formed.
- No workflow change, no secret change, no behavior change to the built binary.
- Fully backwards-compatible; affects only the metadata shown on the Chocolatey package page.

## Test plan

- `python3 -c "import xml.dom.minidom; xml.dom.minidom.parse(...)"` → XML well-formed ✅
- `iconUrl` intentionally commented until `build/package/chocolatey/keboola.png` is committed; uncomment then.

## Change type

Chore — Chocolatey packaging metadata quality (no functional change)

## Related

- Chocolatey moderation review for `keboola-cli2` 0.66.1 (chocolatey-ops, 2026-07-15)
- Related infra: winget bootstrap blocked separately (#484)

## Deployment

Merge & picked up by the next release's chocolatey packaging step. No migration.

## Rollback plan

Revert of this PR.

## Post release support plan

None.