### PR TITLE
test(e2e): poll Files list after upload (read-after-write staleness)

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -2251,8 +2251,17 @@ class TestFullE2E:
 
             assert kbc.files.read_bytes(meta.id) == payload, "read_bytes round-trip mismatch"
 
-            listed = kbc.files.list(tags=[facade_tag])
-            assert any(f.id == meta.id for f in listed), "uploaded file must appear in list"
+            # The tag-filtered Files list is read-after-write eventually
+            # consistent: the upload is durable (read_bytes round-tripped it
+            # just above), but the tag index can lag a few seconds. Poll instead
+            # of asserting the first list (intermittently missed in CI 2026-07-22).
+            found = False
+            for _ in range(15):
+                if any(f.id == meta.id for f in kbc.files.list(tags=[facade_tag])):
+                    found = True
+                    break
+                time.sleep(2)
+            assert found, "uploaded file must appear in list"
 
             kbc.files.delete(meta.id)
             self._created_file_ids.remove(meta.id)
@@ -2672,16 +2681,23 @@ class TestFullE2E:
         self._created_file_ids.append(file_id)
         assert file_id > 0
 
-        # files (list)
-        data = self._run_ok(
-            "storage",
-            "files",
-            "--project",
-            self.alias,
-            "--tag",
-            f"e2e-{RUN_ID}",
-        )
-        file_ids = [f["id"] for f in data["data"]["files"]]
+        # files (list) -- the tag index is read-after-write eventually
+        # consistent; poll until the just-uploaded file appears rather than
+        # asserting the first list.
+        file_ids: list[int] = []
+        for _ in range(15):
+            data = self._run_ok(
+                "storage",
+                "files",
+                "--project",
+                self.alias,
+                "--tag",
+                f"e2e-{RUN_ID}",
+            )
+            file_ids = [f["id"] for f in data["data"]["files"]]
+            if file_id in file_ids:
+                break
+            time.sleep(2)
         assert file_id in file_ids
 
         # file-detail


### PR DESCRIPTION
Follow-up to #521. The nightly's last remaining failure was `TestFullE2E` intermittently failing on "uploaded file must appear in list" — the just-uploaded file was absent from an immediate tag-filtered Files list. The upload is durable (the facade path round-trips `read_bytes` right before the list), but the tag index is **read-after-write eventually consistent** and lags a few seconds, so it passed locally + in some CI runs and failed in others (also seen in pre-token-break June nightlies).

Poll the list until the file appears (bounded ~30s) instead of asserting the first read, in **both** spots that do upload→immediate-list: the SDK-facade round-trip (`kbc.files.list`) and the CLI file-ops flow (`storage files --tag`). Same pattern already used for the add-column/swap read-after-DDL lags in #521.

Test-only; `make check` green (4648 passed). After this, the manual nightly run 29915860766 had exactly this one failure remaining (my four #521 fixes were green: 114 passed / 1 failed).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->