### PR TITLE
chore(release): 0.76.0 -- client/ package split + E2E test hardening (internal)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.75.0",
+      "version": "0.76.0",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.75.0",
+  "version": "0.76.0",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-cli"
-version = "0.75.0"
+version = "0.76.0"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -24,6 +24,23 @@ from .constants import CHANGELOG_HEADLINE_MAX_CHARS
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.76.0": [
+        "Change (#520): the ~3,960-LOC `client.py` is split into a `client/` package by "
+        "endpoint family (storage tables/files, configs, queue, tokens, branches, stream, "
+        "query, workspaces, misc, plus `_core`/`_transfer`). `KeboolaClient` stays a single "
+        "class composed from per-family mixins, so the public import surface and the SDK "
+        "`Client.raw` contract are byte-identical -- verified as a pure move (every method "
+        "body unchanged) plus a full live E2E pass.",
+        "Note: this is an internal-only release -- no user-facing behavior changes. It bundles "
+        "the client refactor above with E2E test-suite hardening; every `client/*.py` module is "
+        "under the CONTRIBUTING.md file-size ceiling, and new HTTP methods now go into the "
+        "relevant `client/*.py` mixin instead of the old monolith.",
+        "Fix (tests, #521 #523): repaired the long-standing nightly E2E flakes -- clone "
+        "(missing bucket create on the default branch), config-secret (response-envelope path), "
+        "swap + file-list (read-after-write / read-after-DDL eventual consistency, now polled), "
+        "and stream (unique per-run source name to dodge a wedged orphan). The nightly E2E is "
+        "green again after ~7 weeks.",
+    ],
     "0.75.0": [
         "New (#512): table snapshots -- `kbagent storage table-from-snapshot` creates a NEW "
         "table from an existing snapshot (restore), plus the full lifecycle: "

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "keboola-cli"
-version = "0.75.0"
+version = "0.76.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Internal-only maintenance release. No user-facing behavior changes.

Bundles everything landed since 0.75.0:
- **#520 / #524** — `client.py` (~3,960 LOC) split into a `client/` package by endpoint family (mixin composition; `KeboolaClient` stays one class, public surface + SDK `.raw` byte-identical; verified pure move + full live E2E pass).
- **#521 / #523** — nightly E2E flake fixes; the nightly is green again after ~7 weeks.

Release mechanics: version bumped in `pyproject.toml`, changelog entry added, `make version-sync` propagated to plugin.json / marketplace.json / uv.lock. `make check` green (4648 passed). No command changes, so no plugin-doc/command-reference updates needed. After merge I'll tag `v0.76.0` to trigger the release pipeline.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->