### PR TITLE
fix(update): make self-update safe on Windows

### DIFF
--- a/docs/superpowers/specs/2026-07-23-issue-528-safe-self-update-design.md
+++ b/docs/superpowers/specs/2026-07-23-issue-528-safe-self-update-design.md
@@ -1,0 +1,213 @@
+# Design: Make kbagent self-update safe on Windows
+
+**Issue:** [#528](https://github.com/keboola/cli/issues/528)  
+**Status:** Proposed  
+**Target:** `kbagent update` and startup auto-update
+
+## Problem
+
+Both self-update entry points currently mutate the `uv tool` environment from
+which the running `kbagent` process was launched:
+
+- startup auto-update calls `_perform_update()`, then continues in the old
+  process long enough to write the cache and re-exec;
+- explicit `kbagent update` updates kbagent first and then performs MCP
+  detection, a PyPI request, and an MCP update from the already-mutated
+  process.
+
+On Windows, a running executable or dependency can be locked. Even without a
+lock, a failed in-place dependency swap can leave the tool environment with a
+mixture of old and new distributions. The reporter observed both failure
+classes:
+
+1. mismatched `rich` and `typer` after a failed startup update;
+2. a missing `certifi/cacert.pem` after explicit update removed the old
+   distribution and the same process subsequently attempted the MCP HTTPS
+   check.
+
+The updater must treat mutation of its own environment as a terminal action,
+and it must use `uv tool install` as a full reinstall/re-resolution rather than
+an incremental upgrade.
+
+## Goals
+
+- Never perform network access, dependency discovery, cache writes, or MCP
+  work after the kbagent environment starts changing.
+- Reinstall the complete kbagent tool environment from an exact release
+  artifact when `uv` manages the install.
+- Preserve `[server]` extras and the beta channel.
+- Keep kbagent and MCP results independently visible in human and JSON output.
+- Fail without claiming success, and provide a copy/paste recovery command.
+- Keep startup auto-update best-effort: update failure must not intentionally
+  abort the requested command.
+
+## Non-goals
+
+- Reimplement `uv`'s package resolver or tool-environment transaction logic.
+- Update a tool while another long-running kbagent process is using the same
+  Windows environment. A locked executable remains a reported, recoverable
+  failure.
+- Change MCP installation ownership or merge the MCP environment into
+  kbagent's environment.
+- Add a persistent background update daemon.
+
+## Design
+
+### 1. Separate planning from mutation
+
+Introduce small immutable plan/result dataclasses in
+`services/version_service.py`. The planning phase performs every operation that
+can touch the network or inspect the current environment:
+
+- fetch the latest kbagent version;
+- resolve the exact release wheel URL, or an exact `@v<version>` git fallback;
+- detect `[server]` extras and build the complete install command;
+- detect the MCP install method and local version;
+- fetch the latest MCP version;
+- calculate which stages actually need work.
+
+The apply phase receives only these prepared values. It must not call
+`httpx`, `importlib`, package metadata probes, or command builders again.
+
+### 2. Apply MCP before kbagent
+
+For explicit `kbagent update`, execute the independent MCP stage first.
+Re-probing the MCP version is allowed immediately after that stage because the
+kbagent environment is still untouched.
+
+The kbagent reinstall is always the final mutation. Its result is assembled
+from the prepared plan and subprocess return value; no post-install version
+probe or network request is made.
+
+This removes the exact ordering bug behind the missing certifi CA bundle.
+
+### 3. Recreate the uv tool environment
+
+For every uv-managed kbagent path, build:
+
+```text
+uv tool install --force --reinstall "<keboola-cli spec pinned to the target release>"
+```
+
+The preferred spec is the versioned release wheel. The fallback source must
+also be pinned to `@v<target_version>` for stable and beta releases; updating
+from mutable `main` is not sufficiently reproducible for a recovery operation.
+When server extras are present, encode them in the primary PEP 508 requirement
+(`keboola-cli[server] @ ...`) so one resolution recreates the complete
+environment.
+
+`uv tool install` is the supported operation for recreating a tool environment;
+`--reinstall` ensures every package is materialized again and `--force` allows
+uv-owned entry points to be replaced. Pip remains a best-effort fallback, but
+its result and recovery limitation must be explicit.
+
+### 4. Make startup mutation terminal
+
+Reorder startup auto-update:
+
+1. perform all fresh kbagent and MCP lookups;
+2. update MCP, if needed;
+3. persist the complete cache;
+4. reinstall kbagent;
+5. on success, immediately re-exec with `KBAGENT_SKIP_UPDATE=1`.
+
+There must be no cache write or MCP stage between steps 4 and 5. The
+already-prepared cache lets the re-exec'd process skip all network work for
+that cycle.
+
+If the kbagent install subprocess fails or times out, emit a concise failure
+and the exact forced-reinstall recovery command. Do not report a successful
+update and do not run further update work from the potentially inconsistent
+process.
+
+### 5. Preserve the command contract
+
+`kbagent update` keeps the current top-level result shape. Add enough fields to
+make partial outcomes unambiguous:
+
+- each stage reports `planned`, `updated`, `up_to_date`, and `message`;
+- kbagent failure includes `recovery_command`;
+- the top-level `updated` remains true when at least one stage changed;
+- the summary reports an MCP success even if the final kbagent stage fails.
+
+The existing `--beta` behavior, `[server]` preservation, timeouts, and
+human/JSON rendering remain supported.
+
+## Implementation map
+
+- `src/keboola_agent_cli/services/version_service.py`
+  - add update-plan dataclasses and prepare/apply helpers;
+  - make exact-version `uv tool install --force --reinstall` the self-update
+    command;
+  - reorder explicit update to MCP first, kbagent last;
+  - avoid post-kbagent probes.
+- `src/keboola_agent_cli/auto_update.py`
+  - prepare both stages before mutation;
+  - move MCP update and cache persistence before `_perform_update`;
+  - re-exec immediately after a successful kbagent install;
+  - expose the forced-reinstall command on failure.
+- `src/keboola_agent_cli/commands/version.py`
+  - update command documentation and render partial/failure outcomes without
+    accessing package metadata after the self-update stage.
+- `src/keboola_agent_cli/changelog.py`
+  - add the user-facing fix and recovery behavior to the next release entry.
+- `tests/test_version_service.py`
+  - pin planning/apply order and assert no network/probe calls after kbagent
+    mutation;
+  - cover MCP success plus kbagent failure;
+  - cover stable, beta, server-extra, wheel, and git-fallback command shapes.
+- `tests/test_auto_update.py`
+  - assert MCP and cache work precede kbagent mutation;
+  - assert successful install is followed directly by re-exec;
+  - assert failure performs no later update work and prints recovery guidance.
+
+## Acceptance criteria
+
+1. Explicit update fetches both latest-version values before running either
+   updater.
+2. Explicit update applies MCP first and kbagent last.
+3. No HTTP call, import/package probe, MCP update, or cache write occurs after
+   the kbagent install command begins.
+4. All uv kbagent installs use an exact target plus `tool install --force
+   --reinstall`.
+5. `[server]` and beta installs retain their current behavior.
+6. Startup auto-update writes the prepared cache before self-mutation and
+   immediately re-execs after success.
+7. A failed kbagent stage is never described as up to date or successful and
+   includes an exact recovery command.
+8. Unit tests reproduce the incident-2 ordering failure by making any
+   post-mutation HTTP call fail; the fixed flow performs no such call.
+9. The focused update suites and the repository's lint, format, and type checks
+   pass.
+
+## Validation
+
+Run locally:
+
+```text
+uv run pytest tests/test_version_service.py tests/test_auto_update.py -v
+uv run ruff check src/ tests/
+uv run ruff format . --check
+uv run ty check
+```
+
+Before merge, exercise a release wheel on Windows 11:
+
+1. install the previous release with `[server]` via `uv tool install`;
+2. run explicit update and verify both reported versions;
+3. repeat through startup auto-update;
+4. interrupt or force a failing install and verify the recovery command restores
+   a working `kbagent --version`;
+5. keep `kbagent serve` open and verify the lock failure is clear and does not
+   claim success.
+
+## Risks and follow-up
+
+- Atomic replacement is ultimately owned by `uv`; this change reduces our
+  mutation to a full, exact reinstall and eliminates all post-mutation work.
+- A future enhancement can use a detached bootstrapper if Windows lock failures
+  remain reproducible with current uv. That is intentionally separate because
+  process detachment/relaunch semantics need dedicated Windows integration
+  coverage.
+- The pip fallback cannot provide the same tool-environment recreation
+  guarantee. Its failure message must recommend reinstalling with uv.

--- a/docs/superpowers/specs/2026-07-23-issue-528-safe-self-update-design.md
+++ b/docs/superpowers/specs/2026-07-23-issue-528-safe-self-update-design.md
@@ -1,7 +1,7 @@
 # Design: Make kbagent self-update safe on Windows
 
-**Issue:** [#528](https://github.com/keboola/cli/issues/528)  
-**Status:** Proposed  
+**Issue:** [#528](https://github.com/keboola/cli/issues/528)
+**Status:** Proposed
 **Target:** `kbagent update` and startup auto-update
 
 ## Problem

--- a/src/keboola_agent_cli/auto_update.py
+++ b/src/keboola_agent_cli/auto_update.py
@@ -549,9 +549,11 @@ def maybe_auto_update() -> None:
         cached_kbagent = cache.get("latest_version") if cache else None
         cached_mcp = cache.get("mcp_latest_version") if cache else None
         skip_kbagent_stage = _should_skip_kbagent_stage()
+        use_cached_kbagent = cache_is_fresh and isinstance(cached_kbagent, str)
+        use_cached_mcp = cache_is_fresh and isinstance(cached_mcp, str)
         latest_version = (
             cached_kbagent
-            if cache_is_fresh and isinstance(cached_kbagent, str)
+            if use_cached_kbagent
             else (
                 None
                 if skip_kbagent_stage
@@ -560,7 +562,7 @@ def maybe_auto_update() -> None:
         )
         mcp_latest = (
             cached_mcp
-            if cache_is_fresh and isinstance(cached_mcp, str)
+            if use_cached_mcp
             else _fetch_mcp_latest_version(timeout=VERSION_CHECK_TIMEOUT)
         )
 
@@ -577,11 +579,24 @@ def maybe_auto_update() -> None:
         # MCP is an independent environment. Finish it before the terminal
         # self-reinstall and persist the prepared cache before self-mutation.
         _apply_prepared_mcp_update(mcp_plan)
-        _write_cache(
-            latest_version=latest_version,
-            mcp_latest_version=mcp_latest,
-            mcp_install_method=mcp_plan.install_method,
-        )
+        if not (use_cached_kbagent and use_cached_mcp):
+            _write_cache(
+                latest_version=(
+                    latest_version
+                    if latest_version is not None
+                    else cached_kbagent
+                    if isinstance(cached_kbagent, str)
+                    else None
+                ),
+                mcp_latest_version=(
+                    mcp_latest
+                    if mcp_latest is not None
+                    else cached_mcp
+                    if isinstance(cached_mcp, str)
+                    else None
+                ),
+                mcp_install_method=mcp_plan.install_method,
+            )
 
         if kbagent_plan.up_to_date is not False:
             return

--- a/src/keboola_agent_cli/auto_update.py
+++ b/src/keboola_agent_cli/auto_update.py
@@ -34,6 +34,8 @@ from .constants import (
 from .services.version_service import (
     MCP_PACKAGE_NAME,
     MCP_UV_PRERELEASE_FLAG,
+    KbagentUpdatePlan,
+    McpUpdatePlan,
     _detect_mcp_install_method,
     _fetch_kbagent_latest_version,
     _fetch_mcp_latest_version,
@@ -42,6 +44,8 @@ from .services.version_service import (
     _perform_mcp_update,
     build_kbagent_upgrade_command,
     get_update_timeout,
+    prepare_kbagent_update_plan,
+    prepare_mcp_update_plan,
     resolve_kbagent_wheel_url,
 )
 
@@ -264,7 +268,9 @@ def _should_skip() -> bool:
     return _should_skip_kbagent_stage() or _should_skip_all()
 
 
-def _perform_update(latest_version: str) -> UpdateOutcome:
+def _perform_update(
+    latest_version: str, *, command: tuple[str, ...] | None = None
+) -> UpdateOutcome:
     """Download and install the latest version.
 
     Delegates to :func:`build_kbagent_upgrade_command` so this path stays
@@ -283,10 +289,14 @@ def _perform_update(latest_version: str) -> UpdateOutcome:
         the install subprocess outran :func:`get_update_timeout` (a slow git+
         build -- retried next run, not a real failure), ``FAILED`` otherwise.
     """
-    # Prefer the prebuilt-wheel Release asset (issue #353) when present; falls
-    # back to the git+ source build for releases without an asset.
-    wheel_url = resolve_kbagent_wheel_url(latest_version)
-    cmd = build_kbagent_upgrade_command(wheel_url=wheel_url)
+    # ``command`` is supplied by the startup planner. Keep the fallback only
+    # for direct legacy callers; it must never be used after another stage has
+    # mutated the kbagent environment.
+    if command is None:
+        wheel_url = resolve_kbagent_wheel_url(latest_version)
+        cmd = build_kbagent_upgrade_command(target_version=latest_version, wheel_url=wheel_url)
+    else:
+        cmd = list(command)
     if cmd is None:
         return UpdateOutcome.FAILED
 
@@ -435,6 +445,58 @@ def _maybe_update_mcp(cache: dict | None, fetched_now: bool) -> str | None:
     return mcp_latest
 
 
+def _apply_prepared_mcp_update(plan: McpUpdatePlan) -> None:
+    """Apply a previously prepared MCP update while kbagent is still intact."""
+    if plan.latest_version is None or plan.up_to_date is True or plan.install_method == "none":
+        return
+    if plan.current_version is None or plan.command is None:
+        return
+
+    sys.stderr.write(
+        f"Updating keboola-mcp-server v{plan.current_version} -> v{plan.latest_version}"
+        f" (via {plan.install_method})...\n"
+    )
+    success, info = _perform_mcp_update(
+        method=plan.install_method,
+        timeout=MCP_UPGRADE_TIMEOUT,
+        command=plan.command,
+    )
+    if not success:
+        sys.stderr.write(
+            f"keboola-mcp-server upgrade skipped: {info}; continuing with current version.\n"
+        )
+        return
+
+    # A post-MCP probe is permitted: the kbagent environment has not yet
+    # changed. It is deliberately the last discovery operation in this flow.
+    post_version = _get_local_mcp_version()
+    if post_version and post_version != plan.current_version:
+        sys.stderr.write(f"Updated keboola-mcp-server to v{post_version}.\n")
+    elif post_version is None:
+        sys.stderr.write(
+            f"Updated keboola-mcp-server (probe failed; latest on PyPI: v{plan.latest_version}).\n"
+        )
+    else:
+        sys.stderr.write(
+            f"keboola-mcp-server upgrade exit 0 but local version still v{plan.current_version} "
+            f"(latest: v{plan.latest_version}). Run `uv tool install --reinstall "
+            f"{MCP_UV_PRERELEASE_FLAG} {MCP_PACKAGE_NAME}` to force the latest.\n"
+        )
+
+
+def _prepare_auto_kbagent_plan(latest_version: str | None) -> KbagentUpdatePlan:
+    """Adapt the shared plan to the startup comparison seam used by tests."""
+    prepared = prepare_kbagent_update_plan(latest_version)
+    up_to_date = _is_up_to_date(__version__, latest_version)
+    return KbagentUpdatePlan(
+        current_version=prepared.current_version,
+        latest_version=prepared.latest_version,
+        up_to_date=up_to_date,
+        command=prepared.command if up_to_date is False else None,
+        recovery_command=prepared.recovery_command,
+    )
+
+
 def maybe_auto_update() -> None:
     """Main entry point for the auto-update flow.
 
@@ -484,66 +546,70 @@ def maybe_auto_update() -> None:
 
         cache = _read_cache()
         cache_is_fresh = bool(cache and _is_cache_fresh(cache, AUTO_UPDATE_CHECK_INTERVAL))
-        latest_version: str | None = None
+        cached_kbagent = cache.get("latest_version") if cache else None
+        cached_mcp = cache.get("mcp_latest_version") if cache else None
+        skip_kbagent_stage = _should_skip_kbagent_stage()
+        latest_version = (
+            cached_kbagent
+            if cache_is_fresh and isinstance(cached_kbagent, str)
+            else (
+                None
+                if skip_kbagent_stage
+                else _fetch_kbagent_latest_version(timeout=VERSION_CHECK_TIMEOUT)
+            )
+        )
+        mcp_latest = (
+            cached_mcp
+            if cache_is_fresh and isinstance(cached_mcp, str)
+            else _fetch_mcp_latest_version(timeout=VERSION_CHECK_TIMEOUT)
+        )
 
-        # ----- Stage 1: kbagent self-update --------------------------------
-        # The re-exec guard skips ONLY this stage (so a freshly upgraded
-        # kbagent in the re-exec'd process does NOT double-upgrade itself
-        # but still proceeds to Stage 2 below).
-        if not _should_skip_kbagent_stage():
-            if cache_is_fresh:
-                latest_version = cache.get("latest_version")  # type: ignore[union-attr]
-            else:
-                latest_version = _fetch_kbagent_latest_version(timeout=VERSION_CHECK_TIMEOUT)
+        # Planning is complete before any subprocess can mutate either tool.
+        # In particular, all HTTP requests, import probes, PATH inspection,
+        # and command construction are above this line.
+        mcp_plan = prepare_mcp_update_plan(mcp_latest)
+        kbagent_plan = (
+            _prepare_auto_kbagent_plan(latest_version)
+            if not skip_kbagent_stage
+            else KbagentUpdatePlan(__version__, latest_version, True, None, None)
+        )
 
-            if latest_version is not None:
-                up_to_date = _is_up_to_date(__version__, latest_version)
-                if up_to_date is False:
-                    sys.stderr.write(f"Updating kbagent v{__version__} -> v{latest_version}...\n")
-                    outcome = _perform_update(latest_version)
-                    if outcome is UpdateOutcome.SUCCESS:
-                        sys.stderr.write(f"Updated to v{latest_version}. Re-launching...\n")
-                        # Persist cache before re-exec so the new process does
-                        # not refetch immediately. The re-exec'd process will
-                        # skip Stage 1 (KBAGENT_SKIP_UPDATE=1) and run Stage 2
-                        # against the just-refreshed cache.
-                        _write_cache(
-                            latest_version,
-                            mcp_latest_version=cache.get("mcp_latest_version") if cache else None,
-                            mcp_install_method=cache.get("mcp_install_method") if cache else None,
-                        )
-                        os.environ[ENV_UPDATED_FROM] = __version__
-                        _re_exec()
-                        return  # Defensive: _re_exec replaces the process.
-                    if outcome is UpdateOutcome.TIMEOUT:
-                        # Not a failure: the git+ source build outran the timeout.
-                        # The wheel fast path makes this rare; when it happens, say
-                        # so plainly instead of "failed" and let a later run finish
-                        # what uv already started (issue #353).
-                        sys.stderr.write(
-                            f"Update still building after {int(get_update_timeout())}s; "
-                            "it will finish on a later run. Continuing with current version.\n"
-                        )
-                    else:
-                        sys.stderr.write("Auto-update failed; continuing with current version.\n")
+        # MCP is an independent environment. Finish it before the terminal
+        # self-reinstall and persist the prepared cache before self-mutation.
+        _apply_prepared_mcp_update(mcp_plan)
+        _write_cache(
+            latest_version=latest_version,
+            mcp_latest_version=mcp_latest,
+            mcp_install_method=mcp_plan.install_method,
+        )
 
-        # ----- Stage 2: keboola-mcp-server update --------------------------
-        # Always runs (subject only to _should_skip_all above). After a
-        # kbagent self-upgrade, this is the re-exec'd process executing
-        # Stage 2 for the first time -- exactly the path B-1 broke before.
-        mcp_latest = _maybe_update_mcp(cache, fetched_now=not cache_is_fresh)
-        mcp_install_method = _detect_mcp_install_method()
+        if kbagent_plan.up_to_date is not False:
+            return
+        if kbagent_plan.command is None:
+            sys.stderr.write(
+                "Auto-update could not prepare a reinstall command. "
+                f"Recover with: {kbagent_plan.recovery_command}\n"
+            )
+            return
 
-        # Persist combined cache (kbagent + MCP) when we did any fresh fetch.
-        # Note: in the re-exec'd path, latest_version stays None (Stage 1
-        # was skipped); _write_cache handles that by falling back to the
-        # running __version__, so we still persist the MCP-side fields and
-        # don't break the next run's cache TTL check.
-        if not cache_is_fresh:
-            _write_cache(
-                latest_version=latest_version or (cache.get("latest_version") if cache else None),
-                mcp_latest_version=mcp_latest,
-                mcp_install_method=mcp_install_method,
+        sys.stderr.write(f"Updating kbagent v{__version__} -> v{kbagent_plan.latest_version}...\n")
+        outcome = _perform_update(
+            kbagent_plan.latest_version or __version__, command=kbagent_plan.command
+        )
+        if outcome is UpdateOutcome.SUCCESS:
+            sys.stderr.write(f"Updated to v{kbagent_plan.latest_version}. Re-launching...\n")
+            os.environ[ENV_UPDATED_FROM] = __version__
+            _re_exec()
+            return
+        if outcome is UpdateOutcome.TIMEOUT:
+            sys.stderr.write(
+                f"Update timed out after {int(get_update_timeout())}s. Recover with: "
+                f"{kbagent_plan.recovery_command}\n"
+            )
+        else:
+            sys.stderr.write(
+                "Auto-update failed; continuing with current version. Recover with: "
+                f"{kbagent_plan.recovery_command}\n"
             )
     except Exception:
         # Blanket catch: auto-update must NEVER crash the CLI.

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -25,7 +25,6 @@ from .constants import CHANGELOG_HEADLINE_MAX_CHARS
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
     "0.76.1": [
-        "Fix (#528): self-update now completes all version lookups and MCP work before its final, exact `uv tool install --force --reinstall` of kbagent. This avoids Windows file-lock and partially-swapped-environment failures; failed kbagent reinstalls report a copy/paste recovery command, while successful MCP updates remain visible as an independent stage.",
         "Fix (#522, #526): `kbagent serve --ui` no longer crashes on startup on Windows "
         "consoles with a non-UTF-8 codepage (cp1250 on Czech/Polish/Hungarian Windows). The "
         "startup banner's box-drawing glyphs (`├─` / `└─`) raised `UnicodeEncodeError` from "

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -25,6 +25,7 @@ from .constants import CHANGELOG_HEADLINE_MAX_CHARS
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
     "0.76.1": [
+        "Fix (#528): self-update now completes all version lookups and MCP work before its final, exact `uv tool install --force --reinstall` of kbagent. This avoids Windows file-lock and partially-swapped-environment failures; failed kbagent reinstalls report a copy/paste recovery command, while successful MCP updates remain visible as an independent stage.",
         "Fix (#522, #526): `kbagent serve --ui` no longer crashes on startup on Windows "
         "consoles with a non-UTF-8 codepage (cp1250 on Czech/Polish/Hungarian Windows). The "
         "startup banner's box-drawing glyphs (`├─` / `└─`) raised `UnicodeEncodeError` from "

--- a/src/keboola_agent_cli/commands/version.py
+++ b/src/keboola_agent_cli/commands/version.py
@@ -142,12 +142,13 @@ def update_command(
 
     Two-stage upgrade (since v0.30.1):
 
-    1. **kbagent** -- ``uv tool install --upgrade`` (preferred) or
-       ``pip install --upgrade`` from the GitHub repository.
-    2. **keboola-mcp-server** -- detects install method and runs the
+    1. **keboola-mcp-server** -- detects install method and runs the
        matching upgrade command (``uv tool upgrade`` / ``pip install -U``
-       / ``uvx --refresh``). Always runs, regardless of whether kbagent
-       itself needed an upgrade.
+       / ``uvx --refresh``).
+    2. **kbagent** -- final terminal stage: ``uv tool install --force
+       --reinstall`` from an exact release wheel or Git tag. This recreates
+       the whole tool environment and preserves ``[server]`` extras. On a
+       failure the result includes a copy/paste recovery command.
 
     JSON output reports both stages independently. Human mode prints a
     one-line summary such as

--- a/src/keboola_agent_cli/services/version_service.py
+++ b/src/keboola_agent_cli/services/version_service.py
@@ -248,19 +248,28 @@ def build_kbagent_upgrade_command(
     return cmd
 
 
+def _render_command(command: tuple[str, ...]) -> str:
+    """Render argv for the current platform's interactive shell."""
+    if os.name == "nt":
+        return subprocess.list2cmdline(command)
+    return shlex.join(command)
+
+
 def _recovery_command(command: tuple[str, ...] | None, target_version: str | None) -> str | None:
     """Render an exact forced-reinstall command safe to copy after failure."""
     if command is not None:
-        if command[0].endswith("uv"):
+        executable = command[0].replace("\\", "/").rsplit("/", maxsplit=1)[-1].casefold()
+        if executable in {"uv", "uv.exe"}:
             recovery = ("uv", *command[1:])
         else:
             prerelease = ("--prerelease=allow",) if "--pre" in command else ()
             recovery = ("uv", "tool", "install", "--force", "--reinstall", *prerelease, command[-1])
-        return shlex.join(recovery)
+        return _render_command(recovery)
     if target_version is None:
         return None
-    source = f"keboola-cli @ {KBAGENT_INSTALL_SOURCE}@v{target_version}"
-    return shlex.join(("uv", "tool", "install", "--force", "--reinstall", source))
+    extras = "[server]" if has_server_extras() else ""
+    source = f"keboola-cli{extras} @ {KBAGENT_INSTALL_SOURCE}@v{target_version}"
+    return _render_command(("uv", "tool", "install", "--force", "--reinstall", source))
 
 
 def _get_local_mcp_version(timeout: float = MCP_PROBE_TIMEOUT) -> str | None:
@@ -726,7 +735,9 @@ def prepare_kbagent_update_plan(
         latest_version=latest_version,
         up_to_date=up_to_date,
         command=command,
-        recovery_command=_recovery_command(command, latest_version),
+        recovery_command=(
+            _recovery_command(command, latest_version) if up_to_date is False else None
+        ),
     )
 
 

--- a/src/keboola_agent_cli/services/version_service.py
+++ b/src/keboola_agent_cli/services/version_service.py
@@ -11,8 +11,10 @@ import importlib.util
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess
+from dataclasses import dataclass
 from typing import Any
 
 import httpx
@@ -37,6 +39,37 @@ logger = logging.getLogger(__name__)
 # keboola-mcp-server constants
 MCP_PACKAGE_NAME = "keboola-mcp-server"
 MCP_BINARY_NAME = "keboola_mcp_server"
+
+
+@dataclass(frozen=True)
+class KbagentUpdatePlan:
+    """All information needed to perform the terminal kbagent reinstall."""
+
+    current_version: str
+    latest_version: str | None
+    up_to_date: bool | None
+    command: tuple[str, ...] | None
+    recovery_command: str | None
+
+
+@dataclass(frozen=True)
+class McpUpdatePlan:
+    """All discovery needed before applying the independent MCP update."""
+
+    current_version: str | None
+    latest_version: str | None
+    install_method: str
+    up_to_date: bool | None
+    command: tuple[str, ...] | None
+
+
+@dataclass(frozen=True)
+class UpdatePlan:
+    """Immutable explicit-update plan, prepared before either environment mutates."""
+
+    kbagent: KbagentUpdatePlan
+    mcp: McpUpdatePlan
+
 
 # MCP_UV_PRERELEASE_FLAG / MCP_PIP_PRERELEASE_FLAG are re-exported from
 # constants (imported above) so existing callers can keep importing them from
@@ -126,7 +159,7 @@ def get_update_timeout() -> float:
 def build_kbagent_upgrade_command(
     *, prerelease: bool = False, target_version: str | None = None, wheel_url: str | None = None
 ) -> list[str] | None:
-    """Build the argv command to upgrade kbagent in-place.
+    """Build the argv command to recreate the kbagent tool environment.
 
     Used by both ``kbagent update`` (explicit) and the startup
     auto-update hook so the two paths stay byte-for-byte consistent --
@@ -142,14 +175,9 @@ def build_kbagent_upgrade_command(
             are the newest available -- the default-deny behaviour we
             want for cron-driven auto-update so stable users never
             silently land on a beta release.
-        target_version: When set together with ``prerelease=True``, append
-            ``@v<target_version>`` to the git+ source URL so uv installs
-            the exact commit pointed to by the tag. Critical when betas
-            live on a feature branch instead of main -- without this, uv
-            resolves the default branch and silently installs the stale
-            main HEAD even though the version fetcher advertised the
-            beta tag. Ignored for stable upgrades (the auto-update path
-            always tracks main, which IS the latest stable).
+        target_version: Exact target release. Git fallbacks are always pinned
+            to ``@v<target_version>``; mutable ``main`` is never safe for a
+            recovery operation.
         wheel_url: When set, install the prebuilt wheel at this URL (a GitHub
             Release asset) via a PEP 508 direct reference instead of building
             from ``git+`` source -- the issue #353 fast path that skips the
@@ -162,70 +190,77 @@ def build_kbagent_upgrade_command(
         neither ``uv`` nor ``pip`` is on ``PATH`` (in which case the
         caller surfaces a manual-install hint).
     """
-    # Prebuilt-wheel fast path (issue #353): when the caller resolved a Release
-    # asset URL, install the ready-made wheel via a PEP 508 direct reference
-    # instead of git-building from source. The bundled npm/React build is what
-    # makes git+ installs take minutes on WSL; the wheel is a seconds download.
-    # wheel_url already pins the exact version, so prerelease / target_version
-    # (git-source knobs) do not apply here.
-    if wheel_url is not None:
-        spec = (
-            f"keboola-cli[server] @ {wheel_url}"
-            if has_server_extras()
-            else f"keboola-cli @ {wheel_url}"
+    # Compatibility for callers that only render a non-actionable command.
+    # Every production update path supplies ``target_version`` and therefore
+    # takes the exact, full-reinstall branch below.
+    if target_version is None:
+        legacy_source = wheel_url or KBAGENT_INSTALL_SOURCE
+        legacy_has_server = has_server_extras()
+        legacy_spec = (
+            f"keboola-cli[server] @ {legacy_source}"
+            if legacy_has_server
+            else f"keboola-cli @ {legacy_source}"
+            if wheel_url
+            else legacy_source
         )
         uv_path = shutil.which("uv")
         if uv_path:
-            return [uv_path, "tool", "install", "--force", spec]
+            if wheel_url:
+                cmd = [uv_path, "tool", "install", "--force"]
+            elif legacy_has_server:
+                cmd = [uv_path, "tool", "install", "--force", "--with", "keboola-cli[server]"]
+            else:
+                cmd = [uv_path, "tool", "install", "--upgrade"]
+            if prerelease:
+                cmd.append("--prerelease=allow")
+            cmd.append(legacy_spec if wheel_url else legacy_source)
+            return cmd
         pip_path = shutil.which("pip")
         if pip_path is None:
             return None
-        return [pip_path, "install", "--upgrade", spec]
+        cmd = [pip_path, "install"]
+        if prerelease:
+            cmd.append("--pre")
+        cmd.append("--upgrade")
+        cmd.append(legacy_spec)
+        return cmd
 
-    # Tag-pin the install source ONLY for beta opt-in (Variant B fix).
-    # Stable upgrades let uv resolve main HEAD as before -- main IS
-    # the stable channel, so an extra HTTP round-trip to fetch the
-    # tag name would be pure overhead.
-    install_source = KBAGENT_INSTALL_SOURCE
-    if prerelease and target_version:
-        install_source = f"{KBAGENT_INSTALL_SOURCE}@v{target_version}"
-    has_server = has_server_extras()
+    # The wheel is already an exact release artifact. When it is unavailable,
+    # pin the source fallback to the corresponding immutable Git tag.
+    install_source = wheel_url or f"{KBAGENT_INSTALL_SOURCE}@v{target_version}"
+    spec = f"keboola-cli{'[server]' if has_server_extras() else ''} @ {install_source}"
     uv_path = shutil.which("uv")
     if uv_path:
-        if has_server:
-            # We pair ``--with`` with ``--force`` (rather than
-            # ``--upgrade``) because ``uv tool install`` rejects
-            # ``--upgrade`` together with ``--with`` when the additional
-            # spec resolves to a different version than the existing
-            # tool environment -- ``--force`` is uv's documented way to
-            # reapply both in one shot.
-            cmd = [
-                uv_path,
-                "tool",
-                "install",
-                "--force",
-                "--with",
-                "keboola-cli[server]",
-                install_source,
-            ]
-        else:
-            cmd = [uv_path, "tool", "install", "--upgrade", install_source]
+        cmd = [uv_path, "tool", "install", "--force", "--reinstall"]
         if prerelease:
-            # Insert before the source spec so uv parses it as a global
-            # resolver flag (not a positional arg).
-            cmd.insert(-1, "--prerelease=allow")
+            cmd.append("--prerelease=allow")
+        cmd.append(spec)
         return cmd
     pip_path = shutil.which("pip")
     if pip_path is None:
         return None
-    # pip extras syntax: the [server] suffix attaches to the project
-    # name in the PEP 508 spec; for git+ URLs we wrap with the project
-    # name on the left of the URL.
-    install_spec = f"keboola-cli[server] @ {install_source}" if has_server else install_source
-    cmd = [pip_path, "install", "--upgrade", install_spec]
+    # Pip cannot recreate a uv-managed tool environment transactionally; it
+    # remains a best-effort fallback and is called out in failure guidance.
+    cmd = [pip_path, "install", "--upgrade"]
     if prerelease:
-        cmd.insert(2, "--pre")
+        cmd.append("--pre")
+    cmd.append(spec)
     return cmd
+
+
+def _recovery_command(command: tuple[str, ...] | None, target_version: str | None) -> str | None:
+    """Render an exact forced-reinstall command safe to copy after failure."""
+    if command is not None:
+        if command[0].endswith("uv"):
+            recovery = ("uv", *command[1:])
+        else:
+            prerelease = ("--prerelease=allow",) if "--pre" in command else ()
+            recovery = ("uv", "tool", "install", "--force", "--reinstall", *prerelease, command[-1])
+        return shlex.join(recovery)
+    if target_version is None:
+        return None
+    source = f"keboola-cli @ {KBAGENT_INSTALL_SOURCE}@v{target_version}"
+    return shlex.join(("uv", "tool", "install", "--force", "--reinstall", source))
 
 
 def _get_local_mcp_version(timeout: float = MCP_PROBE_TIMEOUT) -> str | None:
@@ -457,6 +492,8 @@ def _detect_mcp_install_method() -> str:
 def _perform_mcp_update(
     method: str | None = None,
     timeout: float = MCP_UPGRADE_TIMEOUT,
+    *,
+    command: tuple[str, ...] | None = None,
 ) -> tuple[bool, str]:
     """Run the appropriate upgrade command for keboola-mcp-server.
 
@@ -464,43 +501,27 @@ def _perform_mcp_update(
         method: Optional install method; if None, detect via
             :func:`_detect_mcp_install_method`.
         timeout: Subprocess timeout in seconds.
+        command: Prepared command. Supplying it guarantees this apply phase
+            does not probe PATH or rebuild commands.
 
     Returns:
         Tuple of ``(success, output_or_reason)``.
     """
-    if method is None:
-        method = _detect_mcp_install_method()
-
-    cmd: list[str] | None = None
-    if method == "uv_tool":
-        uv_path = shutil.which("uv")
-        if uv_path is None:
-            return False, "uv not found on PATH"
-        # --prerelease=allow is mandatory: see MCP_UV_PRERELEASE_FLAG (issue
-        # #324). Without it uv backtracks to a stale MCP and exits 0.
-        cmd = [uv_path, "tool", "upgrade", MCP_UV_PRERELEASE_FLAG, MCP_PACKAGE_NAME]
-    elif method == "pip_env":
-        pip_path = shutil.which("pip")
-        if pip_path is None:
-            return False, "pip not found on PATH"
-        cmd = [pip_path, "install", "--upgrade", MCP_PIP_PRERELEASE_FLAG, MCP_PACKAGE_NAME]
-    elif method == "uvx":
-        # Promote uvx-cache install to a persistent `uv tool install`.
-        # The previous strategy (`uvx --refresh ... <bin> --version`) was
-        # broken: the upstream MCP binary does NOT honour --version (it
-        # rejects the arg and exits non-zero), so the upgrade banner
-        # always reported failure even when the cache refresh itself
-        # worked. `uv tool install --upgrade` does the equivalent
-        # refresh AND moves the binary to PATH so subsequent runs use the
-        # faster `uv_tool` detection path. Bug B fix from issue #263.
-        uv_path = shutil.which("uv")
-        if uv_path is None:
-            return False, "uv not found on PATH (needed to promote uvx cache to uv tool)"
-        cmd = [uv_path, "tool", "install", "--upgrade", MCP_UV_PRERELEASE_FLAG, MCP_PACKAGE_NAME]
-    elif method == "none":
-        return False, "keboola-mcp-server is not installed"
+    if command is not None:
+        cmd = list(command)
     else:
-        return False, f"unknown install method: {method!r}"
+        if method is None:
+            method = _detect_mcp_install_method()
+        cmd = build_mcp_upgrade_command(method)
+
+    if cmd is None:
+        if method == "none":
+            return False, "keboola-mcp-server is not installed"
+        if method in {"uv_tool", "uvx"}:
+            return False, "uv not found on PATH"
+        if method == "pip_env":
+            return False, "pip not found on PATH"
+        return False, f"could not build MCP upgrade command for {method!r}"
 
     try:
         result = subprocess.run(
@@ -516,6 +537,34 @@ def _perform_mcp_update(
         return False, f"upgrade timed out after {timeout}s"
     except OSError as exc:
         return False, f"subprocess error: {exc}"
+
+
+def build_mcp_upgrade_command(method: str) -> list[str] | None:
+    """Build an MCP command during planning, before kbagent can mutate."""
+    if method == "uv_tool":
+        uv_path = shutil.which("uv")
+        if uv_path is None:
+            return None
+        return [uv_path, "tool", "upgrade", MCP_UV_PRERELEASE_FLAG, MCP_PACKAGE_NAME]
+    if method == "pip_env":
+        pip_path = shutil.which("pip")
+        if pip_path is None:
+            return None
+        return [pip_path, "install", "--upgrade", MCP_PIP_PRERELEASE_FLAG, MCP_PACKAGE_NAME]
+    if method == "uvx":
+        # Promote uvx-cache install to a persistent `uv tool install`.
+        # The previous strategy (`uvx --refresh ... <bin> --version`) was
+        # broken: the upstream MCP binary does NOT honour --version (it
+        # rejects the arg and exits non-zero), so the upgrade banner
+        # always reported failure even when the cache refresh itself
+        # worked. `uv tool install --upgrade` does the equivalent
+        # refresh AND moves the binary to PATH so subsequent runs use the
+        # faster `uv_tool` detection path. Bug B fix from issue #263.
+        uv_path = shutil.which("uv")
+        if uv_path is None:
+            return None
+        return [uv_path, "tool", "install", "--upgrade", MCP_UV_PRERELEASE_FLAG, MCP_PACKAGE_NAME]
+    return None
 
 
 def _fetch_kbagent_latest_version(
@@ -658,6 +707,59 @@ def _is_up_to_date(local: str | None, latest: str | None) -> bool | None:
         return None
 
 
+def prepare_kbagent_update_plan(
+    latest_version: str | None, *, include_prerelease: bool = False
+) -> KbagentUpdatePlan:
+    """Prepare the terminal self-reinstall without mutating any environment."""
+    up_to_date = _is_up_to_date(__version__, latest_version)
+    command: tuple[str, ...] | None = None
+    if up_to_date is False and latest_version is not None:
+        wheel_url = resolve_kbagent_wheel_url(latest_version)
+        built = build_kbagent_upgrade_command(
+            prerelease=include_prerelease,
+            target_version=latest_version,
+            wheel_url=wheel_url,
+        )
+        command = tuple(built) if built is not None else None
+    return KbagentUpdatePlan(
+        current_version=__version__,
+        latest_version=latest_version,
+        up_to_date=up_to_date,
+        command=command,
+        recovery_command=_recovery_command(command, latest_version),
+    )
+
+
+def prepare_mcp_update_plan(latest_version: str | None) -> McpUpdatePlan:
+    """Prepare MCP discovery and its command before a self-update begins."""
+    install_method = _detect_mcp_install_method()
+    current_version = _get_local_mcp_version()
+    up_to_date = _is_up_to_date(current_version, latest_version)
+    command: tuple[str, ...] | None = None
+    if up_to_date is not True and install_method != "none":
+        built = build_mcp_upgrade_command(install_method)
+        command = tuple(built) if built is not None else None
+    return McpUpdatePlan(
+        current_version=current_version,
+        latest_version=latest_version,
+        install_method=install_method,
+        up_to_date=up_to_date,
+        command=command,
+    )
+
+
+def prepare_update_plan(*, include_prerelease: bool = False) -> UpdatePlan:
+    """Complete all update lookups before either updater is allowed to run."""
+    # Fetch both latest-version values first. This ordering prevents a mutated
+    # kbagent environment from making a later PyPI HTTPS check fail.
+    kbagent_latest = _fetch_kbagent_latest_version(include_prerelease=include_prerelease)
+    mcp_latest = _fetch_mcp_latest_version()
+    return UpdatePlan(
+        kbagent=prepare_kbagent_update_plan(kbagent_latest, include_prerelease=include_prerelease),
+        mcp=prepare_mcp_update_plan(mcp_latest),
+    )
+
+
 class VersionService:
     """Business logic for version detection and update checks.
 
@@ -755,7 +857,7 @@ class VersionService:
         # would copy a stable-channel install command even though
         # latest_version advertised a beta tag -- silently landing on the
         # wrong version.
-        kbagent_target_version = kbagent_latest if include_prerelease else None
+        kbagent_target_version = kbagent_latest
         # Mirror the _update_kbagent path (issue #353, NB-1): advertise the
         # prebuilt-wheel install command when the asset exists, so a programmatic
         # consumer copy-pasting `upgrade_command` from `kbagent version --json`
@@ -823,8 +925,13 @@ class VersionService:
                     "message": str,     # Human-readable single-line summary
                 }
         """
-        kbagent_result = self._update_kbagent(include_prerelease=include_prerelease)
-        mcp_result = self._update_mcp()
+        plan = prepare_update_plan(include_prerelease=include_prerelease)
+
+        # MCP is independent and must finish before the terminal kbagent
+        # reinstall. Re-probing it afterwards is safe because kbagent has not
+        # yet changed its own environment.
+        mcp_result = self._update_mcp(plan.mcp)
+        kbagent_result = self._update_kbagent(plan.kbagent)
 
         any_updated = bool(kbagent_result.get("updated") or mcp_result.get("updated"))
         summary = self._compose_update_summary(kbagent_result, mcp_result)
@@ -888,22 +995,15 @@ class VersionService:
         return " | ".join(parts)
 
     @staticmethod
-    def _update_kbagent(*, include_prerelease: bool = False) -> dict[str, Any]:
-        """Run the kbagent self-upgrade subprocess (or short-circuit).
-
-        Args:
-            include_prerelease: When True (driven by ``kbagent update --beta``
-                or ``KBAGENT_INCLUDE_PRERELEASE=1``), the version lookup
-                considers beta / rc releases and the install command
-                propagates ``--prerelease=allow`` so the resolver accepts
-                PEP 440 pre-release tags like ``0.43.0b1``.
-        """
-        old_version = __version__
-        kbagent_latest = _fetch_kbagent_latest_version(include_prerelease=include_prerelease)
-        up_to_date = _is_up_to_date(old_version, kbagent_latest)
+    def _update_kbagent(plan: KbagentUpdatePlan) -> dict[str, Any]:
+        """Apply a precomputed terminal self-reinstall without new probes."""
+        old_version = plan.current_version
+        kbagent_latest = plan.latest_version
+        up_to_date = plan.up_to_date
 
         if up_to_date is True:
             return {
+                "planned": True,
                 "updated": False,
                 "up_to_date": True,
                 "current_version": old_version,
@@ -911,42 +1011,32 @@ class VersionService:
                 "message": f"kbagent v{old_version} is already up to date.",
             }
 
-        # Tag-pin the install URL ONLY for beta opt-in (Variant B fix).
-        # Stable upgrades intentionally pass target_version=None so uv
-        # resolves main HEAD as before -- main IS the stable channel.
-        target_version = kbagent_latest if include_prerelease else None
-        # Prefer the prebuilt-wheel Release asset (issue #353) when present;
-        # resolve_kbagent_wheel_url returns None for older releases without an
-        # asset, in which case build_kbagent_upgrade_command keeps the git+ path.
-        wheel_url = resolve_kbagent_wheel_url(kbagent_latest)
-        cmd = build_kbagent_upgrade_command(
-            prerelease=include_prerelease, target_version=target_version, wheel_url=wheel_url
-        )
-        if cmd is None:
-            with_flag = "--with 'keboola-cli[server]' " if has_server_extras() else ""
-            pre_flag = "--prerelease=allow " if include_prerelease else ""
-            tag_suffix = f"@v{target_version}" if target_version else ""
+        if plan.command is None:
             return {
+                "planned": True,
                 "updated": False,
+                "up_to_date": up_to_date,
                 "current_version": old_version,
                 "latest_version": kbagent_latest,
                 "message": (
-                    "Neither 'uv' nor 'pip' found on PATH. "
-                    f"Install manually: uv tool install --upgrade {pre_flag}{with_flag}"
-                    f"{KBAGENT_INSTALL_SOURCE}{tag_suffix}"
+                    "Could not prepare a self-update command. "
+                    f"Recover with: {plan.recovery_command or 'uv tool install --force --reinstall'}"
                 ),
+                "recovery_command": plan.recovery_command,
             }
 
         try:
             result = subprocess.run(
-                cmd,
+                list(plan.command),
                 capture_output=True,
                 text=True,
                 timeout=get_update_timeout(),
             )
             if result.returncode == 0:
                 return {
+                    "planned": True,
                     "updated": True,
+                    "up_to_date": False,
                     "current_version": old_version,
                     "latest_version": kbagent_latest,
                     "message": f"Updated kbagent from v{old_version} to v{kbagent_latest}. "
@@ -954,35 +1044,51 @@ class VersionService:
                     "output": result.stdout.strip(),
                 }
             return {
+                "planned": True,
                 "updated": False,
+                "up_to_date": False,
                 "current_version": old_version,
                 "latest_version": kbagent_latest,
                 "message": f"Update failed: {result.stderr.strip()}",
                 "output": result.stderr.strip(),
+                "recovery_command": plan.recovery_command,
             }
         except subprocess.TimeoutExpired:
             timeout_s = int(get_update_timeout())
             return {
+                "planned": True,
                 "updated": False,
+                "up_to_date": False,
                 "current_version": old_version,
                 "latest_version": kbagent_latest,
                 "message": (
-                    f"Update still building after {timeout_s}s (slow git+ source build). "
-                    "It will finish on a later run; raise KBAGENT_UPDATE_TIMEOUT to wait longer."
+                    f"Update timed out after {timeout_s}s. Recover with: {plan.recovery_command}"
                 ),
+                "recovery_command": plan.recovery_command,
+            }
+        except OSError as exc:
+            return {
+                "planned": True,
+                "updated": False,
+                "up_to_date": False,
+                "current_version": old_version,
+                "latest_version": kbagent_latest,
+                "message": f"Update failed: {exc}",
+                "recovery_command": plan.recovery_command,
             }
 
     @staticmethod
-    def _update_mcp() -> dict[str, Any]:
+    def _update_mcp(plan: McpUpdatePlan) -> dict[str, Any]:
         """Run the keboola-mcp-server upgrade subprocess (or short-circuit)."""
-        method = _detect_mcp_install_method()
-        local_version = _get_local_mcp_version()
-        latest_version = _fetch_mcp_latest_version()
-        up_to_date = _is_up_to_date(local_version, latest_version)
+        method = plan.install_method
+        local_version = plan.current_version
+        latest_version = plan.latest_version
+        up_to_date = plan.up_to_date
 
         # Short-circuit: detected and up-to-date.
         if up_to_date is True:
             return {
+                "planned": True,
                 "updated": False,
                 "up_to_date": True,
                 "current_version": local_version,
@@ -994,7 +1100,9 @@ class VersionService:
         # Short-circuit: nothing to upgrade against.
         if method == "none":
             return {
+                "planned": True,
                 "updated": False,
+                "up_to_date": up_to_date,
                 "current_version": local_version,
                 "latest_version": latest_version,
                 "install_method": method,
@@ -1005,7 +1113,20 @@ class VersionService:
             }
 
         # Run the upgrade.
-        success, output = _perform_mcp_update(method=method, timeout=MCP_UPGRADE_TIMEOUT)
+        if plan.command is None:
+            return {
+                "planned": True,
+                "updated": False,
+                "up_to_date": up_to_date,
+                "current_version": local_version,
+                "latest_version": latest_version,
+                "install_method": method,
+                "message": f"Could not prepare MCP upgrade command for {method}.",
+            }
+
+        success, output = _perform_mcp_update(
+            method=method, timeout=MCP_UPGRADE_TIMEOUT, command=plan.command
+        )
         post_version = _get_local_mcp_version() if success else local_version
 
         # Bug E fix from issue #263: subprocess returncode == 0 is NOT
@@ -1044,7 +1165,9 @@ class VersionService:
             )
 
         return {
+            "planned": True,
             "updated": actually_updated,
+            "up_to_date": False if actually_updated else up_to_date,
             "current_version": local_version,
             "latest_version": latest_version,
             "post_upgrade_version": post_version,

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -425,9 +425,14 @@ class TestMaybeAutoUpdate:
         auto_update_module._AUTO_UPDATE_RAN = False
         with (
             patch(
-                "keboola_agent_cli.auto_update._maybe_update_mcp",
+                "keboola_agent_cli.auto_update._fetch_mcp_latest_version",
                 return_value=None,
             ),
+            patch(
+                "keboola_agent_cli.auto_update._get_local_mcp_version",
+                return_value=None,
+            ),
+            patch("keboola_agent_cli.auto_update._apply_prepared_mcp_update"),
             patch(
                 "keboola_agent_cli.auto_update._detect_mcp_install_method",
                 return_value="none",
@@ -461,11 +466,19 @@ class TestMaybeAutoUpdate:
     @patch("keboola_agent_cli.auto_update._read_cache")
     @patch("keboola_agent_cli.auto_update._is_cache_fresh", return_value=True)
     @patch("keboola_agent_cli.auto_update._is_up_to_date", return_value=True)
-    def test_cache_fresh_no_fetch(self, mock_up_to_date, mock_fresh, mock_cache):
-        mock_cache.return_value = {"last_check": time.time(), "latest_version": "1.0.0"}
-        with patch("keboola_agent_cli.auto_update._fetch_kbagent_latest_version") as mock_fetch:
+    def test_cache_fresh_no_fetch_or_ttl_refresh(self, mock_up_to_date, mock_fresh, mock_cache):
+        mock_cache.return_value = {
+            "last_check": time.time(),
+            "latest_version": "1.0.0",
+            "mcp_latest_version": "1.0.0",
+        }
+        with (
+            patch("keboola_agent_cli.auto_update._fetch_kbagent_latest_version") as mock_fetch,
+            patch("keboola_agent_cli.auto_update._write_cache") as mock_write,
+        ):
             maybe_auto_update()
             mock_fetch.assert_not_called()
+            mock_write.assert_not_called()
 
     @patch("keboola_agent_cli.auto_update._read_cache", return_value=None)
     @patch("keboola_agent_cli.auto_update._fetch_kbagent_latest_version", return_value="2.0.0")
@@ -849,7 +862,7 @@ class TestMaybeAutoUpdateMcpIntegration:
             patch("keboola_agent_cli.auto_update._is_cache_fresh", return_value=True),
             patch("keboola_agent_cli.auto_update._is_up_to_date", return_value=True),
             patch(
-                "keboola_agent_cli.auto_update._maybe_update_mcp",
+                "keboola_agent_cli.auto_update._apply_prepared_mcp_update",
                 side_effect=RuntimeError("kaboom"),
             ),
         ):

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -23,6 +23,7 @@ from keboola_agent_cli.auto_update import (
     maybe_auto_update,
 )
 from keboola_agent_cli.constants import ENV_AUTO_UPDATE, ENV_SKIP_UPDATE, MCP_UPGRADE_TIMEOUT
+from keboola_agent_cli.services.version_service import KbagentUpdatePlan, McpUpdatePlan
 
 
 # ---------------------------------------------------------------------------
@@ -303,11 +304,11 @@ class TestPerformUpdate:
         mock_run.return_value = MagicMock(returncode=0)
         assert _perform_update("2.0.0") is UpdateOutcome.SUCCESS
         argv = mock_run.call_args[0][0]
-        # uv tool install --force --with 'keboola-cli[server]' git+...
+        # The extras live in the primary PEP 508 requirement so the complete
+        # environment is resolved in one forced reinstall.
         assert "--force" in argv
-        assert "--with" in argv
-        assert "keboola-cli[server]" in argv
-        # Must NOT pass --upgrade in this branch (uv rejects --upgrade + --with).
+        assert "--reinstall" in argv
+        assert any("keboola-cli[server]" in arg for arg in argv)
         assert "--upgrade" not in argv
 
     @patch(
@@ -317,12 +318,12 @@ class TestPerformUpdate:
     @patch("shutil.which", return_value="/usr/local/bin/uv")
     @patch("subprocess.run")
     def test_update_without_server_extras_uses_upgrade(self, mock_run, mock_which, mock_has_server):
-        """No-extras install keeps the simpler ``--upgrade`` form."""
+        """No-extras installs are also a full forced reinstall."""
         mock_run.return_value = MagicMock(returncode=0)
         assert _perform_update("2.0.0") is UpdateOutcome.SUCCESS
         argv = mock_run.call_args[0][0]
-        assert "--upgrade" in argv
-        assert "--with" not in argv
+        assert "--force" in argv
+        assert "--reinstall" in argv
         assert "keboola-cli[server]" not in argv
 
 
@@ -511,7 +512,9 @@ class TestMaybeAutoUpdate:
         mock_cache,
     ):
         maybe_auto_update()
-        mock_update.assert_called_once_with("2.0.0")
+        mock_update.assert_called_once()
+        assert mock_update.call_args.args == ("2.0.0",)
+        assert "command" in mock_update.call_args.kwargs
         mock_reexec.assert_called_once()
 
     @patch("keboola_agent_cli.auto_update._read_cache", return_value=None)
@@ -543,7 +546,7 @@ class TestMaybeAutoUpdate:
         return_value=UpdateOutcome.TIMEOUT,
     )
     @patch("keboola_agent_cli.auto_update._re_exec")
-    @patch("keboola_agent_cli.auto_update._maybe_update_mcp")
+    @patch("keboola_agent_cli.auto_update._apply_prepared_mcp_update")
     @patch("keboola_agent_cli.auto_update._detect_mcp_install_method", return_value="none")
     @patch("keboola_agent_cli.auto_update._write_cache")
     @patch("keboola_agent_cli.auto_update.__version__", "1.0.0")
@@ -568,8 +571,8 @@ class TestMaybeAutoUpdate:
         maybe_auto_update()
         mock_reexec.assert_not_called()
         err = capsys.readouterr().err
-        assert "still building" in err
-        assert "failed" not in err.lower()
+        assert "timed out" in err
+        assert "Recover with:" in err
 
     @patch("keboola_agent_cli.auto_update._read_cache", return_value=None)
     @patch("keboola_agent_cli.auto_update._fetch_kbagent_latest_version", return_value=None)
@@ -801,7 +804,7 @@ class TestMaybeAutoUpdateMcpIntegration:
     @patch("keboola_agent_cli.auto_update._read_cache", return_value=None)
     @patch("keboola_agent_cli.auto_update._fetch_kbagent_latest_version", return_value="1.0.0")
     @patch("keboola_agent_cli.auto_update._is_up_to_date", return_value=True)
-    @patch("keboola_agent_cli.auto_update._maybe_update_mcp")
+    @patch("keboola_agent_cli.auto_update._apply_prepared_mcp_update")
     @patch("keboola_agent_cli.auto_update._detect_mcp_install_method", return_value="uv_tool")
     @patch("keboola_agent_cli.auto_update._write_cache")
     def test_kbagent_uptodate_still_runs_mcp_stage(
@@ -821,7 +824,7 @@ class TestMaybeAutoUpdateMcpIntegration:
     @patch("keboola_agent_cli.auto_update._fetch_kbagent_latest_version", return_value="2.0.0")
     @patch("keboola_agent_cli.auto_update._is_up_to_date", return_value=False)
     @patch("keboola_agent_cli.auto_update._perform_update", return_value=UpdateOutcome.FAILED)
-    @patch("keboola_agent_cli.auto_update._maybe_update_mcp")
+    @patch("keboola_agent_cli.auto_update._apply_prepared_mcp_update")
     @patch("keboola_agent_cli.auto_update._detect_mcp_install_method", return_value="uv_tool")
     @patch("keboola_agent_cli.auto_update._write_cache")
     def test_failed_kbagent_upgrade_still_runs_mcp_stage(
@@ -893,7 +896,7 @@ class TestReExecPathStillRunsMcp:
             patch(
                 "keboola_agent_cli.auto_update._fetch_kbagent_latest_version"
             ) as mock_fetch_kbagent,
-            patch("keboola_agent_cli.auto_update._maybe_update_mcp") as mock_mcp,
+            patch("keboola_agent_cli.auto_update._apply_prepared_mcp_update") as mock_mcp,
             patch(
                 "keboola_agent_cli.auto_update._detect_mcp_install_method",
                 return_value="uv_tool",
@@ -918,7 +921,7 @@ class TestReExecPathStillRunsMcp:
             patch(
                 "keboola_agent_cli.auto_update._fetch_kbagent_latest_version"
             ) as mock_fetch_kbagent,
-            patch("keboola_agent_cli.auto_update._maybe_update_mcp") as mock_mcp,
+            patch("keboola_agent_cli.auto_update._apply_prepared_mcp_update") as mock_mcp,
         ):
             maybe_auto_update()
 
@@ -936,7 +939,7 @@ class TestReExecPathStillRunsMcp:
             patch(
                 "keboola_agent_cli.auto_update._fetch_kbagent_latest_version"
             ) as mock_fetch_kbagent,
-            patch("keboola_agent_cli.auto_update._maybe_update_mcp") as mock_mcp,
+            patch("keboola_agent_cli.auto_update._apply_prepared_mcp_update") as mock_mcp,
         ):
             maybe_auto_update()
 
@@ -1011,7 +1014,7 @@ class TestProcessLevelSentinel:
     @patch("keboola_agent_cli.auto_update._read_cache", return_value=None)
     @patch("keboola_agent_cli.auto_update._fetch_kbagent_latest_version", return_value="1.0.0")
     @patch("keboola_agent_cli.auto_update._is_up_to_date", return_value=True)
-    @patch("keboola_agent_cli.auto_update._maybe_update_mcp")
+    @patch("keboola_agent_cli.auto_update._apply_prepared_mcp_update")
     @patch("keboola_agent_cli.auto_update._detect_mcp_install_method", return_value="uv_tool")
     @patch("keboola_agent_cli.auto_update._write_cache")
     def test_second_call_short_circuits(
@@ -1048,5 +1051,88 @@ class TestProcessLevelSentinel:
             side_effect=RuntimeError("kaboom"),
         ):
             maybe_auto_update()  # blanket try/except swallows the RuntimeError
+
+
+class TestSafeStartupUpdateOrder:
+    """Regression coverage for issue #528's terminal-mutation contract."""
+
+    def test_mcp_and_cache_precede_kbagent_and_reexec_is_immediate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        auto_update_module._AUTO_UPDATE_RAN = False
+        events: list[str] = []
+        mutated = False
+
+        def fetch_kbagent(*args: object, **kwargs: object) -> str:
+            assert not mutated
+            events.append("fetch_kbagent")
+            return "2.0.0"
+
+        def fetch_mcp(*args: object, **kwargs: object) -> str:
+            assert not mutated
+            events.append("fetch_mcp")
+            return "2.0.0"
+
+        def prepare_mcp(latest: str | None) -> McpUpdatePlan:
+            assert not mutated
+            events.append("prepare_mcp")
+            return McpUpdatePlan("1.0.0", latest, "uv_tool", False, ("uv", "mcp"))
+
+        def prepare_kbagent(latest: str | None) -> KbagentUpdatePlan:
+            assert not mutated
+            events.append("prepare_kbagent")
+            return KbagentUpdatePlan(
+                "1.0.0",
+                latest,
+                False,
+                ("uv", "kbagent"),
+                "uv tool install --force --reinstall exact",
+            )
+
+        def apply_mcp(plan: McpUpdatePlan) -> None:
+            assert not mutated
+            events.append("apply_mcp")
+
+        def write_cache(**kwargs: object) -> None:
+            assert not mutated
+            events.append("cache")
+
+        def perform(version: str, *, command: tuple[str, ...]) -> UpdateOutcome:
+            nonlocal mutated
+            assert events[-1] == "cache"
+            mutated = True
+            events.append("kbagent")
+            return UpdateOutcome.SUCCESS
+
+        def reexec() -> None:
+            assert mutated
+            events.append("reexec")
+
+        monkeypatch.setattr(auto_update_module, "_AUTO_UPDATE_RAN", False)
+        monkeypatch.setattr(auto_update_module, "_should_skip_all", lambda: False)
+        monkeypatch.setattr(auto_update_module, "_should_skip_kbagent_stage", lambda: False)
+        monkeypatch.setattr(auto_update_module, "_read_cache", lambda: None)
+        monkeypatch.setattr(auto_update_module, "_fetch_kbagent_latest_version", fetch_kbagent)
+        monkeypatch.setattr(auto_update_module, "_fetch_mcp_latest_version", fetch_mcp)
+        monkeypatch.setattr(auto_update_module, "prepare_mcp_update_plan", prepare_mcp)
+        monkeypatch.setattr(auto_update_module, "prepare_kbagent_update_plan", prepare_kbagent)
+        monkeypatch.setattr(auto_update_module, "_apply_prepared_mcp_update", apply_mcp)
+        monkeypatch.setattr(auto_update_module, "_write_cache", write_cache)
+        monkeypatch.setattr(auto_update_module, "_perform_update", perform)
+        monkeypatch.setattr(auto_update_module, "_re_exec", reexec)
+        monkeypatch.setattr(auto_update_module, "_is_up_to_date", lambda *_: False)
+
+        maybe_auto_update()
+
+        assert events == [
+            "fetch_kbagent",
+            "fetch_mcp",
+            "prepare_mcp",
+            "prepare_kbagent",
+            "apply_mcp",
+            "cache",
+            "kbagent",
+            "reexec",
+        ]
         # Sentinel was flipped before the crash.
         assert auto_update_module._AUTO_UPDATE_RAN is True

--- a/tests/test_version_service.py
+++ b/tests/test_version_service.py
@@ -20,6 +20,7 @@ from keboola_agent_cli.services.version_service import (
     _is_up_to_date,
     _is_uvx_available,
     _perform_mcp_update,
+    _recovery_command,
     _uv_tool_list_get_mcp_version,
     _uv_tool_list_has_mcp,
     build_kbagent_upgrade_command,
@@ -1251,6 +1252,31 @@ class TestBuildKbagentUpgradeCommand:
         assert cmd[-1].endswith("@v0.43.3")
         assert "--force" in cmd
         assert "--reinstall" in cmd
+
+    def test_windows_uv_executable_keeps_exact_beta_recovery_command(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """uv.exe is uv, not a pip fallback; retain its prerelease flag."""
+        monkeypatch.setattr(
+            "keboola_agent_cli.services.version_service._render_command",
+            subprocess.list2cmdline,
+        )
+        command = (
+            r"C:\Users\test\.local\bin\uv.exe",
+            "tool",
+            "install",
+            "--force",
+            "--reinstall",
+            "--prerelease=allow",
+            "keboola-cli[server] @ https://example.test/keboola.whl",
+        )
+
+        recovery = _recovery_command(command, "1.0.0b1")
+
+        assert recovery is not None
+        assert recovery.startswith("uv tool install")
+        assert "--prerelease=allow" in recovery
+        assert "'keboola-cli" not in recovery
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_version_service.py
+++ b/tests/test_version_service.py
@@ -9,6 +9,9 @@ from keboola_agent_cli.constants import MCP_UPGRADE_TIMEOUT
 from keboola_agent_cli.services.version_service import (
     MCP_BINARY_NAME,
     MCP_PACKAGE_NAME,
+    KbagentUpdatePlan,
+    McpUpdatePlan,
+    UpdatePlan,
     VersionService,
     _detect_mcp_install_method,
     _fetch_kbagent_latest_version,
@@ -725,7 +728,67 @@ class TestSelfUpdateTwoStage:
         # Critical: kbagent up-to-date does NOT short-circuit MCP stage.
         assert result["mcp"]["updated"] is True
         assert result["updated"] is True
-        mock_perform.assert_called_once()
+
+    def test_prepares_every_lookup_then_updates_mcp_before_terminal_kbagent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Issue #528: no discovery may happen after self-mutation begins."""
+        events: list[str] = []
+        mutated = False
+
+        def prepare(*, include_prerelease: bool = False) -> UpdatePlan:
+            events.append("prepare")
+            return UpdatePlan(
+                kbagent=KbagentUpdatePlan(
+                    current_version="1.0.0",
+                    latest_version="2.0.0",
+                    up_to_date=False,
+                    command=("uv", "tool", "install"),
+                    recovery_command="uv tool install --force --reinstall exact",
+                ),
+                mcp=McpUpdatePlan(
+                    current_version="1.0.0",
+                    latest_version="2.0.0",
+                    install_method="uv_tool",
+                    up_to_date=False,
+                    command=("uv", "tool", "upgrade", MCP_PACKAGE_NAME),
+                ),
+            )
+
+        def perform_mcp(*args: object, **kwargs: object) -> tuple[bool, str]:
+            assert not mutated
+            events.append("mcp")
+            return True, "ok"
+
+        def probe_mcp() -> str:
+            assert not mutated
+            events.append("mcp_probe")
+            return "2.0.0"
+
+        def run(command: list[str], **kwargs: object) -> MagicMock:
+            nonlocal mutated
+            assert command == ["uv", "tool", "install"]
+            mutated = True
+            events.append("kbagent")
+            return MagicMock(returncode=1, stdout="", stderr="locked")
+
+        monkeypatch.setattr(
+            "keboola_agent_cli.services.version_service.prepare_update_plan", prepare
+        )
+        monkeypatch.setattr(
+            "keboola_agent_cli.services.version_service._perform_mcp_update", perform_mcp
+        )
+        monkeypatch.setattr(
+            "keboola_agent_cli.services.version_service._get_local_mcp_version", probe_mcp
+        )
+        monkeypatch.setattr("keboola_agent_cli.services.version_service.subprocess.run", run)
+
+        result = VersionService().self_update()
+
+        assert events == ["prepare", "mcp", "mcp_probe", "kbagent"]
+        assert result["mcp"]["updated"] is True
+        assert result["kbagent"]["updated"] is False
+        assert result["kbagent"]["recovery_command"].endswith("exact")
 
     @patch("keboola_agent_cli.services.version_service._fetch_kbagent_latest_version")
     @patch("keboola_agent_cli.services.version_service._fetch_mcp_latest_version")
@@ -1078,7 +1141,8 @@ class TestBuildKbagentWheelInstall:
             prerelease=True, target_version="1.2.3", wheel_url=self.WHEEL
         )
         assert cmd is not None
-        assert "--prerelease=allow" not in cmd
+        assert "--prerelease=allow" in cmd
+        assert "--reinstall" in cmd
         assert all("git+" not in part for part in cmd)
         assert cmd[-1] == f"keboola-cli[server] @ {self.WHEEL}"
 
@@ -1174,24 +1238,19 @@ class TestBuildKbagentUpgradeCommand:
 
     @patch("keboola_agent_cli.services.version_service.has_server_extras")
     @patch("keboola_agent_cli.services.version_service.shutil.which")
-    def test_uv_stable_with_target_version_ignores_tag(
+    def test_uv_stable_with_target_version_pins_tag(
         self, mock_which: MagicMock, mock_has_server: MagicMock
     ) -> None:
-        """target_version is ignored unless prerelease=True.
-
-        Stable upgrades always track main (which IS the stable channel),
-        so tag-pinning would just add a needless HTTP round-trip without
-        changing the resolved version.
-        """
+        """Stable recovery is pinned to the requested immutable release tag."""
         mock_which.side_effect = lambda x: "/usr/bin/uv" if x == "uv" else None
         mock_has_server.return_value = False
 
         cmd = build_kbagent_upgrade_command(prerelease=False, target_version="0.43.3")
 
         assert cmd is not None
-        # No tag suffix when prerelease=False, even if target_version supplied.
-        assert not cmd[-1].endswith("@v0.43.3")
-        assert "@v" not in cmd[-1]
+        assert cmd[-1].endswith("@v0.43.3")
+        assert "--force" in cmd
+        assert "--reinstall" in cmd
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Design: Make kbagent self-update safe on Windows

**Issue:** [#528](https://github.com/keboola/cli/issues/528)  
**Status:** Proposed  
**Target:** `kbagent update` and startup auto-update

## Problem

Both self-update entry points currently mutate the `uv tool` environment from
which the running `kbagent` process was launched:

- startup auto-update calls `_perform_update()`, then continues in the old
  process long enough to write the cache and re-exec;
- explicit `kbagent update` updates kbagent first and then performs MCP
  detection, a PyPI request, and an MCP update from the already-mutated
  process.

On Windows, a running executable or dependency can be locked. Even without a
lock, a failed in-place dependency swap can leave the tool environment with a
mixture of old and new distributions. The reporter observed both failure
classes:

1. mismatched `rich` and `typer` after a failed startup update;
2. a missing `certifi/cacert.pem` after explicit update removed the old
   distribution and the same process subsequently attempted the MCP HTTPS
   check.

The updater must treat mutation of its own environment as a terminal action,
and it must use `uv tool install` as a full reinstall/re-resolution rather than
an incremental upgrade.

## Goals

- Never perform network access, dependency discovery, cache writes, or MCP
  work after the kbagent environment starts changing.
- Reinstall the complete kbagent tool environment from an exact release
  artifact when `uv` manages the install.
- Preserve `[server]` extras and the beta channel.
- Keep kbagent and MCP results independently visible in human and JSON output.
- Fail without claiming success, and provide a copy/paste recovery command.
- Keep startup auto-update best-effort: update failure must not intentionally
  abort the requested command.

## Non-goals

- Reimplement `uv`'s package resolver or tool-environment transaction logic.
- Update a tool while another long-running kbagent process is using the same
  Windows environment. A locked executable remains a reported, recoverable
  failure.
- Change MCP installation ownership or merge the MCP environment into
  kbagent's environment.
- Add a persistent background update daemon.

## Design

### 1. Separate planning from mutation

Introduce small immutable plan/result dataclasses in
`services/version_service.py`. The planning phase performs every operation that
can touch the network or inspect the current environment:

- fetch the latest kbagent version;
- resolve the exact release wheel URL, or an exact `@v<version>` git fallback;
- detect `[server]` extras and build the complete install command;
- detect the MCP install method and local version;
- fetch the latest MCP version;
- calculate which stages actually need work.

The apply phase receives only these prepared values. It must not call
`httpx`, `importlib`, package metadata probes, or command builders again.

### 2. Apply MCP before kbagent

For explicit `kbagent update`, execute the independent MCP stage first.
Re-probing the MCP version is allowed immediately after that stage because the
kbagent environment is still untouched.

The kbagent reinstall is always the final mutation. Its result is assembled
from the prepared plan and subprocess return value; no post-install version
probe or network request is made.

This removes the exact ordering bug behind the missing certifi CA bundle.

### 3. Recreate the uv tool environment

For every uv-managed kbagent path, build:

```text
uv tool install --force --reinstall "<keboola-cli spec pinned to the target release>"
```

The preferred spec is the versioned release wheel. The fallback source must
also be pinned to `@v<target_version>` for stable and beta releases; updating
from mutable `main` is not sufficiently reproducible for a recovery operation.
When server extras are present, encode them in the primary PEP 508 requirement
(`keboola-cli[server] @ ...`) so one resolution recreates the complete
environment.

`uv tool install` is the supported operation for recreating a tool environment;
`--reinstall` ensures every package is materialized again and `--force` allows
uv-owned entry points to be replaced. Pip remains a best-effort fallback, but
its result and recovery limitation must be explicit.

### 4. Make startup mutation terminal

Reorder startup auto-update:

1. perform all fresh kbagent and MCP lookups;
2. update MCP, if needed;
3. persist the complete cache;
4. reinstall kbagent;
5. on success, immediately re-exec with `KBAGENT_SKIP_UPDATE=1`.

There must be no cache write or MCP stage between steps 4 and 5. The
already-prepared cache lets the re-exec'd process skip all network work for
that cycle.

If the kbagent install subprocess fails or times out, emit a concise failure
and the exact forced-reinstall recovery command. Do not report a successful
update and do not run further update work from the potentially inconsistent
process.

### 5. Preserve the command contract

`kbagent update` keeps the current top-level result shape. Add enough fields to
make partial outcomes unambiguous:

- each stage reports `planned`, `updated`, `up_to_date`, and `message`;
- kbagent failure includes `recovery_command`;
- the top-level `updated` remains true when at least one stage changed;
- the summary reports an MCP success even if the final kbagent stage fails.

The existing `--beta` behavior, `[server]` preservation, timeouts, and
human/JSON rendering remain supported.

## Implementation map

- `src/keboola_agent_cli/services/version_service.py`
  - add update-plan dataclasses and prepare/apply helpers;
  - make exact-version `uv tool install --force --reinstall` the self-update
    command;
  - reorder explicit update to MCP first, kbagent last;
  - avoid post-kbagent probes.
- `src/keboola_agent_cli/auto_update.py`
  - prepare both stages before mutation;
  - move MCP update and cache persistence before `_perform_update`;
  - re-exec immediately after a successful kbagent install;
  - expose the forced-reinstall command on failure.
- `src/keboola_agent_cli/commands/version.py`
  - update command documentation and render partial/failure outcomes without
    accessing package metadata after the self-update stage.
- `src/keboola_agent_cli/changelog.py`
  - add the user-facing fix and recovery behavior to the next release entry.
- `tests/test_version_service.py`
  - pin planning/apply order and assert no network/probe calls after kbagent
    mutation;
  - cover MCP success plus kbagent failure;
  - cover stable, beta, server-extra, wheel, and git-fallback command shapes.
- `tests/test_auto_update.py`
  - assert MCP and cache work precede kbagent mutation;
  - assert successful install is followed directly by re-exec;
  - assert failure performs no later update work and prints recovery guidance.

## Acceptance criteria

1. Explicit update fetches both latest-version values before running either
   updater.
2. Explicit update applies MCP first and kbagent last.
3. No HTTP call, import/package probe, MCP update, or cache write occurs after
   the kbagent install command begins.
4. All uv kbagent installs use an exact target plus `tool install --force
   --reinstall`.
5. `[server]` and beta installs retain their current behavior.
6. Startup auto-update writes the prepared cache before self-mutation and
   immediately re-execs after success.
7. A failed kbagent stage is never described as up to date or successful and
   includes an exact recovery command.
8. Unit tests reproduce the incident-2 ordering failure by making any
   post-mutation HTTP call fail; the fixed flow performs no such call.
9. The focused update suites and the repository's lint, format, and type checks
   pass.

## Validation

Run locally:

```text
uv run pytest tests/test_version_service.py tests/test_auto_update.py -v
uv run ruff check src/ tests/
uv run ruff format . --check
uv run ty check
```

Before merge, exercise a release wheel on Windows 11:

1. install the previous release with `[server]` via `uv tool install`;
2. run explicit update and verify both reported versions;
3. repeat through startup auto-update;
4. interrupt or force a failing install and verify the recovery command restores
   a working `kbagent --version`;
5. keep `kbagent serve` open and verify the lock failure is clear and does not
   claim success.

## Risks and follow-up

- Atomic replacement is ultimately owned by `uv`; this change reduces our
  mutation to a full, exact reinstall and eliminates all post-mutation work.
- A future enhancement can use a detached bootstrapper if Windows lock failures
  remain reproducible with current uv. That is intentionally separate because
  process detachment/relaunch semantics need dedicated Windows integration
  coverage.
- The pip fallback cannot provide the same tool-environment recreation
  guarantee. Its failure message must recommend reinstalling with uv.
