### PR TITLE
fix(output): write --json as UTF-8 regardless of the console codepage (#546)

### DIFF
--- a/src/keboola_agent_cli/commands/agent.py
+++ b/src/keboola_agent_cli/commands/agent.py
@@ -23,7 +23,7 @@ from typing import Any
 import typer
 
 from ..errors import ConfigError, ErrorCode
-from ..output import OutputFormatter
+from ..output import OutputFormatter, write_machine_output
 from ..server.agents_store import AgentAction, Trigger
 from ..services.agent_service import AgentService
 from ._helpers import check_cli_permission, get_formatter, get_service
@@ -394,8 +394,11 @@ def _render_stream_event(formatter: OutputFormatter, evt: dict[str, Any]) -> Non
     multi-line summary with exit code, elapsed time, response preview.
     """
     if formatter.json_mode:
-        sys.stdout.write(json.dumps(evt, ensure_ascii=False) + "\n")
-        sys.stdout.flush()
+        # `ensure_ascii=False` keeps the event text readable, which means raw
+        # non-ASCII reaches stdout -- so it must not go through the console's
+        # encoder (issue #546). `write_machine_output` also flushes, which a
+        # stream consumer depends on.
+        write_machine_output(json.dumps(evt, ensure_ascii=False))
         return
     event = evt.get("event", "?")
     data = evt.get("data") or {}

--- a/src/keboola_agent_cli/commands/http_client.py
+++ b/src/keboola_agent_cli/commands/http_client.py
@@ -16,12 +16,12 @@ of :mod:`keboola_agent_cli.services.http_forwarder_service`.
 from __future__ import annotations
 
 import json
-import sys
 from typing import Any
 
 import typer
 
 from ..constants import HTTP_DEFAULT_TIMEOUT
+from ..output import write_machine_output
 from ..services.http_forwarder_service import (
     ForwardedResponse,
     ForwarderError,
@@ -41,15 +41,20 @@ http_app = typer.Typer(
 def _print_json(_console: Any, data: Any) -> None:
     """Human-mode renderer: pipe-safe pretty JSON.
 
-    Uses ``sys.stdout.write`` instead of ``console.print`` because Rich
-    can soft-wrap long strings or escape markup, which breaks downstream
+    Writes straight to stdout instead of ``console.print`` because Rich can
+    soft-wrap long strings or escape markup, which breaks downstream
     ``json.loads`` consumers. Real-world case: an AI agent piped
     ``kbagent http get /openapi.json`` into ``python3 -c "json.load(sys.stdin)"``
     and hit ``JSONDecodeError`` because Rich had reflowed lines. The output
     of ``kbagent http`` is virtually always parsed by something downstream
     (an LLM, a script, jq) -- so machine-clean stdout is the contract.
+
+    Through :func:`write_machine_output` so that contract also survives a
+    non-UTF-8 console (issue #546). ``json.dumps`` escapes non-ASCII under its
+    ``ensure_ascii`` default, so this path cannot crash today; it uses the
+    helper so it stays correct if that default is ever dropped.
     """
-    sys.stdout.write(json.dumps(data, indent=2) + "\n")
+    write_machine_output(json.dumps(data, indent=2))
 
 
 def _resolve_service(ctx: typer.Context) -> HttpForwarderService:

--- a/src/keboola_agent_cli/output.py
+++ b/src/keboola_agent_cli/output.py
@@ -14,6 +14,33 @@ from rich.text import Text
 from .models import ErrorResponse, SuccessResponse
 
 
+def write_machine_output(text: str) -> None:
+    """Write a machine-readable line to stdout as UTF-8, whatever the console is.
+
+    ``--json`` exists to be piped into another program, so its bytes must not
+    depend on the terminal's active codepage. On a default Czech / Polish /
+    Hungarian Windows console (cp1250), ``sys.stdout.write`` raised
+    ``UnicodeEncodeError`` on any non-ASCII character in the payload -- an arrow
+    in a flow name was enough to make ``kbagent --json flow list`` unusable
+    (issue #546). Pydantic's ``model_dump_json`` emits raw non-ASCII, unlike
+    ``json.dumps``, whose ``ensure_ascii`` default escapes it away.
+
+    Writing through ``sys.stdout.buffer`` bypasses the text layer's encoder
+    entirely, so the codepage never gets a say. The text layer is flushed first
+    so anything already written through it keeps its place in the stream. A
+    stdout with no binary buffer (captured or replaced streams) has no encoder
+    to bypass, so the plain write is already correct there.
+    """
+    payload = text + "\n"
+    buffer = getattr(sys.stdout, "buffer", None)
+    if buffer is None:
+        sys.stdout.write(payload)
+        return
+    sys.stdout.flush()
+    buffer.write(payload.encode("utf-8"))
+    buffer.flush()
+
+
 class OutputFormatter:
     """Formats CLI output as either JSON (for machines/agents) or Rich (for humans).
 
@@ -54,7 +81,7 @@ class OutputFormatter:
         """
         if self.json_mode:
             response = SuccessResponse(status="ok", data=data)
-            sys.stdout.write(response.model_dump_json(indent=2) + "\n")
+            write_machine_output(response.model_dump_json(indent=2))
         else:
             if human_formatter is not None:
                 human_formatter(self.console, data)
@@ -99,7 +126,7 @@ class OutputFormatter:
                 "status": "error",
                 "error": err.model_dump(exclude_none=True),
             }
-            sys.stdout.write(json.dumps(error_envelope, indent=2) + "\n")
+            write_machine_output(json.dumps(error_envelope, indent=2))
         else:
             self.err_console.print(f"[bold red]Error:[/bold red] {message}")
 
@@ -111,7 +138,7 @@ class OutputFormatter:
         """
         if self.json_mode:
             response = SuccessResponse(status="ok", data={"message": message})
-            sys.stdout.write(response.model_dump_json(indent=2) + "\n")
+            write_machine_output(response.model_dump_json(indent=2))
         else:
             self.console.print(f"[bold green]Success:[/bold green] {message}")
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -3,9 +3,11 @@
 import io
 import json
 import sys
+from collections.abc import Callable
 from io import StringIO
 from typing import cast
 
+import pytest
 from rich.console import Console
 
 from keboola_agent_cli.output import (
@@ -1100,14 +1102,16 @@ class TestMachineOutputIsAlwaysUtf8:
         """A stdout whose text layer cannot encode the payload, like cp1250."""
         return io.TextIOWrapper(io.BytesIO(), encoding="cp1250", newline="")
 
-    def _capture(self, monkeypatch, action) -> bytes:
+    def _capture(self, monkeypatch: pytest.MonkeyPatch, action: Callable[[], None]) -> bytes:
         stream = self._cp1250_stdout()
         monkeypatch.setattr(sys, "stdout", stream)
         action()
         stream.flush()
         return cast(io.BytesIO, stream.buffer).getvalue()
 
-    def test_output_survives_a_codepage_that_cannot_encode_the_data(self, monkeypatch) -> None:
+    def test_output_survives_a_codepage_that_cannot_encode_the_data(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         formatter = OutputFormatter(json_mode=True)
 
         written = self._capture(monkeypatch, lambda: formatter.output({"name": self.ARROW_NAME}))
@@ -1115,14 +1119,14 @@ class TestMachineOutputIsAlwaysUtf8:
         # Bytes are UTF-8 and round-trip, rather than being lost or escaped.
         assert json.loads(written.decode("utf-8"))["data"]["name"] == self.ARROW_NAME
 
-    def test_success_survives_it_too(self, monkeypatch) -> None:
+    def test_success_survives_it_too(self, monkeypatch: pytest.MonkeyPatch) -> None:
         formatter = OutputFormatter(json_mode=True)
 
         written = self._capture(monkeypatch, lambda: formatter.success(self.ARROW_NAME))
 
         assert json.loads(written.decode("utf-8"))["data"]["message"] == self.ARROW_NAME
 
-    def test_error_survives_it_too(self, monkeypatch) -> None:
+    def test_error_survives_it_too(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Passes pre-fix too -- `json.dumps` escapes the arrow away.
 
         Kept as the guard on the invariant: it starts failing the moment the
@@ -1136,7 +1140,9 @@ class TestMachineOutputIsAlwaysUtf8:
 
         assert self.ARROW_NAME in json.loads(written.decode("utf-8"))["error"]["message"]
 
-    def test_a_text_stream_without_a_binary_buffer_still_works(self, monkeypatch) -> None:
+    def test_a_text_stream_without_a_binary_buffer_still_works(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Captured/replaced stdout has no encoder to bypass -- write plainly."""
         stream = StringIO()
         monkeypatch.setattr(sys, "stdout", stream)
@@ -1145,7 +1151,9 @@ class TestMachineOutputIsAlwaysUtf8:
 
         assert stream.getvalue() == '{"ok": true}\n'
 
-    def test_human_mode_output_written_earlier_keeps_its_place(self, monkeypatch) -> None:
+    def test_human_mode_output_written_earlier_keeps_its_place(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Flushing the text layer first stops the two writers reordering."""
         stream = self._cp1250_stdout()
         monkeypatch.setattr(sys, "stdout", stream)
@@ -1155,3 +1163,44 @@ class TestMachineOutputIsAlwaysUtf8:
         stream.flush()
 
         assert cast(io.BytesIO, stream.buffer).getvalue() == b"first\nsecond\n"
+
+
+class TestStreamedAgentEventsAreUtf8:
+    """`--json ... --stream` writes NDJSON of its own, outside OutputFormatter.
+
+    `_render_stream_event` builds each line with `json.dumps(..., ensure_ascii
+    =False)` -- deliberately, so event text stays readable -- which means raw
+    non-ASCII reaches stdout. That is precisely the property that crashes on a
+    cp1250 console, so this path needs the same UTF-8 write as the formatter
+    (issue #546).
+    """
+
+    def test_event_with_non_ascii_does_not_crash_on_a_cp1250_console(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from keboola_agent_cli.commands.agent import _render_stream_event
+
+        stream = io.TextIOWrapper(io.BytesIO(), encoding="cp1250", newline="")
+        monkeypatch.setattr(sys, "stdout", stream)
+        formatter = OutputFormatter(json_mode=True)
+
+        _render_stream_event(formatter, {"event": "log", "data": {"msg": "načítám → hotovo"}})
+        stream.flush()
+
+        written = cast(io.BytesIO, stream.buffer).getvalue()
+        assert json.loads(written.decode("utf-8"))["data"]["msg"] == "načítám → hotovo"
+
+    def test_each_event_is_flushed_so_consumers_see_it_immediately(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stream consumer reads line by line; buffering would stall it."""
+        from keboola_agent_cli.commands.agent import _render_stream_event
+
+        stream = io.TextIOWrapper(io.BytesIO(), encoding="cp1250", newline="")
+        monkeypatch.setattr(sys, "stdout", stream)
+        formatter = OutputFormatter(json_mode=True)
+
+        _render_stream_event(formatter, {"event": "init", "data": {}})
+
+        # Readable without an explicit flush by the test.
+        assert cast(io.BytesIO, stream.buffer).getvalue().endswith(b"\n")

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,5 +1,6 @@
 """Tests for OutputFormatter with JSON and Rich dual mode."""
 
+import io
 import json
 import sys
 from io import StringIO
@@ -20,6 +21,7 @@ from keboola_agent_cli.output import (
     format_query_results,
     format_tool_result,
     format_tools_table,
+    write_machine_output,
 )
 
 
@@ -1074,3 +1076,82 @@ class TestFormatQueryResults:
         assert "Results:" in output
         assert "id,name" in output
         assert "alice" in output
+
+
+class TestMachineOutputIsAlwaysUtf8:
+    """`--json` must not depend on the console codepage (issue #546).
+
+    On a default Czech/Polish/Hungarian Windows console (cp1250) a single
+    non-ASCII character in the data -- an arrow in a flow name was the real
+    report -- made `kbagent --json flow list` raise UnicodeEncodeError instead
+    of printing JSON. The codepage is simulated here, so these run everywhere.
+
+    Only the two pydantic paths reproduce the crash: `model_dump_json` emits
+    raw non-ASCII, whereas `json.dumps` escapes it to `\\uXXXX` under its
+    `ensure_ascii` default. The `error()` test below therefore pins the
+    invariant rather than the bug -- it is what fails if anyone later turns
+    `ensure_ascii` off.
+    """
+
+    ARROW_NAME = "extract → transform"
+
+    @staticmethod
+    def _cp1250_stdout() -> io.TextIOWrapper:
+        """A stdout whose text layer cannot encode the payload, like cp1250."""
+        return io.TextIOWrapper(io.BytesIO(), encoding="cp1250", newline="")
+
+    def _capture(self, monkeypatch, action) -> bytes:
+        stream = self._cp1250_stdout()
+        monkeypatch.setattr(sys, "stdout", stream)
+        action()
+        stream.flush()
+        return cast(io.BytesIO, stream.buffer).getvalue()
+
+    def test_output_survives_a_codepage_that_cannot_encode_the_data(self, monkeypatch) -> None:
+        formatter = OutputFormatter(json_mode=True)
+
+        written = self._capture(monkeypatch, lambda: formatter.output({"name": self.ARROW_NAME}))
+
+        # Bytes are UTF-8 and round-trip, rather than being lost or escaped.
+        assert json.loads(written.decode("utf-8"))["data"]["name"] == self.ARROW_NAME
+
+    def test_success_survives_it_too(self, monkeypatch) -> None:
+        formatter = OutputFormatter(json_mode=True)
+
+        written = self._capture(monkeypatch, lambda: formatter.success(self.ARROW_NAME))
+
+        assert json.loads(written.decode("utf-8"))["data"]["message"] == self.ARROW_NAME
+
+    def test_error_survives_it_too(self, monkeypatch) -> None:
+        """Passes pre-fix too -- `json.dumps` escapes the arrow away.
+
+        Kept as the guard on the invariant: it starts failing the moment the
+        error envelope stops escaping non-ASCII.
+        """
+        formatter = OutputFormatter(json_mode=True)
+
+        written = self._capture(
+            monkeypatch, lambda: formatter.error(self.ARROW_NAME, error_code="ERROR")
+        )
+
+        assert self.ARROW_NAME in json.loads(written.decode("utf-8"))["error"]["message"]
+
+    def test_a_text_stream_without_a_binary_buffer_still_works(self, monkeypatch) -> None:
+        """Captured/replaced stdout has no encoder to bypass -- write plainly."""
+        stream = StringIO()
+        monkeypatch.setattr(sys, "stdout", stream)
+
+        write_machine_output('{"ok": true}')
+
+        assert stream.getvalue() == '{"ok": true}\n'
+
+    def test_human_mode_output_written_earlier_keeps_its_place(self, monkeypatch) -> None:
+        """Flushing the text layer first stops the two writers reordering."""
+        stream = self._cp1250_stdout()
+        monkeypatch.setattr(sys, "stdout", stream)
+
+        sys.stdout.write("first\n")
+        write_machine_output("second")
+        stream.flush()
+
+        assert cast(io.BytesIO, stream.buffer).getvalue() == b"first\nsecond\n"


### PR DESCRIPTION
Fixes #546.

## The bug

`kbagent --json flow list` crashed with `UnicodeEncodeError` on a default
Czech/Polish/Hungarian Windows console (cp1250) whenever the output contained a
non-ASCII character. An arrow in a flow name was enough:

```
File "keboola_agent_cli/output.py", line 57, in output
    sys.stdout.write(response.model_dump_json(indent=2) + "\n")
UnicodeEncodeError: 'charmap' codec can't encode character '→'
```

`--json` exists to be piped into another program, so its bytes must not depend on the
terminal's active codepage.

## Which writer actually crashes

Worth being precise, because it decides what the tests are worth:

| Writer | Non-ASCII handling | Crashes on cp1250 |
|---|---|---|
| `response.model_dump_json()` (pydantic) — `output()`, `success()` | emits raw UTF-8 | **yes** |
| `json.dumps(..., indent=2)` — `error()` | escapes to `\uXXXX` (`ensure_ascii` default) | no |

So only the two pydantic paths reproduce the report. The error envelope is routed
through the same helper anyway for consistency, and its test says so plainly rather
than posing as a regression test for a bug it cannot hit.

## The fix

One `write_machine_output` helper behind all three call sites. It writes UTF-8 through
`sys.stdout.buffer`, bypassing the text layer's encoder entirely, so the codepage never
gets a say. The text layer is flushed first so anything already written through it keeps
its place in the stream; a stdout with no binary buffer (captured or replaced streams,
e.g. under test) has no encoder to bypass and takes the plain write.

Chosen over `sys.stdout.reconfigure(encoding="utf-8")` because reconfigure is not
available on every stream kind the CLI runs under, and over `PYTHONUTF8=1` because the
reporter should not have to set an environment variable to get valid JSON.

## Testing

Five tests in `tests/test_output.py::TestMachineOutputIsAlwaysUtf8`. They simulate the
cp1250 encoder with `io.TextIOWrapper(io.BytesIO(), encoding="cp1250")`, so they run on
every platform rather than needing a Windows box.

I verified they are load-bearing by reverting the fix: the two covering the crash
(`output`, `success`) fail with the reporter's exact `UnicodeEncodeError`; the other
three pass either way and are documented as invariant guards, not bug reproductions.

Also covered: the no-binary-buffer fallback, and that a human-mode write issued before a
machine-output write keeps its order (the reason for the flush).

`make check` equivalent is green — ruff, ty, and 4688 tests.

Reproduced end to end through the real CLI as well, not just the formatter. Forcing the
console encoding and asking for output that contains box-drawing characters (the v0.76.1
changelog entry):

```
PYTHONIOENCODING=cp1250 kbagent --json changelog --limit 8 --full
```

- before the fix: `exit=1`, `UnicodeEncodeError: 'charmap' codec can't encode characters
  in position 4481-4482` — the reporter's failure;
- after: `exit=0`, output parses as UTF-8 JSON with `─ └ ├` intact.

(Worth noting for anyone repeating this: a small `--limit` proves nothing here. The most
recent changelog entries happen to be pure ASCII, so the command exits 0 either way.)

## Notes for merge

- **Side effect on Windows:** JSON lines now end `LF` rather than `CRLF`, because the
  binary buffer does no newline translation. For machine-consumed output that is the
  better default and no parser cares, but it is a real behaviour change worth knowing.
- **No version bump or changelog entry**, matching how #530 / #531 landed before the
  #533 release PR bundled them. The line for whichever release picks this up:

  > `Fix (#546): `kbagent --json` no longer crashes with `UnicodeEncodeError` on Windows consoles with a non-UTF-8 codepage (cp1250 on Czech/Polish/Hungarian Windows). Any non-ASCII character in the data — an arrow in a flow name was the report — made machine-readable output unusable, because pydantic's `model_dump_json` emits raw UTF-8 and `sys.stdout` encoded it through the console codepage. JSON is now written as UTF-8 bytes through `sys.stdout.buffer`, independent of the console. The `PYTHONUTF8=1` workaround is no longer needed. Thanks to @MichalProchazka for the report.`

- Independent of #543 (the Windows self-update fix); different subsystem, no overlapping
  files.
