### PR TITLE
docs(semantic-layer): document schema command in its workflow guide

### DIFF
--- a/plugins/kbagent/skills/kbagent/references/semantic-layer-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/semantic-layer-workflow.md
@@ -47,6 +47,12 @@ kbagent --json semantic-layer show --project prod --model core_model
 kbagent --json semantic-layer show --project prod --model core_model --type metric
 kbagent --json semantic-layer show --project prod --model core_model --type constraint
 
+# 3b. Fetch the JSON Schema of a type before building/validating one (0.73.0+).
+#     Server-fetched, so it always matches the deployed metastore version.
+kbagent --json semantic-layer schema --project prod --type metric,dataset
+kbagent --json semantic-layer schema --project prod --all
+# -> {"project": "prod", "schemas": [{"type": "metric", "schema": {...}}, ...]}
+
 # 4. Validate (no Snowflake probe -- fast)
 kbagent --json semantic-layer validate --project prod --model core_model
 


### PR DESCRIPTION
Closes the last silent-drift gap from the v0.73.0 MCP-parity release: `semantic-layer schema` (#394) was in commands-reference.md / AGENT_CONTEXT / CLAUDE.md / keboola-expert.md but missing from its dedicated `semantic-layer-workflow.md`. Added to Workflow 1 (inspect) next to `show`/`validate`. Docs-only.

Found during a post-release audit of all plugin surfaces (convention #17). Every other 0.73.0/0.74.0 change was already fully propagated.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/515" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->