### PR TITLE
chore(release): 0.76.1 — serve banner ASCII fallback on non-UTF-8 Windows consoles (#522)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.76.0",
+      "version": "0.76.1",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.76.0",
+  "version": "0.76.1",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-cli"
-version = "0.76.0"
+version = "0.76.1"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -24,6 +24,17 @@ from .constants import CHANGELOG_HEADLINE_MAX_CHARS
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.76.1": [
+        "Fix (#522, #526): `kbagent serve --ui` no longer crashes on startup on Windows "
+        "consoles with a non-UTF-8 codepage (cp1250 on Czech/Polish/Hungarian Windows). The "
+        "startup banner's box-drawing glyphs (`├─` / `└─`) raised `UnicodeEncodeError` from "
+        "`sys.stdout.write` before uvicorn bound the port, so the server never started. They "
+        "now degrade to ASCII (`|-` / `` `- ``) when the console can't encode them -- the same "
+        "UTF-8/ASCII fallback `install.sh` already uses -- with a belt-and-braces `try/except` "
+        "so a cosmetic banner can never abort startup. Modern UTF-8 terminals are unchanged. "
+        "The `set PYTHONUTF8=1` workaround is no longer needed. Thanks to @papousek-radan for "
+        "the detailed report.",
+    ],
     "0.76.0": [
         "Change (#520): the ~3,960-LOC `client.py` is split into a `client/` package by "
         "endpoint family (storage tables/files, configs, queue, tokens, branches, stream, "

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "keboola-cli"
-version = "0.76.0"
+version = "0.76.1"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Release 0.76.1

Patch release shipping the already-merged [#526](https://github.com/keboola/cli/pull/526)
fix (closes #522).

### What's in it

**Fix (#522, #526):** `kbagent serve --ui` no longer crashes on startup on
Windows consoles with a non-UTF-8 codepage (cp1250 on Czech/Polish/Hungarian
Windows). The startup banner's box-drawing glyphs (`├─` / `└─`) raised
`UnicodeEncodeError` from `sys.stdout.write` before uvicorn bound the port, so
the server never started. They now degrade to ASCII (`|-` / `` `- ``) when the
console can't encode them — the same UTF-8/ASCII fallback `install.sh` already
uses — with a belt-and-braces `try/except` so a cosmetic banner can never abort
startup. Modern UTF-8 terminals are unchanged; the `set PYTHONUTF8=1` workaround
is no longer needed.

### Release mechanics

- `pyproject.toml` 0.76.0 → 0.76.1 (single source of truth)
- Changelog entry added for 0.76.1
- `make version-sync` → `plugin.json`, `marketplace.json`, `uv.lock`

No command signatures changed, so the hand-maintained agent/skill docs
(`keboola-expert.md`, `gotchas.md`, `CLAUDE.md` command list,
`commands-reference.md`) need no edits; `make skill-gen` was a no-op.

`make check` is green (lint, format, typecheck, skill-check, version-check,
command-sync, changelog-check, error-codes, full test suite).

Tag `v0.76.1` will be pushed after merge to trigger the `release-kbagent`
pipeline (wheel build + GitHub release).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/527" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->