### PR TITLE
chore(release): 0.77.0 -- config --change-description

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.76.3",
+      "version": "0.77.0",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.76.3",
+  "version": "0.77.0",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -124,6 +124,28 @@ Versioning convention:
   the credential -- config version history keeps the old plaintext. Read-only,
   no API call.
 
+## `--change-description` is the version audit line; `--description` is the display name (since v0.77.0, #505)
+
+- **Two different fields, similar names.** `config update` / `config row-update`
+  accept both. `--description` overwrites the configuration's **display
+  description** (the text shown in the UI, persisted on the config itself).
+  `--change-description` writes the **new version's `changeDescription`** -- the
+  one-line "why" in version history. Passing the wrong one either clobbers a
+  description someone wrote, or buries the reason for the change.
+- **Omitting it is safe.** Without the flag kbagent keeps the previous
+  auto-generated default verbatim (`Updated metadata + configuration via kbagent
+  config update`), so existing callers see no behavior change.
+- **`--dry-run` echoes it.** The dry-run result carries `change_description`
+  (JSON) / a `changeDescription:` line (human), so the audit text can be
+  reviewed before the write -- unlike the version number, which does not exist
+  until the PUT lands.
+- **Read it back from the config, not a version list.** `config detail` returns
+  the current version's `changeDescription` at the top level; there is no
+  `config versions` command.
+- **Not available on creates.** `config new`, `config row-create`, `flow new`,
+  and `flow update` do NOT take the flag -- their client methods have no such
+  parameter yet. Only the two update paths are covered.
+
 ## `config create/update` + rows auto-encrypt `#`-prefixed secrets before write (since v0.54.0, closes #378)
 
 - **Before v0.54.0 this was a plaintext leak.** `config new --push`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-cli"
-version = "0.76.3"
+version = "0.77.0"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -24,6 +24,17 @@ from .constants import CHANGELOG_HEADLINE_MAX_CHARS
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.77.0": [
+        "New (#505): `kbagent config update` and `kbagent config row-update` accept "
+        "`--change-description TEXT`, which writes the new config version's "
+        "`changeDescription` -- the version-history audit line -- instead of the generic "
+        "auto-generated default. On shared production configs that history is the paper "
+        "trail, so a change can now say *why* it happened. Omitting the flag preserves the "
+        "previous default verbatim, and `--dry-run` echoes the description that would be "
+        "sent (`change_description` in `--json`). Note this is distinct from `--description`, "
+        "which sets the configuration's display description. Both `kbagent serve` PATCH "
+        "routes mirror the flag. Thanks to @jordanrburger.",
+    ],
     "0.76.3": [
         "Security: bump npm dependencies flagged by Dependabot in `web/backend` and "
         "`web/frontend` -- `@fastify/static` (path traversal / auth bypass), "

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "keboola-cli"
-version = "0.76.3"
+version = "0.77.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Release commit for **0.77.0**, whose only functional content is #505 (`--change-description` on `config update` / `config row-update`). `main` was exactly at `v0.76.3` before #505 landed, so nothing else needs changelog coverage.

## Release checklist (CONTRIBUTING > "Releasing a new version")

| # | Step | State |
|---|---|---|
| 1 | `pyproject.toml` -> `0.77.0` | done |
| 2 | Changelog entry | done |
| 3 | `make version-sync` | done (`plugin.json`, `marketplace.json`, `uv.lock`) |
| 4 | `make skill-gen` | no-op -- #505 added a *flag*, not a command, so the decision table is unchanged |
| 5 | Review `keboola-expert.md` | done in #505 (see below) |
| 6 | Review `gotchas.md` | **new entry** (see below) |
| 7 | Review `CLAUDE.md` command list | done in #505 |
| 8 | Review `commands-reference.md` | done in #505 |
| 9 | `make check` | green -- 4683 passed, 8 skipped |
| 10 | `make test-e2e` | **not run here** -- needs `E2E_API_TOKEN` / `E2E_URL` |

## Plugin files touched

- `plugins/kbagent/skills/kbagent/references/gotchas.md` -- new `(since v0.77.0)` entry for `--change-description` vs `--description`. The names are similar and the targets are not: one writes the version-history audit line, the other overwrites the configuration's display description. That is precisely the confusion an agent cannot infer from `--help`, and picking the wrong one silently clobbers someone's description.
- `plugins/kbagent/agents/keboola-expert.md` -- already updated in #505: the data-app secret-removal row no longer claims MCP `tool call update_config` is the only route to a custom change description (it was, until this release), and the canonical §4.2 "Safe config update" recipe now carries the flag. Both gated `(0.77.0+)` per Rule 6.

## Notes for the reviewer

- Step 10 is the real gap: E2E is not part of CI and the nightly run has been failing on an expired secret since 2026-06-27 (#518), so the `config update --change-description` E2E path added in #505 is currently unexercised against a live project.
- After merge: tag `v0.77.0` to trigger `release-kbagent.yml` (freeze, sign, package, GitHub Release); `release.yml` then attaches the wheel on publish.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->