### PR TITLE
fix(deps): drop removed Typer all extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     { name = "Keboola", email = "dev@keboola.com" },
 ]
 dependencies = [
-    "typer[all]>=0.12",
+    "typer>=0.12",
     "rich>=13",
     "httpx>=0.27",
     "pydantic>=2.5",

--- a/uv.lock
+++ b/uv.lock
@@ -645,7 +645,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6" },
     { name = "rich", specifier = ">=13" },
     { name = "sse-starlette", marker = "extra == 'server'", specifier = ">=2.1" },
-    { name = "typer", extras = ["all"], specifier = ">=0.12" },
+    { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.30" },
 ]
 provides-extras = ["server"]


### PR DESCRIPTION
## Summary

- remove the obsolete `all` extra from the direct Typer dependency
- keep the existing version floor and resolved dependency graph unchanged
- eliminate the installer warning reported during Windows verification of #528

## Validation

- `uv lock --check`
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->