### PR TITLE
fix(docs): pin command-reference metavar format as a stable contract (#513)

### DIFF
--- a/scripts/gen_command_reference.py
+++ b/scripts/gen_command_reference.py
@@ -16,7 +16,10 @@ the public documented surface.
 Metavar column contract (STABLE -- do not let it drift under a dependency bump):
     Value-taking options render as ``| `--flag` `<type>` | required | help |``.
     The metavar span is ALWAYS wrapped in angle brackets (``<str>``, ``<int>``,
-    ``<path>``, ``<a|b|c>`` for choices); flags carry no metavar span at all.
+    ``<path>``, ``<a|b|c>`` for choices, ``<str,int>`` for composites/multi-value
+    ``nargs``); options that consume NO value -- boolean flags AND ``count=True``
+    counters -- carry no metavar span at all. An unrecognised or nameless custom
+    type degrades to a neutral ``<value>`` rather than mislabelling itself.
     This is derived from Click's version-stable ``ParamType.name`` (see
     ``_stable_option_metavar``), NOT from ``make_metavar()``, whose default
     drifted between releases (bare ``TEXT`` at Click 8.x vs ``<str>`` later).
@@ -33,6 +36,8 @@ Usage (run from repo root):
 from __future__ import annotations
 
 import argparse
+import enum
+import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -84,24 +89,87 @@ _METAVAR_BY_TYPE_NAME: dict[str, str] = {
 }
 
 
+# Anything outside this set is not part of the documented token alphabet; it is
+# folded to "-" so a stray ``ParamType.name`` can never emit a malformed span
+# (e.g. a composite's literal name ``"<text integer>"`` becoming ``<<text-integer>>``).
+_TOKEN_DISALLOWED = re.compile(r"[^A-Za-z0-9|,_-]+")
+
+
+def _sanitize_token(raw: str) -> str:
+    """Fold an arbitrary type/metavar string into the documented token alphabet."""
+    cleaned = _TOKEN_DISALLOWED.sub("-", raw.strip("<>[]. ")).strip("-")
+    return cleaned or "value"
+
+
+def _choice_token(choice: object) -> str:
+    """The literal CLI token for one ``click.Choice`` member.
+
+    ``click.Choice`` accepts an ``Enum`` class, in which case Click parses the
+    member NAME off the command line while ``str(member)`` is ``Color.RED``.
+    Render ``.name`` so the documented token is the one a user actually types.
+    Click's own ``normalize_choice()`` is deliberately NOT used: for a
+    ``case_sensitive=False`` choice it casefolds, which would silently rewrite
+    real tokens like ``readOnly`` in the published asset.
+    """
+    if isinstance(choice, enum.Enum):
+        return choice.name
+    return str(choice)
+
+
+def _composite_types(ptype: object) -> list[object]:
+    """Member types of a composite (``click.Tuple``), or [] for a scalar type."""
+    if not getattr(ptype, "is_composite", False):
+        return []
+    return list(getattr(ptype, "types", []) or [])
+
+
+def _stable_type_token(ptype: object) -> str:
+    """Click-version-independent token for one ParamType (no angle brackets)."""
+    composite = _composite_types(ptype)
+    if composite:
+        return ",".join(_stable_type_token(member) for member in composite)
+    choices = getattr(ptype, "choices", None)
+    if choices:
+        return "|".join(_sanitize_token(_choice_token(choice)) for choice in choices)
+    type_name = getattr(ptype, "name", None)
+    if not type_name:
+        # A custom ParamType that never set `name`. "value" is deliberately
+        # neutral -- guessing "str" would assert a type we do not know.
+        return "value"
+    return _METAVAR_BY_TYPE_NAME.get(type_name, _sanitize_token(type_name))
+
+
 def _stable_option_metavar(param: click.Parameter) -> str:
     """Angle-bracket-wrapped, Click-version-independent metavar for a value option.
 
     Choices keep their literal case (``<admin|guest|readOnly|share>``) -- they are
-    real CLI tokens. Scalars map through ``ParamType.name``; an author-set metavar
-    wins and is lowercased. Always returns a ``<...>`` span (never empty, never a
-    bare uppercase ``TEXT``), which is the shape the downstream docs gate matches.
+    real CLI tokens. Scalars map through ``ParamType.name``; composites and
+    multi-value ``nargs`` render comma-joined (``<str,int>``); an author-set
+    metavar wins and is lowercased. Always returns a ``<...>`` span (never empty,
+    never a bare uppercase ``TEXT``, never nested brackets), which is the shape
+    the downstream docs gate matches.
     """
     explicit = getattr(param, "metavar", None)
     if explicit:
-        return f"<{explicit.strip('<>[] ').lower()}>"
+        return f"<{_sanitize_token(explicit.lower())}>"
     ptype = param.type
-    choices = getattr(ptype, "choices", None)
-    if choices:
-        return f"<{'|'.join(str(choice) for choice in choices)}>"
-    type_name = getattr(ptype, "name", None) or "text"
-    inner = _METAVAR_BY_TYPE_NAME.get(type_name, type_name.replace(" ", "-"))
-    return f"<{inner}>"
+    token = _stable_type_token(ptype)
+    # Click sets nargs == len(types) for a composite, which the token already
+    # spells out -- only repeat for a scalar type consuming several values.
+    nargs = getattr(param, "nargs", 1)
+    if not _composite_types(ptype) and isinstance(nargs, int) and nargs > 1:
+        token = ",".join([token] * nargs)
+    return f"<{token}>"
+
+
+def _takes_a_value(param: click.Parameter) -> bool:
+    """Whether the option consumes a value token (so it earns a metavar span).
+
+    ``count=True`` counters are the trap: Click leaves ``is_flag`` False on them
+    while they take no value, so keying only on ``is_flag`` would publish
+    ``--verbose <int>`` and make the downstream gate demand an argument.
+    """
+    return not (getattr(param, "is_flag", False) or getattr(param, "count", False))
 
 
 def _format_param(param: click.Parameter, ctx: click.Context) -> str | None:
@@ -111,7 +179,7 @@ def _format_param(param: click.Parameter, ctx: click.Context) -> str | None:
         if getattr(param, "hidden", False) or "--help" in param.opts:
             return None
         names = " / ".join(f"`{opt}`" for opt in [*param.opts, *param.secondary_opts])
-        metavar = "" if getattr(param, "is_flag", False) else f" `{_stable_option_metavar(param)}`"
+        metavar = f" `{_stable_option_metavar(param)}`" if _takes_a_value(param) else ""
         required = "yes" if param.required else ""
         help_text = (getattr(param, "help", "") or "").replace("\n", " ").strip()
         return f"| {names}{metavar} | {required} | {help_text} |"

--- a/scripts/gen_command_reference.py
+++ b/scripts/gen_command_reference.py
@@ -13,6 +13,18 @@ Hidden commands and groups (e.g. the ``sl`` alias) are skipped together with
 their subtree, matching scripts/check_command_sync.py -- they are not part of
 the public documented surface.
 
+Metavar column contract (STABLE -- do not let it drift under a dependency bump):
+    Value-taking options render as ``| `--flag` `<type>` | required | help |``.
+    The metavar span is ALWAYS wrapped in angle brackets (``<str>``, ``<int>``,
+    ``<path>``, ``<a|b|c>`` for choices); flags carry no metavar span at all.
+    This is derived from Click's version-stable ``ParamType.name`` (see
+    ``_stable_option_metavar``), NOT from ``make_metavar()``, whose default
+    drifted between releases (bare ``TEXT`` at Click 8.x vs ``<str>`` later).
+    A downstream consumer -- the connection-docs freshness gate
+    (keboola/connection-docs#1037) -- detects value-taking options by matching
+    ``/^<.*>$/`` on this span, so the shape is a published contract. See issue
+    #513; ``tests/test_gen_command_reference.py`` fails CI if it drifts.
+
 Usage (run from repo root):
     python scripts/gen_command_reference.py                    # print to stdout
     python scripts/gen_command_reference.py --output PATH      # write to file
@@ -54,6 +66,44 @@ def _metavar(param: click.Parameter, ctx: click.Context) -> str:
         return param.make_metavar()  # ty: ignore[missing-argument]
 
 
+# Click's ``ParamType.name`` is a version-stable token; ``make_metavar()`` output
+# is not (see module docstring). Map the stable name to the documented metavar so
+# the reference-asset contract can't drift under a Typer/Click bump.
+_METAVAR_BY_TYPE_NAME: dict[str, str] = {
+    "text": "str",
+    "integer": "int",
+    "integer range": "int",
+    "float": "float",
+    "float range": "float",
+    "path": "path",
+    "filename": "path",
+    "file": "file",
+    "boolean": "bool",
+    "uuid": "uuid",
+    "datetime": "datetime",
+}
+
+
+def _stable_option_metavar(param: click.Parameter) -> str:
+    """Angle-bracket-wrapped, Click-version-independent metavar for a value option.
+
+    Choices keep their literal case (``<admin|guest|readOnly|share>``) -- they are
+    real CLI tokens. Scalars map through ``ParamType.name``; an author-set metavar
+    wins and is lowercased. Always returns a ``<...>`` span (never empty, never a
+    bare uppercase ``TEXT``), which is the shape the downstream docs gate matches.
+    """
+    explicit = getattr(param, "metavar", None)
+    if explicit:
+        return f"<{explicit.strip('<>[] ').lower()}>"
+    ptype = param.type
+    choices = getattr(ptype, "choices", None)
+    if choices:
+        return f"<{'|'.join(str(choice) for choice in choices)}>"
+    type_name = getattr(ptype, "name", None) or "text"
+    inner = _METAVAR_BY_TYPE_NAME.get(type_name, type_name.replace(" ", "-"))
+    return f"<{inner}>"
+
+
 def _format_param(param: click.Parameter, ctx: click.Context) -> str | None:
     """Render one parameter as a markdown table row, or None if hidden/help."""
     kind = getattr(param, "param_type_name", "")
@@ -61,7 +111,7 @@ def _format_param(param: click.Parameter, ctx: click.Context) -> str | None:
         if getattr(param, "hidden", False) or "--help" in param.opts:
             return None
         names = " / ".join(f"`{opt}`" for opt in [*param.opts, *param.secondary_opts])
-        metavar = "" if getattr(param, "is_flag", False) else f" `{_metavar(param, ctx)}`"
+        metavar = "" if getattr(param, "is_flag", False) else f" `{_stable_option_metavar(param)}`"
         required = "yes" if param.required else ""
         help_text = (getattr(param, "help", "") or "").replace("\n", " ").strip()
         return f"| {names}{metavar} | {required} | {help_text} |"

--- a/tests/test_gen_command_reference.py
+++ b/tests/test_gen_command_reference.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import enum
 import importlib.util
 import re
 import sys
@@ -136,3 +137,164 @@ class TestMetavarContract:
         """The documented scalar/choice forms are present in the generated asset."""
         for expected in ("`<str>`", "`<int>`", "`<path>`", "`<admin|guest|readOnly|share>`"):
             assert expected in reference, f"expected metavar {expected} missing from reference"
+
+
+class TestValuelessOptions:
+    """Options that consume no value must never grow a metavar span.
+
+    A ``count=True`` counter is the trap: Click leaves ``is_flag`` False on it,
+    so keying only on ``is_flag`` publishes ``--verbose <int>`` and makes the
+    downstream connection-docs gate demand a value the CLI does not accept.
+    """
+
+    def test_count_option_gets_no_metavar(self) -> None:
+        mod = _load_script()
+        option = click.Option(["--verbose", "-v"], count=True, help="Increase verbosity")
+        assert option.is_flag is False and option.count is True  # the trap, made explicit
+        row = mod._format_param(option, click.Context(click.Command("x")))
+        assert row == "| `--verbose` / `-v` |  | Increase verbosity |"
+        assert "<" not in row
+
+    def test_boolean_flag_gets_no_metavar(self) -> None:
+        mod = _load_script()
+        option = click.Option(["--json"], is_flag=True, help="JSON output")
+        row = mod._format_param(option, click.Context(click.Command("x")))
+        assert row == "| `--json` |  | JSON output |"
+
+    def test_value_option_still_gets_a_metavar(self) -> None:
+        """Guard the opposite mistake: the suppression must stay narrow."""
+        mod = _load_script()
+        option = click.Option(["--limit"], type=int, help="Max rows")
+        row = mod._format_param(option, click.Context(click.Command("x")))
+        assert row == "| `--limit` `<int>` |  | Max rows |"
+
+
+class TestCompositeAndUnknownTypes:
+    """Composite/custom types must degrade to a well-formed span, never a broken one."""
+
+    def test_tuple_type_renders_member_types(self) -> None:
+        """``click.Tuple``'s own name is ``<text integer>`` -- naive use nests brackets."""
+        mod = _load_script()
+        ptype = click.Tuple([click.STRING, click.INT])
+        assert ptype.name == "<text integer>"  # the shape that must not leak through
+        option = click.Option(["--pair"], type=ptype)
+        assert mod._stable_option_metavar(option) == "<str,int>"
+
+    def test_multi_value_nargs_repeats_the_token(self) -> None:
+        mod = _load_script()
+        option = click.Option(["--point"], type=int, nargs=2)
+        assert mod._stable_option_metavar(option) == "<int,int>"
+
+    def test_multiple_does_not_change_the_span(self) -> None:
+        """`multiple=True` repeats the OPTION, not its value -- span stays scalar."""
+        mod = _load_script()
+        option = click.Option(["--tag"], type=str, multiple=True)
+        assert mod._stable_option_metavar(option) == "<str>"
+
+    def test_nameless_custom_type_falls_back_to_value(self) -> None:
+        """A custom ParamType with no `name` must not be mislabelled as `<str>`."""
+        mod = _load_script()
+
+        class NamelessType(click.ParamType):
+            pass
+
+        assert getattr(NamelessType(), "name", None) is None
+        option = click.Option(["--x"], type=NamelessType())
+        assert mod._stable_option_metavar(option) == "<value>"
+
+    def test_unknown_named_type_is_sanitized(self) -> None:
+        """An unmapped type name keeps its identity but stays inside the alphabet."""
+        mod = _load_script()
+
+        class WeirdType(click.ParamType):
+            name = "my weird <type>"
+
+        option = click.Option(["--x"], type=WeirdType())
+        assert mod._stable_option_metavar(option) == "<my-weird-type>"
+
+
+class TestEnumBackedChoice:
+    """`click.Choice(SomeEnum)` parses member NAMES; `str(member)` is `Color.RED`."""
+
+    def test_enum_choice_renders_member_names(self) -> None:
+        mod = _load_script()
+
+        class Color(enum.Enum):
+            RED = "r"
+            BLUE = "b"
+
+        option = click.Option(["--color"], type=click.Choice(Color))
+        assert mod._stable_option_metavar(option) == "<RED|BLUE>"
+
+    def test_string_choice_case_is_never_normalized(self) -> None:
+        """Even a case-insensitive Choice keeps the literal tokens users type."""
+        mod = _load_script()
+        option = click.Option(
+            ["--role"], type=click.Choice(["admin", "readOnly"], case_sensitive=False)
+        )
+        assert mod._stable_option_metavar(option) == "<admin|readOnly>"
+
+
+# One option cell of a generated row: backticked option names, then an optional
+# `<...>` metavar span. This is the grammar the connection-docs gate parses.
+_OPTION_CELL = re.compile(
+    r"^(?P<names>`-{1,2}[^`]+`(?: / `-{1,2}[^`]+`)*)(?: `(?P<metavar><[^`]+>)`)?$"
+)
+_STABLE_SPAN = re.compile(r"^<[A-Za-z0-9][A-Za-z0-9|,_-]*>$")
+
+
+class TestLiveCommandTreeGrammar:
+    """Walk the REAL Typer tree: the synthetic cases above use plain `click`,
+    while the app renders Typer's vendored Click objects. This is the test that
+    actually catches vendored-Click drift.
+    """
+
+    def test_every_emitted_option_row_matches_the_grammar(self, reference: str) -> None:
+        rows = [line for line in reference.splitlines() if line.startswith("| `-")]
+        # Guard against a silently-empty scan passing this test.
+        assert len(rows) > 500, f"only {len(rows)} option rows scanned -- walker broken?"
+        malformed: list[str] = []
+        for row in rows:
+            cell = row.split(" | ", 1)[0].removeprefix("| ").strip()
+            match = _OPTION_CELL.match(cell)
+            if match is None:
+                malformed.append(row)
+                continue
+            span = match.group("metavar")
+            if span is not None and not _STABLE_SPAN.match(span):
+                malformed.append(row)
+        assert malformed == [], f"{len(malformed)} option rows off-contract: {malformed[:3]}"
+
+    def test_no_live_option_row_nests_angle_brackets(self, reference: str) -> None:
+        """`<<text-integer>>` (the naive composite rendering) must never appear."""
+        assert "<<" not in reference and ">>" not in reference
+
+    def test_live_tree_has_no_valueless_option_with_a_span(self, reference: str) -> None:
+        """Cross-check the rendered rows against the live params themselves."""
+        mod = _load_script()
+        import typer.main
+
+        from keboola_agent_cli.cli import app
+        from keboola_agent_cli.commands.repl import _is_group
+
+        click_app = typer.main.get_command(app)
+        # TypeGuard narrowing: Typer >=0.25 vendors Click, so the returned object
+        # is not an instance of the plain `click` classes (see the script header).
+        assert _is_group(click_app)
+        offenders: list[str] = []
+        with click.Context(click_app, info_name=mod.PROG) as root_ctx:
+            leaves = [
+                *(mod.LeafCommand(path=(), command=click_app, ctx=root_ctx),),
+                *mod._walk(click_app, root_ctx),
+            ]
+            for leaf in leaves:
+                for param in leaf.command.params:
+                    if getattr(param, "param_type_name", "") != "option":
+                        continue
+                    row = mod._format_param(param, leaf.ctx)
+                    if row is None:
+                        continue
+                    takes_value = mod._takes_a_value(param)
+                    if takes_value != ("`<" in row):
+                        offenders.append(f"{' '.join(leaf.path)}: {row}")
+        assert offenders == [], f"metavar presence disagrees with value-taking: {offenders[:3]}"

--- a/tests/test_gen_command_reference.py
+++ b/tests/test_gen_command_reference.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 from pathlib import Path
 
+import click
 import pytest
 
 
@@ -67,3 +69,70 @@ class TestGenCommandReference:
         from keboola_agent_cli import __version__
 
         assert f"Generated from kbagent v{__version__}" in reference
+
+
+# A value-taking option's metavar span: angle-bracketed, no whitespace inside.
+# Choice values (e.g. `readOnly`) keep their literal case, so uppercase is allowed;
+# the durable contract the connection-docs gate matches is only ``/^<.*>$/``.
+_METAVAR_SPAN = re.compile(r"^<[A-Za-z0-9|_-]+>$")
+
+
+class TestMetavarContract:
+    """Issue #513: the metavar column is a published contract; pin its shape.
+
+    These tests fail CI on a Typer/Click bump that changes ``make_metavar()``
+    (e.g. reverting `<str>` back to bare `TEXT`), so the drift is caught here
+    instead of silently breaking the downstream connection-docs freshness gate.
+    """
+
+    def test_scalar_types_map_to_documented_metavars(self) -> None:
+        """Each scalar Click type renders as its stable lowercase `<...>` span."""
+        stable = _load_script()._stable_option_metavar
+        cases = {
+            str: "<str>",
+            int: "<int>",
+            float: "<float>",
+            click.Path(): "<path>",
+            click.IntRange(0, 5): "<int>",
+        }
+        for click_type, expected in cases.items():
+            option = click.Option(["--x"], type=click_type)
+            assert stable(option) == expected
+
+    def test_choice_preserves_literal_case(self) -> None:
+        """Choice values are real CLI tokens -- their case must not be normalized."""
+        stable = _load_script()._stable_option_metavar
+        option = click.Option(["--role"], type=click.Choice(["admin", "readOnly", "share"]))
+        assert stable(option) == "<admin|readOnly|share>"
+
+    def test_explicit_metavar_is_wrapped_and_lowercased(self) -> None:
+        stable = _load_script()._stable_option_metavar
+        option = click.Option(["--alias"], metavar="ALIAS")
+        assert stable(option) == "<alias>"
+
+    def test_every_value_option_matches_the_span_contract(self) -> None:
+        """Every scalar/choice rendering satisfies the downstream `<...>` matcher."""
+        stable = _load_script()._stable_option_metavar
+        for click_type in (str, int, float, click.Path(), click.Choice(["a", "b_c", "D"])):
+            option = click.Option(["--x"], type=click_type)
+            assert _METAVAR_SPAN.match(stable(option))
+
+    def test_flags_carry_no_metavar_span(self, reference: str) -> None:
+        """A boolean flag row must not gain a `<...>` value span."""
+        section = reference.split("## Global options", 1)[1].split("\n## ", 1)[0]
+        json_row = next(line for line in section.splitlines() if "`--json`" in line)
+        assert "`<" not in json_row, f"flag row unexpectedly has a metavar: {json_row}"
+
+    def test_no_bare_uppercase_metavar_on_option_rows(self, reference: str) -> None:
+        """No option row may carry a bare `TEXT`/`INTEGER`/`PATH`/`FLOAT` metavar."""
+        offenders = [
+            line
+            for line in reference.splitlines()
+            if line.startswith("| `--") and re.search(r"`(TEXT|INTEGER|PATH|FLOAT|BOOLEAN)`", line)
+        ]
+        assert offenders == [], f"bare uppercase metavars leaked (Click drift?): {offenders[:3]}"
+
+    def test_scalar_and_choice_metavars_documented(self, reference: str) -> None:
+        """The documented scalar/choice forms are present in the generated asset."""
+        for expected in ("`<str>`", "`<int>`", "`<path>`", "`<admin|guest|readOnly|share>`"):
+            assert expected in reference, f"expected metavar {expected} missing from reference"


### PR DESCRIPTION
## What

The release-asset command reference (`scripts/gen_command_reference.py`, consumed by help.keboola.com and the connection-docs freshness gate) rendered its option **metavar** column via Click's `make_metavar()`. That default is not stable across Click versions — it already drifted once: bare `` `TEXT` `` / `` `INTEGER` `` at v0.70.1 (Click 8.x), `` `<str>` `` / `` `<int>` `` at v0.72.0.

This PR pins the option metavar shape to a documented convention independent of the installed Click:

- **Derive from `ParamType.name`** (a version-stable token: `text`/`integer`/`float`/`path`/`choice`) instead of `make_metavar()`, via a new `_stable_option_metavar()`.
- Value-taking options always render as a `<...>` span — `<str>`, `<int>`, `<float>`, `<path>`, and `<a|b|c>` for choices (literal case preserved, e.g. `<admin|guest|readOnly|share>`, since choice values are real CLI tokens). Flags carry no metavar span.
- Author-set metavars are wrapped and lowercased (`ALIAS` → `<alias>`).
- The column contract is documented in the module header.
- Positional arguments are unchanged — they render as `` `NAME` (positional) `` and are not part of the `` | `--flag` `<type>` | `` shape the downstream gate parses.

## Why

The connection-docs freshness gate (keboola/connection-docs#1037, PRDCT-556) detects whether an option takes a value by matching `/^<.*>$/` on the metavar span. That works today only because 0.72.0 happens to emit the `<…>` form. A future Typer/Click bump reverting to bare `TEXT` would silently make the checker misparse value-taking options, turning valid commands into false-positive "unknown command" errors and reddening the docs build on correct content. Pinning the format at the source makes the published asset a contract by intent, not by accident of the dependency version.

## How it was tested

- New `TestMetavarContract` in `tests/test_gen_command_reference.py`: asserts scalar types map to the documented `<...>` forms, choices preserve literal case, explicit metavars are wrapped/lowercased, every value option satisfies the `<...>` span contract, flags carry no span, no bare uppercase `TEXT`/`INTEGER`/`PATH`/`FLOAT` leaks onto an option row, and the documented scalar/choice forms are present in the generated asset. A Click/Typer bump that changes `make_metavar()` now fails CI here instead of downstream.
- `make check` green (lint + format + changelog-check + typecheck + full suite: 4620 passed, 8 skipped).
- Verified the generated reference: all option metavars are `<...>`-wrapped; no bare uppercase metavars remain.

Note: no version bump / changelog entry — this only stabilizes the generated asset's shape (already `<str>` in the last release), it does not change the CLI surface. The immediate mitigation on the consumer side (accept `<str>` | `TEXT` | `[a|b]`) is still recommended in the linked issue; this is the durable source-side fix.

Fixes #513
