### PR TITLE
chore(release): 0.76.2 Windows update and export fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.76.1",
+      "version": "0.76.2",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -664,6 +664,9 @@ kbagent update [--beta]
 # source build; falls back to git+ when absent). Env `KBAGENT_UPDATE_TIMEOUT` (integer
 # seconds, default 300) raises the self-update subprocess timeout for the slow git+
 # fallback on WSL. Bootstrap install: `curl -LsSf .../main/install.sh | sh`.
+# Since 0.76.2 self-update completes discovery first, updates MCP before the terminal
+# exact-version full kbagent reinstall, then immediately re-executes; failures print a
+# copy-paste recovery command.
 kbagent changelog [--limit N] [--full]
 # Default shows a one-line summary (first sentence) per version; --full / -v expands every note.
 kbagent serve [--host HOST] [--port PORT] [--ui] [--ui-dist PATH] [--reload] [--log-level LVL] [--cors-origin ORIGIN] [--config-dir DIR]

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.76.1",
+  "version": "0.76.2",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -960,11 +960,17 @@ events and emits a final `done` SSE frame mirroring the same record.
   schema is missing fields (e.g. `configuration_row_ids` added in MCP v1.55.0)
   and `kbagent --json tool list` reports the stale schema with no warning.
   Reported in #243 -- a real user hit this with MCP v1.49.0 (six minors behind).
-- Since v0.30.1: `kbagent` startup runs a two-stage auto-update -- (1) kbagent
-  itself, (2) `keboola-mcp-server`. The MCP stage detects the install method
+- Since v0.30.1: `kbagent` startup runs a two-stage auto-update for kbagent
+  itself and `keboola-mcp-server`. The MCP stage detects the install method
   (`uv_tool` / `pip_env` / `uvx`) and runs the matching upgrade command
   (`uv tool upgrade` / `pip install -U` / `uvx --refresh`). No re-exec needed
   for the MCP path -- the next `tool call` spawn picks up the new version.
+- Since v0.76.2 (#528/#530), both updates are fully planned before anything is
+  mutated. MCP is upgraded first; a pending kbagent self-update is the terminal
+  mutation and uses an exact-version full reinstall (`uv tool install --force
+  --reinstall` for uv tools), then immediately re-executes the original command.
+  A failed or timed-out reinstall prints a copy-paste recovery command. Do not
+  run discovery or another update stage after the kbagent reinstall starts.
 - Since v0.43.8: every MCP install/upgrade command carries `--prerelease=allow`
   (uv) / `--pre` (pip). `keboola-mcp-server >= 1.55.0` pins a pre-release-only
   transitive dep (`toon-format~=0.9.0b1`); without the opt-in uv backtracks to
@@ -2099,14 +2105,16 @@ Update all references in the code that creates and uses the renamed table.
 
 ## Auto-update
 
-kbagent automatically checks for updates on every invocation. When a newer version
-is available on PyPI, it installs the update and re-executes the same command
-seamlessly. This is transparent -- no user action required.
+kbagent automatically checks for updates on every invocation. When a newer stable
+GitHub Release is available, it prefers the release wheel, performs a full
+exact-version reinstall, and re-executes the same command seamlessly. This is
+transparent -- no user action is normally required.
 
 - Opt-out: `KBAGENT_AUTO_UPDATE=false`
-- Version cache: checks PyPI at most once per hour
+- Version cache: checks the release endpoints at most once per hour
 - Skipped for: dev/editable installs, `update`/`version` commands
-- Never crashes the CLI -- update failures are silently ignored
+- Never crashes the CLI -- update failures leave the current invocation running
+  and print a recovery command (since v0.76.2)
 
 ## `lineage build` and sync layouts
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-cli"
-version = "0.76.1"
+version = "0.76.2"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -24,6 +24,20 @@ from .constants import CHANGELOG_HEADLINE_MAX_CHARS
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.76.2": [
+        "Fix (#528, #530): self-update no longer risks leaving the running Windows uv tool "
+        "environment partially upgraded. kbagent now completes all network checks and command "
+        "planning before mutation, upgrades the independent keboola-mcp-server environment "
+        "first, caches the result, then performs an exact-version full reinstall as the terminal "
+        "step and immediately re-executes. Failed or timed-out updates print a copy-paste recovery "
+        "command instead of continuing without repair guidance. Thanks to @papousek-radan for "
+        "the detailed corruption reports.",
+        "Fix (#529, #531): `kbagent semantic-layer export` now writes snapshots on Windows. "
+        "The writer conditionally enables platform-specific `O_NOFOLLOW` and `O_BINARY` flags, "
+        "so Windows no longer raises `AttributeError` while POSIX keeps its existing final-path "
+        "symlink protection; the real Windows export path is covered by CI. Thanks to "
+        "@papousek-radan for the report.",
+    ],
     "0.76.1": [
         "Fix (#522, #526): `kbagent serve --ui` no longer crashes on startup on Windows "
         "consoles with a non-UTF-8 codepage (cp1250 on Czech/Polish/Hungarian Windows). The "

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "keboola-cli"
-version = "0.76.1"
+version = "0.76.2"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Release 0.76.2

Patch release for the two Windows issues reported by @papousek-radan:

- #530 / #528 — make self-update terminal, exact-version, and recoverable so a
  live Windows uv tool environment is not left partially upgraded.
- #531 / #529 — make semantic-layer snapshot export portable to Windows while
  retaining POSIX final-path symlink protection.

## Release notes

- **Fix (#528, #530):** self-update no longer risks leaving the running Windows
  uv tool environment partially upgraded. kbagent now completes all network
  checks and command planning before mutation, upgrades the independent
  keboola-mcp-server environment first, caches the result, then performs an
  exact-version full reinstall as the terminal step and immediately re-executes.
  Failed or timed-out updates print a copy-paste recovery command instead of
  continuing without repair guidance.
- **Fix (#529, #531):** `kbagent semantic-layer export` now writes snapshots on
  Windows. The writer conditionally enables platform-specific `O_NOFOLLOW` and
  `O_BINARY` flags, so Windows no longer raises `AttributeError` while POSIX
  keeps its existing final-path symlink protection; the real Windows export
  path is covered by CI.

## Release checklist

- [x] `pyproject.toml` bumped to `0.76.2`
- [x] changelog entry added; generated release notes reviewed
- [x] `make version-sync`
- [x] `make skill-gen` (idempotent; no SKILL.md diff)
- [x] agent/plugin silent-drift review
- [x] `make check`
- [ ] live E2E — credentials are not configured in this environment; neither
  fix changes a remote Keboola API contract, and both merged PRs have focused
  regression tests including a real `windows-latest` export job

Validation:

- `make check`: 4,672 passed, 8 skipped, 132 deselected
- focused update/export suite: 350 passed
- all 43 published stable releases have changelog entries

Plugin/release files touched:

- `.claude-plugin/marketplace.json`
- `plugins/kbagent/.claude-plugin/plugin.json`
- `plugins/kbagent/skills/kbagent/references/gotchas.md`
- `CLAUDE.md`
- `uv.lock`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->