### PR TITLE
fix(semantic-layer): support snapshot export on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,13 +129,14 @@ jobs:
       - name: Tests (with coverage report)
         run: uv run pytest tests/ -v -m "not integration" --cov --cov-report=term-missing
 
-  # Real wheel build on Windows -- the only place the issue #320 fixes can be
-  # verified end-to-end without a Windows developer machine. GitHub provides
+  # Real wheel build and focused export regression on Windows -- the only
+  # place the issue #320 and #529 fixes can be verified against real Windows
+  # behavior without a Windows developer machine. GitHub provides
   # windows-latest runners (with Node/npm preinstalled) for free, so the
   # `npm.cmd` invocation (Bug 1) and the force-include path resolution (Bug 2)
   # are exercised against a real `uv build` rather than mocks.
   build-windows:
-    name: Windows wheel build (issue #320)
+    name: Windows wheel build and export regression (issues #320, #529)
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
@@ -165,6 +166,11 @@ jobs:
       # `FileNotFoundError [WinError 2]`, and the SPA must land in the wheel.
       - name: Build wheel WITH bundled UI
         run: uv build --wheel
+
+      # Windows does not expose os.O_NOFOLLOW. Exercise the focused export
+      # regression here, where the portable flags run on the real platform.
+      - name: Test semantic-layer export on Windows (issue #529)
+        run: uv run pytest tests/test_semantic_layer_service.py -k "export" -v
 
       - name: Assert the SPA is bundled (Bug 1 fixed)
         run: python scripts/check_wheel_ui.py --expect-ui

--- a/docs/superpowers/specs/2026-07-23-issue-529-windows-semantic-layer-export-design.md
+++ b/docs/superpowers/specs/2026-07-23-issue-529-windows-semantic-layer-export-design.md
@@ -70,8 +70,10 @@ than implying that every platform provides it.
 - `.github/workflows/ci.yml`
   - run the focused semantic-layer export regression on the existing
     `windows-latest` job so the real Windows `os` flags are exercised.
-- `src/keboola_agent_cli/changelog.py`
-  - record the Windows export fix in the next release entry.
+
+No changelog entry is made in this PR: the repository has no unreleased
+section, so the Windows export fix is recorded when the next release version is
+prepared rather than being added to an already released entry.
 
 ## Acceptance criteria
 

--- a/docs/superpowers/specs/2026-07-23-issue-529-windows-semantic-layer-export-design.md
+++ b/docs/superpowers/specs/2026-07-23-issue-529-windows-semantic-layer-export-design.md
@@ -1,0 +1,111 @@
+# Design: Make semantic-layer snapshot export portable to Windows
+
+**Issue:** [#529](https://github.com/keboola/cli/issues/529)  
+**Status:** Proposed  
+**Target:** `kbagent semantic-layer export` and every shared snapshot writer
+
+## Problem
+
+`write_snapshot_to_file()` builds its `os.open()` flags with
+`os.O_NOFOLLOW`. That flag is available on POSIX platforms but is not defined
+by Python's `os` module on Windows. Evaluating the flags therefore raises
+`AttributeError` before the output file is opened.
+
+The helper is shared by semantic-layer export and the optional build output
+path, so the portability bug affects more than one command even though export
+is the reported reproducer.
+
+## Goals
+
+- Make snapshot writes work on Windows without weakening the existing POSIX
+  symlink protection.
+- Continue writing UTF-8 JSON bytes with deterministic line endings.
+- Preserve the current `0o644` permissions contract on POSIX.
+- Cover both the Windows-compatible path and the POSIX hardening path with
+  regression tests.
+
+## Non-goals
+
+- Add Windows ACL management; the numeric mode argument is intentionally
+  ignored by Windows.
+- Guarantee protection against every Windows reparse-point race. Python does
+  not expose a direct `O_NOFOLLOW` equivalent through `os.open`.
+- Change the snapshot schema, export result, default filename, or CLI output.
+
+## Design
+
+Build the flags incrementally from portable flags:
+
+```python
+flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+flags |= getattr(os, "O_NOFOLLOW", 0)
+flags |= getattr(os, "O_BINARY", 0)
+```
+
+- On POSIX, `O_NOFOLLOW` remains active and a pre-existing final-component
+  symlink is rejected.
+- On Windows, the unavailable flag contributes zero, so `os.open()` succeeds.
+- `O_BINARY` is a no-op where unavailable and prevents Windows text-mode
+  newline translation because the helper writes an already encoded byte
+  payload with `os.write()`.
+
+Keep the descriptor lifecycle in the existing `try/finally`; do not replace it
+with a text-mode `Path.write_text()` call, which would discard the POSIX
+hardening and change the low-level write contract.
+
+Update the docstring to describe conditional `O_NOFOLLOW` protection rather
+than implying that every platform provides it.
+
+## Implementation map
+
+- `src/keboola_agent_cli/services/_semantic_layer_internals.py`
+  - construct portable open flags with guarded platform-specific additions;
+  - document POSIX and Windows behavior.
+- `tests/test_semantic_layer_service.py`
+  - simulate Windows by temporarily removing `os.O_NOFOLLOW` and verify export
+    creates valid UTF-8 JSON;
+  - where `O_NOFOLLOW` exists, verify a symlink output path is rejected and its
+    target remains unchanged;
+  - retain the existing content and POSIX permission checks.
+- `.github/workflows/ci.yml`
+  - run the focused semantic-layer export regression on the existing
+    `windows-latest` job so the real Windows `os` flags are exercised.
+- `src/keboola_agent_cli/changelog.py`
+  - record the Windows export fix in the next release entry.
+
+## Acceptance criteria
+
+1. Importing/evaluating `write_snapshot_to_file()` on Windows never accesses
+   `os.O_NOFOLLOW` directly.
+2. `kbagent semantic-layer export --output <path>` creates parseable UTF-8 JSON
+   on Windows.
+3. The shared build-output writer follows the same portable path.
+4. POSIX exports still create mode `0o644` files.
+5. On platforms with `O_NOFOLLOW`, a pre-existing symlink at the output path is
+   rejected and the symlink target is not modified.
+6. The regression is tested both by a platform-independent missing-flag unit
+   test and on the existing Windows CI runner.
+7. Focused tests plus lint, format, and type checks pass.
+
+## Validation
+
+Run locally:
+
+```text
+uv run pytest tests/test_semantic_layer_service.py -k "export" -v
+uv run ruff check src/ tests/
+uv run ruff format . --check
+uv run ty check
+```
+
+On `windows-latest`, run the focused export regression against Python 3.12 and
+the built project. Confirm the output contains non-ASCII data without newline
+or encoding corruption.
+
+## Risks
+
+- Windows lacks the exact final-component symlink behavior provided by
+  `O_NOFOLLOW`. This PR preserves the strongest protection Python exposes
+  through the current low-level API on each platform and documents the gap.
+- CI workflow time increases slightly from one focused pytest invocation; the
+  existing Windows dependency/build setup is reused.

--- a/docs/superpowers/specs/2026-07-23-issue-529-windows-semantic-layer-export-design.md
+++ b/docs/superpowers/specs/2026-07-23-issue-529-windows-semantic-layer-export-design.md
@@ -1,7 +1,7 @@
 # Design: Make semantic-layer snapshot export portable to Windows
 
-**Issue:** [#529](https://github.com/keboola/cli/issues/529)  
-**Status:** Proposed  
+**Issue:** [#529](https://github.com/keboola/cli/issues/529)
+**Status:** Proposed
 **Target:** `kbagent semantic-layer export` and every shared snapshot writer
 
 ## Problem

--- a/src/keboola_agent_cli/services/_semantic_layer_internals.py
+++ b/src/keboola_agent_cli/services/_semantic_layer_internals.py
@@ -1059,16 +1059,21 @@ def build_export_snapshot(
 
 
 def write_snapshot_to_file(snapshot: dict[str, Any], output_path: Path) -> None:
-    """Atomic-write a JSON snapshot with 0o644 perms and O_NOFOLLOW.
+    """Write a JSON snapshot with 0o644 permissions where supported.
 
-    O_NOFOLLOW refuses to follow a pre-existing symlink at the chosen
-    path so a malicious --output (or a planted symlink in CWD) cannot
-    redirect the write to a sensitive file.
+    On platforms that expose ``O_NOFOLLOW``, reject a pre-existing symlink at
+    the output path so a malicious ``--output`` (or a planted symlink in the
+    current directory) cannot redirect the write to a sensitive file. Windows
+    does not provide that flag through :mod:`os`; its portable flags still
+    write the encoded JSON bytes without text-mode newline translation.
     """
     payload = json.dumps(snapshot, indent=2).encode("utf-8")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    flags |= getattr(os, "O_BINARY", 0)
     fd = os.open(
         str(output_path),
-        os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+        flags,
         0o644,
     )
     try:

--- a/tests/test_semantic_layer_service.py
+++ b/tests/test_semantic_layer_service.py
@@ -12,6 +12,7 @@ without touching HTTP. The pattern mirrors ``test_data_app_service.py``.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -796,7 +797,9 @@ class TestValidateDeep:
 
 
 class TestExportModel:
-    def _setup(self, tmp_path: Path) -> tuple[SemanticLayerService, MagicMock]:
+    def _setup(
+        self, tmp_path: Path, *, glossary_term: str = "GMV"
+    ) -> tuple[SemanticLayerService, MagicMock]:
         store = _make_store(tmp_path)
         service, mock = _make_service(store)
 
@@ -814,7 +817,7 @@ class TestExportModel:
             if item_type == "semantic-constraint":
                 return [_child_item("semantic-constraint", "c1", {"name": "c_warning"})]
             if item_type == "semantic-glossary":
-                return [_child_item("semantic-glossary", "g1", {"term": "GMV"})]
+                return [_child_item("semantic-glossary", "g1", {"term": glossary_term})]
             return []
 
         mock.list_items.side_effect = _list
@@ -843,6 +846,34 @@ class TestExportModel:
         payload = json.loads(out_path.read_text())
         assert payload["datasets"][0]["id"] == "d1"
         assert payload["model"]["id"] == "U"
+
+    def test_export_writes_utf8_json_without_o_nofollow(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Windows lacks O_NOFOLLOW but must still write the export snapshot."""
+        service, _ = self._setup(tmp_path, glossary_term="Žluťoučký")
+        out_path = tmp_path / "windows-export.json"
+        monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+
+        service.export_model("prod", output_path=out_path)
+
+        payload = json.loads(out_path.read_text(encoding="utf-8"))
+        assert payload["glossary"][0]["attributes"]["term"] == "Žluťoučký"
+
+    @pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="requires POSIX O_NOFOLLOW")
+    def test_export_rejects_existing_symlink_output_path(self, tmp_path: Path) -> None:
+        """POSIX exports must not follow a symlink planted at the output path."""
+        service, _ = self._setup(tmp_path)
+        target = tmp_path / "target.json"
+        target.write_text("unchanged", encoding="utf-8")
+        output_path = tmp_path / "symlink.json"
+        output_path.symlink_to(target)
+
+        with pytest.raises(OSError):
+            service.export_model("prod", output_path=output_path)
+
+        assert output_path.is_symlink()
+        assert target.read_text(encoding="utf-8") == "unchanged"
 
     def test_export_default_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         service, _ = self._setup(tmp_path)

--- a/tests/test_semantic_layer_service.py
+++ b/tests/test_semantic_layer_service.py
@@ -839,9 +839,11 @@ class TestExportModel:
         out_path = tmp_path / "snap.json"
         service.export_model("prod", output_path=out_path)
         assert out_path.is_file()
-        # Permissions: world-readable per spec
-        mode = out_path.stat().st_mode & 0o777
-        assert mode == 0o644
+        # Windows ignores os.open's numeric mode; POSIX keeps the documented
+        # world-readable permission contract.
+        if os.name != "nt":
+            mode = out_path.stat().st_mode & 0o777
+            assert mode == 0o644
         # Content is valid JSON with expected keys
         payload = json.loads(out_path.read_text())
         assert payload["datasets"][0]["id"] == "d1"


### PR DESCRIPTION
# Design: Make semantic-layer snapshot export portable to Windows

**Issue:** [#529](https://github.com/keboola/cli/issues/529)  
**Status:** Proposed  
**Target:** `kbagent semantic-layer export` and every shared snapshot writer

## Problem

`write_snapshot_to_file()` builds its `os.open()` flags with
`os.O_NOFOLLOW`. That flag is available on POSIX platforms but is not defined
by Python's `os` module on Windows. Evaluating the flags therefore raises
`AttributeError` before the output file is opened.

The helper is shared by semantic-layer export and the optional build output
path, so the portability bug affects more than one command even though export
is the reported reproducer.

## Goals

- Make snapshot writes work on Windows without weakening the existing POSIX
  symlink protection.
- Continue writing UTF-8 JSON bytes with deterministic line endings.
- Preserve the current `0o644` permissions contract on POSIX.
- Cover both the Windows-compatible path and the POSIX hardening path with
  regression tests.

## Non-goals

- Add Windows ACL management; the numeric mode argument is intentionally
  ignored by Windows.
- Guarantee protection against every Windows reparse-point race. Python does
  not expose a direct `O_NOFOLLOW` equivalent through `os.open`.
- Change the snapshot schema, export result, default filename, or CLI output.

## Design

Build the flags incrementally from portable flags:

```python
flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
flags |= getattr(os, "O_NOFOLLOW", 0)
flags |= getattr(os, "O_BINARY", 0)
```

- On POSIX, `O_NOFOLLOW` remains active and a pre-existing final-component
  symlink is rejected.
- On Windows, the unavailable flag contributes zero, so `os.open()` succeeds.
- `O_BINARY` is a no-op where unavailable and prevents Windows text-mode
  newline translation because the helper writes an already encoded byte
  payload with `os.write()`.

Keep the descriptor lifecycle in the existing `try/finally`; do not replace it
with a text-mode `Path.write_text()` call, which would discard the POSIX
hardening and change the low-level write contract.

Update the docstring to describe conditional `O_NOFOLLOW` protection rather
than implying that every platform provides it.

## Implementation map

- `src/keboola_agent_cli/services/_semantic_layer_internals.py`
  - construct portable open flags with guarded platform-specific additions;
  - document POSIX and Windows behavior.
- `tests/test_semantic_layer_service.py`
  - simulate Windows by temporarily removing `os.O_NOFOLLOW` and verify export
    creates valid UTF-8 JSON;
  - where `O_NOFOLLOW` exists, verify a symlink output path is rejected and its
    target remains unchanged;
  - retain the existing content and POSIX permission checks.
- `.github/workflows/ci.yml`
  - run the focused semantic-layer export regression on the existing
    `windows-latest` job so the real Windows `os` flags are exercised.
- `src/keboola_agent_cli/changelog.py`
  - record the Windows export fix in the next release entry.

## Acceptance criteria

1. Importing/evaluating `write_snapshot_to_file()` on Windows never accesses
   `os.O_NOFOLLOW` directly.
2. `kbagent semantic-layer export --output <path>` creates parseable UTF-8 JSON
   on Windows.
3. The shared build-output writer follows the same portable path.
4. POSIX exports still create mode `0o644` files.
5. On platforms with `O_NOFOLLOW`, a pre-existing symlink at the output path is
   rejected and the symlink target is not modified.
6. The regression is tested both by a platform-independent missing-flag unit
   test and on the existing Windows CI runner.
7. Focused tests plus lint, format, and type checks pass.

## Validation

Run locally:

```text
uv run pytest tests/test_semantic_layer_service.py -k "export" -v
uv run ruff check src/ tests/
uv run ruff format . --check
uv run ty check
```

On `windows-latest`, run the focused export regression against Python 3.12 and
the built project. Confirm the output contains non-ASCII data without newline
or encoding corruption.

## Risks

- Windows lacks the exact final-component symlink behavior provided by
  `O_NOFOLLOW`. This PR preserves the strongest protection Python exposes
  through the current low-level API on each platform and documents the gap.
- CI workflow time increases slightly from one focused pytest invocation; the
  existing Windows dependency/build setup is reused.
