### PR TITLE
chore(release): renumber unreleased 0.77.1 to 0.78.0, log #546

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.77.1",
+      "version": "0.78.0",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.77.1",
+  "version": "0.78.0",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -2138,7 +2138,7 @@ transparent -- no user action is normally required.
 - Never crashes the CLI -- update failures leave the current invocation running
   and print a recovery command (since v0.76.2)
 
-### Windows updates are deferred, not immediate (since v0.77.1)
+### Windows updates are deferred, not immediate (since v0.78.0)
 
 `uv tool install` recreates a tool environment by **removing** it and then
 building a fresh venv at the same path. It is not atomic and has no rollback.
@@ -2164,7 +2164,7 @@ So on Windows kbagent never installs into its own live environment:
 - `KBAGENT_DEFER_UPDATE=1` / `=0` forces the deferred path on or off,
   overriding the platform default.
 
-A slow install is never killed on any platform (also since v0.77.1): the
+A slow install is never killed on any platform (also since v0.78.0): the
 timeout bounds only how long kbagent waits, because terminating uv mid-write
 produces the same half-deleted environment a file lock does. When that happens
 the banner says the install is *still running* and deliberately offers no

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-cli"
-version = "0.77.1"
+version = "0.78.0"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -24,7 +24,15 @@ from .constants import CHANGELOG_HEADLINE_MAX_CHARS
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
-    "0.77.1": [
+    "0.78.0": [
+        "Fix (#546): `kbagent --json` no longer crashes with `UnicodeEncodeError` on Windows "
+        "consoles using a non-UTF-8 codepage (cp1250 on Czech/Polish/Hungarian Windows). Any "
+        "non-ASCII character in the data -- an arrow in a flow name was the report -- made "
+        "machine-readable output unusable, because pydantic's `model_dump_json` emits raw UTF-8 "
+        "and `sys.stdout` then encoded it through the console codepage. All machine output, "
+        "including the `--stream` NDJSON from `kbagent agent run`, is now written as UTF-8 bytes "
+        "independent of the console. The `PYTHONUTF8=1` workaround is no longer needed. JSON "
+        "lines now end LF rather than CRLF on Windows. Thanks to @MichalProchazka for the report.",
         "Fix (#528): the Windows self-update no longer corrupts the uv tool environment. "
         "`uv tool install` recreates a tool environment by REMOVING it and then building a fresh "
         "venv at the same path -- it is not atomic and has no rollback. On POSIX that is harmless, "

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -4,6 +4,7 @@ import io
 import json
 import sys
 from collections.abc import Callable
+from dataclasses import dataclass
 from io import StringIO
 from typing import cast
 
@@ -1080,6 +1081,23 @@ class TestFormatQueryResults:
         assert "alice" in output
 
 
+@dataclass(frozen=True)
+class Cp1250Stdout:
+    """A stdout whose text layer cannot encode non-ASCII, like a cp1250 console.
+
+    `raw` is held directly rather than reached through `text.buffer`, whose
+    declared type (`_WrappedBuffer`) has no `getvalue`.
+    """
+
+    text: io.TextIOWrapper
+    raw: io.BytesIO
+
+    @classmethod
+    def create(cls) -> "Cp1250Stdout":
+        raw = io.BytesIO()
+        return cls(io.TextIOWrapper(raw, encoding="cp1250", newline=""), raw)
+
+
 class TestMachineOutputIsAlwaysUtf8:
     """`--json` must not depend on the console codepage (issue #546).
 
@@ -1097,17 +1115,12 @@ class TestMachineOutputIsAlwaysUtf8:
 
     ARROW_NAME = "extract → transform"
 
-    @staticmethod
-    def _cp1250_stdout() -> io.TextIOWrapper:
-        """A stdout whose text layer cannot encode the payload, like cp1250."""
-        return io.TextIOWrapper(io.BytesIO(), encoding="cp1250", newline="")
-
     def _capture(self, monkeypatch: pytest.MonkeyPatch, action: Callable[[], None]) -> bytes:
-        stream = self._cp1250_stdout()
-        monkeypatch.setattr(sys, "stdout", stream)
+        stdout = Cp1250Stdout.create()
+        monkeypatch.setattr(sys, "stdout", stdout.text)
         action()
-        stream.flush()
-        return cast(io.BytesIO, stream.buffer).getvalue()
+        stdout.text.flush()
+        return stdout.raw.getvalue()
 
     def test_output_survives_a_codepage_that_cannot_encode_the_data(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1155,14 +1168,14 @@ class TestMachineOutputIsAlwaysUtf8:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Flushing the text layer first stops the two writers reordering."""
-        stream = self._cp1250_stdout()
-        monkeypatch.setattr(sys, "stdout", stream)
+        stdout = Cp1250Stdout.create()
+        monkeypatch.setattr(sys, "stdout", stdout.text)
 
         sys.stdout.write("first\n")
         write_machine_output("second")
-        stream.flush()
+        stdout.text.flush()
 
-        assert cast(io.BytesIO, stream.buffer).getvalue() == b"first\nsecond\n"
+        assert stdout.raw.getvalue() == b"first\nsecond\n"
 
 
 class TestStreamedAgentEventsAreUtf8:
@@ -1180,14 +1193,14 @@ class TestStreamedAgentEventsAreUtf8:
     ) -> None:
         from keboola_agent_cli.commands.agent import _render_stream_event
 
-        stream = io.TextIOWrapper(io.BytesIO(), encoding="cp1250", newline="")
-        monkeypatch.setattr(sys, "stdout", stream)
+        stdout = Cp1250Stdout.create()
+        monkeypatch.setattr(sys, "stdout", stdout.text)
         formatter = OutputFormatter(json_mode=True)
 
         _render_stream_event(formatter, {"event": "log", "data": {"msg": "načítám → hotovo"}})
-        stream.flush()
+        stdout.text.flush()
 
-        written = cast(io.BytesIO, stream.buffer).getvalue()
+        written = stdout.raw.getvalue()
         assert json.loads(written.decode("utf-8"))["data"]["msg"] == "načítám → hotovo"
 
     def test_each_event_is_flushed_so_consumers_see_it_immediately(
@@ -1196,11 +1209,11 @@ class TestStreamedAgentEventsAreUtf8:
         """A stream consumer reads line by line; buffering would stall it."""
         from keboola_agent_cli.commands.agent import _render_stream_event
 
-        stream = io.TextIOWrapper(io.BytesIO(), encoding="cp1250", newline="")
-        monkeypatch.setattr(sys, "stdout", stream)
+        stdout = Cp1250Stdout.create()
+        monkeypatch.setattr(sys, "stdout", stdout.text)
         formatter = OutputFormatter(json_mode=True)
 
         _render_stream_event(formatter, {"event": "init", "data": {}})
 
         # Readable without an explicit flush by the test.
-        assert cast(io.BytesIO, stream.buffer).getvalue().endswith(b"\n")
+        assert stdout.raw.getvalue().endswith(b"\n")

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "keboola-cli"
-version = "0.77.1"
+version = "0.78.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Bookkeeping ahead of the 0.78.0 release. No behaviour change.

## Why

**1. #546 has no changelog entry at all.** #549 merged without one, matching how #530 /
#531 landed before their release PR bundled them. That is exactly the failure mode that
left 0.67.0–0.70.1 merged-but-unpublished and undocumented, so the entry is written now
while the change is fresh rather than reconstructed at tag time.

**2. `0.77.1` will never exist.** It is merged into `main` (`pyproject.toml` and a
changelog key) but was never tagged, and the next release is 0.78.0 bundling several PRs.
Leaving the key would ship 0.78.0 with its fixes filed under a version nobody can install.

So: `0.77.1` → `0.78.0` in `pyproject.toml` and `changelog.py`, the `(since v0.77.1)` tags
in `gotchas.md` retargeted, `make version-sync` run, and the #546 entry added above the
#528 one.

## Also: two `redundant-cast` warnings I introduced in #549

`ty` flagged `cast(io.BytesIO, stream.buffer)` in the new tests. Deleting the casts turned
the warnings into `unresolved-attribute` **errors** — `TextIOWrapper.buffer` is declared
as `_WrappedBuffer`, which has no `getvalue` — so removing them would have been a
downgrade from a non-blocking warning to a blocking one.

The actual fix is to stop reaching through `.buffer`: a small frozen `Cp1250Stdout` holds
the `BytesIO` directly alongside the text wrapper. That also gives the streaming tests
access to the helper, which lived in the other test class and was unreachable from them —
they had been duplicating the wrapper construction.

Preferred over returning a 2-tuple, which CONTRIBUTING's "Code Quality Patterns" rules out
for semantically distinct values (the same rule Devin cited on #543).

`ty` is now down to the 3 pre-existing warnings on `main`, none from this code.

## Checks

`make check` green — ruff, format, ty, skill, version, command-sync, changelog, error
codes, and 4744 tests.

## Note for the release

Windows users on ≤0.77.0 should install 0.78.0 with the recovery command rather than
letting auto-update make the jump — the update *to* the fixed version is still performed
by the old, unsafe updater on their current install. From 0.78.0 onward auto-update is
safe. Both #528 and #546 reporters have been told; worth repeating in the release notes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/550" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->