### PR TITLE
fix(windows): read transformation source as UTF-8, not the host codepage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.80.2",
+      "version": "0.80.3",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.80.2",
+  "version": "0.80.3",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -3445,3 +3445,22 @@ applied. `kbagent update` printed `(scheduled)` and every later launch printed
   `job run --idempotency-key`, `storage download-table`, `doctor`, and
   redirected-output encoding all landed there.
 - POSIX was never affected; it uses the inline install plus re-exec.
+
+## Source files are read as UTF-8, not the host codepage (since v0.80.3)
+
+`lineage build` reads `transform.sql` / `code.py` as UTF-8 regardless of the
+machine's locale, and tolerates files that are not valid UTF-8.
+
+- **Before v0.80.3** the reads used the platform default. On a Czech or Polish
+  Windows box (cp1250) a single accented character in a SQL comment aborted the
+  entire build with `UnicodeDecodeError`. Workaround on older versions:
+  `PYTHONUTF8=1`.
+- **A build is now reproducible across machines.** Previously the same synced
+  tree could decode differently on Windows and on Linux, so a lineage graph was
+  quietly host-dependent.
+- **Undecodable bytes cost a comment, not the graph** -- `errors="replace"`.
+  Table identifiers are ASCII, so references are never lost.
+- **Data inputs stay strict**: `dev-portal create --data`, `patch
+  --value-file`, and `semantic-layer reference-data set --members-file` read
+  UTF-8 without a fallback, so a genuinely mis-encoded input file fails loudly
+  and identically everywhere rather than being silently mis-parsed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-cli"
-version = "0.80.2"
+version = "0.80.3"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -24,6 +24,28 @@ from .constants import CHANGELOG_HEADLINE_MAX_CHARS
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.80.3": [
+        "Fix (#570): `kbagent lineage build` crashed with `UnicodeDecodeError` on "
+        "Windows when a transformation's `transform.sql` or `code.py` contained "
+        "non-ASCII text -- an accented word in a Czech comment was enough to abort "
+        "the whole graph. The reads used `Path.read_text()`, which decodes with "
+        "the platform default: cp1250 on a Czech box, where UTF-8's continuation "
+        "bytes are undefined. Keboola serves this content as UTF-8, so UTF-8 is "
+        "now explicit, which also makes a build reproducible across machines "
+        "instead of varying with the host locale. Files that genuinely hold "
+        "non-UTF-8 bytes -- a transformation edited locally and saved in the OS "
+        'codepage -- decode with `errors="replace"`: table identifiers are '
+        "ASCII, so a mangled comment costs nothing and never costs the graph. The "
+        "`PYTHONUTF8=1` workaround is no longer needed. Thanks to "
+        "@papousek-radan for the report.",
+        "Fix (#570): the same unqualified `Path.read_text()` in "
+        "`dev-portal create --data` / `patch --value-file` and "
+        "`semantic-layer reference-data set --members-file` now reads UTF-8 too. "
+        "Those parse their input as data rather than scan it, so they stay "
+        "strict: a decode error there is honest and identical on every OS, "
+        "whereas the platform default silently produced different results per "
+        "machine.",
+    ],
     "0.80.2": [
         "Fix (#571): the deferred Windows self-update never applied. kbagent has "
         "not auto-updated on Windows since the deferred path landed in 0.78.0 -- "

--- a/src/keboola_agent_cli/commands/_semantic_layer_reference_data.py
+++ b/src/keboola_agent_cli/commands/_semantic_layer_reference_data.py
@@ -111,7 +111,11 @@ def _print_reference_data_delete_result(console: Console, data: dict) -> None:
 def _load_members(formatter: Any, members_file: str) -> list[dict]:
     """Read a JSON array of member objects from a file or ``-`` (stdin)."""
     try:
-        raw = sys.stdin.read() if members_file == "-" else Path(members_file).read_text()
+        raw = (
+            sys.stdin.read()
+            if members_file == "-"
+            else Path(members_file).read_text(encoding="utf-8")
+        )
     except OSError as exc:
         formatter.error(
             message=f"Could not read members file {members_file!r}: {exc}",

--- a/src/keboola_agent_cli/commands/dev_portal.py
+++ b/src/keboola_agent_cli/commands/dev_portal.py
@@ -317,7 +317,7 @@ def _load_payload(data: str | None) -> dict:
         raise typer.BadParameter("--data is required")
     if data == "-":
         return json.loads(sys.stdin.read())
-    return json.loads(Path(data).read_text())
+    return json.loads(Path(data).read_text(encoding="utf-8"))
 
 
 def _render_pending(formatter: OutputFormatter, pending: PendingWrite) -> None:
@@ -435,7 +435,7 @@ def patch_cmd(
         payload = _load_payload(data)
     elif property_:
         if value_file:
-            raw = Path(value_file).read_text()
+            raw = Path(value_file).read_text(encoding="utf-8")
         elif value is not None:
             raw = value
         else:

--- a/src/keboola_agent_cli/services/deep_lineage_service.py
+++ b/src/keboola_agent_cli/services/deep_lineage_service.py
@@ -48,6 +48,23 @@ _QUALIFIED_3 = re.compile(r'"KBC_USE4_(\d+)"\s*\.\s*"([^"]+)"\s*\.\s*"([^"]+)"')
 _QUALIFIED_2 = re.compile(r'"([^"]+)"\s*\.\s*"([^"]+)"')
 
 
+def _read_source(path: Path) -> str:
+    """Read a transformation's code, whatever bytes the file actually holds.
+
+    ``Path.read_text()`` decodes with the platform default, which on a Czech or
+    Polish Windows box is cp1250 -- so a single accented character in a SQL
+    comment aborted the whole lineage build with ``UnicodeDecodeError`` (issue
+    #570). Keboola serves this content as UTF-8, so UTF-8 is the right guess
+    everywhere, and forcing it also makes a build reproducible across machines.
+
+    ``errors="replace"`` because the goal here is finding table references: a
+    file that genuinely holds non-UTF-8 bytes (a locally-edited transformation
+    saved in the OS codepage) should cost a mangled comment, never the entire
+    graph. Table identifiers are ASCII, so nothing load-bearing is lost.
+    """
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
 def extract_sql_table_refs(sql: str, project_id: int) -> list[tuple[int, str, str]]:
     """Extract table references from Snowflake SQL using a state machine.
 
@@ -632,10 +649,10 @@ class DeepLineageService:
         code_py = full_path / "code.py"
 
         if transform_sql.exists():
-            code = transform_sql.read_text()
+            code = _read_source(transform_sql)
             code_type = "sql"
         elif code_py.exists():
-            code = code_py.read_text()
+            code = _read_source(code_py)
             code_type = "python"
 
         # Include config row mappings

--- a/tests/test_deep_lineage_service.py
+++ b/tests/test_deep_lineage_service.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import yaml
 
 from keboola_agent_cli.config_store import ConfigStore
@@ -15,6 +16,7 @@ from keboola_agent_cli.services.deep_lineage_service import (
     Table,
     _collect_create_targets,
     _collect_cte_names,
+    _read_source,
     _strip_comments_and_strings,
     extract_sql_table_refs,
 )
@@ -939,3 +941,48 @@ class TestRenderErDiagramXssRegression:
         )
         assert "<img" not in rendered
         assert "&lt;img" in rendered
+
+
+class TestSourceReadsAreUtf8:
+    """Transformation code must decode the same on every host (issue #570).
+
+    `Path.read_text()` uses the platform default encoding. On a Czech or Polish
+    Windows box that is cp1250, so one accented character in a SQL comment
+    aborted the entire `lineage build` with `UnicodeDecodeError`. These run
+    everywhere by driving the decode explicitly rather than by depending on the
+    host's locale.
+    """
+
+    def test_utf8_content_survives_a_cp1250_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The exact reported crash: UTF-8 bytes read on a cp1250 host."""
+        sql = tmp_path / "transform.sql"
+        # U+0159 encodes to 0xC5 0x99 in UTF-8; 0x99 is undefined in cp1250,
+        # which is what raised in the report.
+        sql.write_bytes("-- příprava dat\nSELECT 1 FROM t;\n".encode())
+
+        real_read_text = Path.read_text
+
+        def cp1250_default(
+            self: Path, encoding: str | None = None, errors: str | None = None
+        ) -> str:
+            # Mimic a Windows host: no explicit encoding means cp1250.
+            return real_read_text(self, encoding=encoding or "cp1250", errors=errors)
+
+        monkeypatch.setattr(Path, "read_text", cp1250_default)
+
+        code = _read_source(sql)
+        assert "SELECT 1 FROM t" in code
+        assert "příprava" in code, "UTF-8 content must round-trip intact"
+
+    def test_genuinely_undecodable_bytes_do_not_abort_the_build(self, tmp_path: Path) -> None:
+        """A locally-edited file saved in the OS codepage costs a comment, not the graph."""
+        sql = tmp_path / "transform.sql"
+        # 0x81 is invalid UTF-8 and is the byte from the report's traceback.
+        sql.write_bytes(b"-- koment\x81\nSELECT 1 FROM in.c_bucket.tbl;\n")
+
+        code = _read_source(sql)
+
+        # The table reference -- the only thing lineage actually needs -- survives.
+        assert "in.c_bucket.tbl" in code

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "keboola-cli"
-version = "0.80.2"
+version = "0.80.3"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Fixes #570.

`kbagent lineage build` crashed with `UnicodeDecodeError` on Windows when a transformation's `transform.sql` or `code.py` contained non-ASCII text — an accented word in a Czech comment was enough to abort the whole graph.

## Cause

The reads used `Path.read_text()`, which decodes with the **platform default**. On the reporter's Czech box that is cp1250, where UTF-8's continuation bytes are undefined.

Two things follow, and the second is arguably worse than the crash:

- it fails on perfectly valid UTF-8 content, and
- the same synced tree decodes **differently on Windows and on Linux**, so a lineage graph was quietly host-dependent.

Keboola serves this content as UTF-8, so UTF-8 is now explicit.

## Why `errors="replace"` here specifically

A transformation edited locally and saved in the OS codepage really does contain non-UTF-8 bytes, and strict UTF-8 would still abort. For lineage the job is finding table references, which are ASCII — so a mangled comment costs nothing, and losing the entire graph to one byte in a comment is the wrong trade.

The other three unqualified reads got the opposite treatment, deliberately: `dev-portal create --data`, `dev-portal patch --value-file` and `semantic-layer reference-data set --members-file` **parse** their input as data rather than scan it, so they read UTF-8 **strictly**. A decode error there is honest and identical everywhere, whereas the platform default silently produced different results per machine.

## Tests

Two, both confirmed to fail without the fix: valid UTF-8 content read on a simulated cp1250 host, and genuinely undecodable bytes not aborting the scan.

They drive the decode explicitly instead of depending on the host locale — which matters more than it looks. My Windows box is **cp1252**, where the reporter's bytes happen to be defined and the bug does not reproduce at all. A test that just "runs on Windows CI" would have passed on a broken build.

Verified on real Windows: the table reference is found and the accents survive.

Local: 5413 passed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->