### PR TITLE
docs(changelog): credit the right reporter for #570

### DIFF
--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -37,7 +37,7 @@ CHANGELOG: dict[str, list[str]] = {
         'codepage -- decode with `errors="replace"`: table identifiers are '
         "ASCII, so a mangled comment costs nothing and never costs the graph. The "
         "`PYTHONUTF8=1` workaround is no longer needed. Thanks to "
-        "@papousek-radan for the report.",
+        "@MichalProchazkaP3 for the report.",
         "Fix (#570): the same unqualified `Path.read_text()` in "
         "`dev-portal create --data` / `patch --value-file` and "
         "`semantic-layer reference-data set --members-file` now reads UTF-8 too. "


### PR DESCRIPTION
#570 was filed by @MichalProchazkaP3, but the 0.80.3 changelog entry thanks @papousek-radan — who reported #528, a different issue. Michal is credited correctly for #546 in the 0.78.0 entry, so this is an isolated slip on my part, and it shipped in 0.80.3.

The released wheel keeps the wrong text and nothing can change that, but the `CHANGELOG` dict carries every past version, so anyone updating from here on reads the corrected entry. The [v0.80.3 release notes](https://github.com/keboola/cli/releases/tag/v0.80.3) are already fixed, and I have credited Michal on the issue itself.

Docs only — no version bump, no behaviour change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->