### PR TITLE
fix(windows): spawn the deferred update helper with a console it never shows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.80.1",
+      "version": "0.80.2",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.80.1",
+  "version": "0.80.2",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -3423,3 +3423,25 @@ possible remedy.
   as actionable was previously reporting an unfixable problem on every run.
 - **POSIX behaviour is unchanged** — a config file that is not `0600` still
   warns there, because there the bits mean something.
+
+## Windows auto-update did not work at all from 0.78.0 to 0.80.1 (since v0.80.2)
+
+If a Windows user reports being on an old kbagent, this is why: between 0.78.0
+and 0.80.1 inclusive, the deferred self-update was scheduled and then never
+applied. `kbagent update` printed `(scheduled)` and every later launch printed
+"Updating in the background", while the version never moved.
+
+- **It fails safe.** Nothing is corrupted (unlike the original #528); the
+  install stays complete and usable. The update simply never arrives, and the
+  24-hour single-flight marker suppresses retries in the meantime — so the
+  banner keeps promising an update that cannot happen.
+- **Do not tell a stuck user to run `kbagent update`** on an affected version.
+  It takes the same broken path. The reinstall is the only way out:
+
+      uv tool install --force --reinstall "keboola-cli @ https://github.com/keboola/cli/releases/download/v0.80.2/keboola_cli-0.80.2-py3-none-any.whl"
+
+- **A version between 0.78.0 and 0.80.1 on Windows means the user has been
+  stuck for a while**, and is missing every Windows fix from 0.80.1 —
+  `job run --idempotency-key`, `storage download-table`, `doctor`, and
+  redirected-output encoding all landed there.
+- POSIX was never affected; it uses the inline install plus re-exec.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-cli"
-version = "0.80.1"
+version = "0.80.2"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -24,6 +24,39 @@ from .constants import CHANGELOG_HEADLINE_MAX_CHARS
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.80.2": [
+        "Fix (#571): the deferred Windows self-update never applied. kbagent has "
+        "not auto-updated on Windows since the deferred path landed in 0.78.0 -- "
+        "`kbagent update` reported `(scheduled)`, the marker was written, and "
+        "nothing else ever happened. The helper was spawned with "
+        "`DETACHED_PROCESS`, which gives the child no console at all, and "
+        "`powershell.exe` is a console application whose host cannot start "
+        "without one: it exits 0, in under a second, having executed nothing. A "
+        "zero exit code with no output is the worst shape such a failure can "
+        "take -- the spawn looks successful, so the single-flight guard then "
+        "suppressed every retry for the full 24-hour staleness window while each "
+        'launch kept printing "Updating in the background". It failed safe, '
+        "unlike the original #528: nothing was corrupted, the update simply never "
+        "arrived. Now spawned with `CREATE_NO_WINDOW`, which creates a console "
+        "and never shows it. Measured on one Windows 11 box back to back, fresh "
+        "install of the same wheel per trial, only the flag changed: "
+        "`DETACHED_PROCESS` 0/3 updated with no exit file and no helper ever "
+        "visible in the process list; `CREATE_NO_WINDOW` 3/3 updated with the "
+        "exit file and full install log written. Thanks to @papousek-radan, "
+        'whose "we never saw the deferred update actually arrive" is what '
+        "reopened this after I had wrongly closed it.",
+        "Fix (tests, #571): the regression sat in the seam between two test "
+        "layers -- the waiter script's text was asserted as a string and the "
+        "spawn was tested with `subprocess.Popen` mocked, so the pairing that "
+        "actually ships was never executed. The Windows CI suite ran the script "
+        "through `subprocess.run`, which supplies the very console the real "
+        "flags withheld, so it could not reproduce the failure either. A new "
+        "Windows-only test performs the real spawn and asserts on the process "
+        'rather than on a file, because "never spawned" and "spawned and '
+        'died instantly" leave identical evidence on disk -- which is why this '
+        "took three rounds to pin down. Both new tests are confirmed to fail "
+        "with the old flag restored.",
+    ],
     "0.80.1": [
         "Fix (#427): `kbagent job run --idempotency-key` was completely broken on "
         "Windows -- every run raised `PermissionError: [WinError 5] Access is "

--- a/src/keboola_agent_cli/update_runner.py
+++ b/src/keboola_agent_cli/update_runner.py
@@ -65,7 +65,28 @@ logger = logging.getLogger(__name__)
 
 # Windows-only process-creation flags. Absent on POSIX, where the detached
 # helper path is never taken; `getattr` keeps the module importable there.
-_DETACHED_PROCESS = getattr(subprocess, "DETACHED_PROCESS", 0)
+#
+# `CREATE_NO_WINDOW`, and deliberately NOT `DETACHED_PROCESS` (issue #571). The
+# two read as synonyms -- "run this hidden in the background" -- but differ in
+# the one way that matters: `DETACHED_PROCESS` gives the child no console *at
+# all*, and `powershell.exe` is a console application whose host cannot start
+# without one. It exits 0, in under a second, having executed nothing.
+#
+# Zero, silently, is the worst shape this failure can take. `Popen` returns a
+# live-looking handle, the marker is already written, and the single-flight
+# guard then suppresses every retry for the full 24-hour staleness window while
+# each launch keeps printing "Updating in the background". Nothing is corrupted
+# -- it fails safe -- but the update never arrives and nobody is told.
+#
+# Measured on one Windows 11 box, back to back, fresh install of the same wheel
+# per trial, only this flag changed:
+#
+#     DETACHED_PROCESS   0/3 updated, no exit file, helper never visible in
+#                        the process list across 46 s of 1.5 s sampling
+#     CREATE_NO_WINDOW   3/3 updated, exit file and full install log written
+#
+# `CREATE_NO_WINDOW` still creates a console, it just never shows it.
+_CREATE_NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0)
 _CREATE_NEW_PROCESS_GROUP = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
 
 # Fallback location of the in-box Windows PowerShell, used when PATH lookup
@@ -486,7 +507,7 @@ def request_deferred_update(request: DeferredUpdateRequest) -> bool:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             close_fds=True,
-            creationflags=_DETACHED_PROCESS | _CREATE_NEW_PROCESS_GROUP,
+            creationflags=_CREATE_NO_WINDOW | _CREATE_NEW_PROCESS_GROUP,
         )
     except OSError:
         logger.debug("Could not spawn the deferred-update helper", exc_info=True)

--- a/tests/test_update_runner.py
+++ b/tests/test_update_runner.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -251,6 +252,17 @@ class TestRequestDeferredUpdate:
         assert spawned[0]["kwargs"]["stdin"] is subprocess.DEVNULL
         assert spawned[0]["kwargs"]["stdout"] is subprocess.DEVNULL
 
+        flags = spawned[0]["kwargs"]["creationflags"]
+        detached = getattr(subprocess, "DETACHED_PROCESS", 0)
+        # Both constants are 0 on POSIX, where this path is never taken, so the
+        # guard below only bites on Windows -- and says so rather than
+        # pretending to assert something everywhere (issue #571).
+        assert not (detached and flags & detached), (
+            "DETACHED_PROCESS leaves powershell without a console; it exits 0 having run nothing"
+        )
+        if os.name == "nt":
+            assert flags & subprocess.CREATE_NO_WINDOW
+
         marker = json.loads((tmp_path / DEFERRED_UPDATE_MARKER_FILENAME).read_text())
         assert marker["from_version"] == "0.76.3"
         assert marker["target_version"] == "0.76.4"
@@ -401,6 +413,54 @@ class TestWaiterScriptOnWindows:
         powershell = resolve_powershell()
         assert powershell is not None, "Windows must always provide an in-box PowerShell"
         subprocess.run(build_helper_command(powershell, script), check=True, timeout=180)
+
+    def test_the_real_spawn_produces_a_helper_that_stays_alive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Script and spawn together -- the combination that actually ships.
+
+        Everything else here either pins the script's text or mocks `Popen`, so
+        this exact pairing was never executed, and that is where #571 lived:
+        with `DETACHED_PROCESS` the helper died in under a second having run
+        nothing, leaving only a marker. "Never spawned" and "spawned and died
+        instantly" leave identical evidence on disk, which is why three rounds
+        of investigation failed to separate them -- so this asserts on the
+        process, not on a file.
+
+        The spy calls straight through to the real `subprocess.Popen`, so the
+        creation flags under test are the shipped ones.
+        """
+        real_popen = subprocess.Popen
+        spawned: list[subprocess.Popen[Any]] = []
+
+        def spy(argv: list[str], **kwargs: Any) -> subprocess.Popen[Any]:
+            process = real_popen(argv, **kwargs)
+            spawned.append(process)
+            return process
+
+        monkeypatch.setattr("keboola_agent_cli.update_runner.subprocess.Popen", spy)
+
+        request = DeferredUpdateRequest(
+            from_version="1.0.0",
+            target_version="2.0.0",
+            # Never reached: this process is alive, so the helper stays parked
+            # in its `Wait-Process` on our own PID for the whole assertion.
+            install_command=(sys.executable, "-c", "pass"),
+            recovery_command=None,
+        )
+        assert request_deferred_update(request) is True
+        assert len(spawned) == 1
+        helper = spawned[0]
+
+        try:
+            with pytest.raises(subprocess.TimeoutExpired):
+                helper.wait(timeout=15)
+            assert not (tmp_path / DEFERRED_UPDATE_EXIT_FILENAME).exists(), (
+                "the helper must install nothing while a watched process is alive"
+            )
+        finally:
+            helper.kill()
+            helper.wait(timeout=30)
 
     def test_installer_exit_code_is_recorded(self, tmp_path: Path) -> None:
         exit_file = tmp_path / DEFERRED_UPDATE_EXIT_FILENAME

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "keboola-cli"
-version = "0.80.1"
+version = "0.80.2"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Fixes #571. The deferred Windows self-update has **never applied** since it landed in 0.78.0 — `kbagent update` reports `(scheduled)`, the marker is written, and then nothing: no exit file, no install log, no version change.

## Cause

`DETACHED_PROCESS` gives the child no console at all, and `powershell.exe` is a console application whose host cannot start without one. It exits **0, in under a second, having executed nothing**.

Zero-with-no-output is the worst shape this failure can take. `Popen` returns a live-looking handle, so the single-flight guard then suppresses every retry for the full 24-hour staleness window while each launch keeps printing "Updating in the background". It fails *safe* — nothing is corrupted, unlike the original #528 — which is exactly why it survived three releases unnoticed.

`CREATE_NO_WINDOW` still creates a console, it just never shows it.

## A/B on a real Windows 11 box

Back to back, same machine, fresh install of the same wheel per trial, only the flag changed:

| flag | updated | `pending_update.exit` |
|---|---|---|
| `DETACHED_PROCESS` (shipped) | **0/3** | never written |
| `CREATE_NO_WINDOW` (this PR) | **3/3** | written, with full install log |

Separately, polling the process list every 1.5 s for 46 s during a `DETACHED_PROCESS` run never sees the helper at all. I validated that instrument against a live decoy process carrying the same command-line marker before trusting the negative.

## I got this wrong twice first, and it is worth saying why

1. I claimed this exact cause once before, from observations taken while the test laptop was suspending every few minutes — a machine that sleeps mid-run also produces "no exit file, no log".
2. I then retracted it on three successful runs, which I now believe executed against an already-patched install.

Both times I generalised one batch of runs into a mechanism instead of holding everything constant and flipping a single variable. The table above is the experiment I should have run first, and it is the only evidence in this PR I would defend.

## Tests

Two, both **confirmed to fail with the old flag restored** on real Windows:

- cross-platform: pins the flag choice so `DETACHED_PROCESS` cannot come back;
- Windows-only: performs the real spawn and asserts the helper is **still alive** afterwards.

The second asserts on the *process*, not on a file, deliberately. "Never spawned" and "spawned and died instantly" leave identical evidence on disk — that indistinguishability is what made this take three rounds, and it is why the existing tests could not catch it: they pin the script's text and mock `Popen`, and the Windows CI test runs the script through `subprocess.run`, which supplies the very console the real flags withheld.

## Impact on users

Anyone on Windows between 0.78.0 and 0.80.1 is stuck and is missing every fix from 0.80.1. Telling them to run `kbagent update` does not help — it takes the same broken path. Recorded in `gotchas.md` so agents give the reinstall instead:

```
uv tool install --force --reinstall "keboola-cli @ https://github.com/keboola/cli/releases/download/v0.80.2/keboola_cli-0.80.2-py3-none-any.whl"
```

Local: 5411 passed. Windows: 44 passed in `test_update_runner.py`, 2 of them failing on demand when the bug is restored.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->