### PR TITLE
fix(sync): write manifest paths with forward slashes on every OS

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.80.3",
+      "version": "0.80.4",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.80.3",
+  "version": "0.80.4",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-cli"
-version = "0.80.3"
+version = "0.80.4"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -24,6 +24,28 @@ from .constants import CHANGELOG_HEADLINE_MAX_CHARS
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.80.4": [
+        "Fix: a sync manifest written on Windows was unusable by everyone else "
+        "on the team. `.keboola/manifest.json` is a **tracked** file -- sharing "
+        "the synced tree through git is the point of the sync workflow -- but "
+        "`sync push --adopt-existing` recorded config paths with the host's "
+        "separator, so a Windows machine committed "
+        "`extractor\\keboola.ex-http\\name`. The asymmetry is what hid it: "
+        "`Path()` on Windows accepts forward slashes, so POSIX-written "
+        "manifests work everywhere, while on POSIX a backslash path is a single "
+        "filename that matches nothing. Paths are now written with `as_posix()` "
+        "and normalised on load, so a manifest already committed by a Windows "
+        "kbagent repairs itself on the next read instead of needing a hand "
+        "edit. Found by running the full test suite on Windows rather than by a "
+        "report -- see the note below.",
+        "Note (tests): this is the first Windows-only defect the project found "
+        "itself. The full suite has never run on Windows in CI (only a narrow "
+        "slice does), and a real run was 55 failures -- unusable as a gate, so "
+        "nobody enabled it, so anything could hide in it. Working through those "
+        "failures to make gating possible is what surfaced this one, among "
+        "otherwise routine test-portability noise. The remaining failures are "
+        "POSIX-only permission assertions and unguarded `fcntl` imports.",
+    ],
     "0.80.3": [
         "Fix (#570): `kbagent lineage build` crashed with `UnicodeDecodeError` on "
         "Windows when a transformation's `transform.sql` or `code.py` contained "

--- a/src/keboola_agent_cli/services/sync_service.py
+++ b/src/keboola_agent_cli/services/sync_service.py
@@ -2350,7 +2350,7 @@ class SyncService(BaseService):
                         {
                             "component_id": keboola_meta.get("component_id", "unknown"),
                             "config_id": keboola_meta.get("config_id", ""),
-                            "path": str(config_dir.relative_to(project_root / branch.path)),
+                            "path": config_dir.relative_to(project_root / branch.path).as_posix(),
                         }
                     )
 

--- a/src/keboola_agent_cli/sync/manifest.py
+++ b/src/keboola_agent_cli/sync/manifest.py
@@ -10,7 +10,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from ..constants import KEBOOLA_DIR_NAME, MANIFEST_FILENAME, MANIFEST_VERSION
 
@@ -59,6 +59,26 @@ class ManifestNaming(BaseModel):
     data_app_config: str = Field(default="app/{component_id}/{config_name}", alias="dataAppConfig")
 
 
+def _posix_path(value: str) -> str:
+    r"""Normalise a manifest path to forward slashes.
+
+    The manifest is a **tracked** file -- the point of a sync tree is that a
+    team shares it through git -- so its paths must mean the same thing on
+    every machine. The asymmetry is what makes this bite: ``Path()`` on Windows
+    happily accepts ``a/b``, but on POSIX ``a\b`` is a single filename that
+    merely contains a backslash. So a manifest written on Windows silently
+    stops resolving for everyone else on the team, while the reverse direction
+    works fine and hides the problem.
+
+    Applied on load as well as on write, so a manifest already committed by a
+    Windows kbagent repairs itself on the next read instead of needing a hand
+    edit. Component and config names are slugified by :mod:`.naming` long
+    before they reach a path, so a backslash here is always a separator and
+    never part of a real name.
+    """
+    return value.replace("\\", "/")
+
+
 class ManifestBranch(BaseModel):
     """A branch entry in the manifest."""
 
@@ -67,6 +87,11 @@ class ManifestBranch(BaseModel):
     id: int
     path: str
     metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("path")
+    @classmethod
+    def _normalise_path(cls, value: str) -> str:
+        return _posix_path(value)
 
 
 class ManifestConfigRow(BaseModel):
@@ -85,6 +110,11 @@ class ManifestConfigRow(BaseModel):
     path: str
     metadata: dict[str, Any] = Field(default_factory=dict)
 
+    @field_validator("path")
+    @classmethod
+    def _normalise_path(cls, value: str) -> str:
+        return _posix_path(value)
+
 
 class ManifestConfiguration(BaseModel):
     """A single configuration reference inside the manifest."""
@@ -97,6 +127,11 @@ class ManifestConfiguration(BaseModel):
     path: str
     metadata: dict[str, Any] = Field(default_factory=dict)
     rows: list[ManifestConfigRow] = Field(default_factory=list)
+
+    @field_validator("path")
+    @classmethod
+    def _normalise_path(cls, value: str) -> str:
+        return _posix_path(value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sync_manifest.py
+++ b/tests/test_sync_manifest.py
@@ -1,6 +1,7 @@
 """Tests for sync manifest models and load/save functions."""
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -275,3 +276,48 @@ class TestManifestExtraFields:
         # Extra field on nested model
         project_dumped = loaded.project.model_dump(mode="json", by_alias=True)
         assert project_dumped["unknownField"] == "kept"
+
+
+class TestManifestPathsArePortable:
+    """The manifest is tracked in git, so its paths must be OS-neutral.
+
+    The asymmetry is what makes this dangerous: `Path()` on Windows accepts
+    `a/b`, but on POSIX `a\\b` is a single filename containing a backslash. A
+    manifest written on Windows therefore stops resolving for every teammate on
+    macOS or Linux, while the reverse direction works and hides the problem.
+    """
+
+    def test_windows_separators_are_normalised_on_load(self) -> None:
+        """A manifest already committed by a Windows kbagent repairs itself."""
+        cfg = ManifestConfiguration(
+            branchId=1,
+            componentId="keboola.ex-http",
+            id="123",
+            path=r"extractor\keboola.ex-http\adopted-extractor",
+        )
+        assert cfg.path == "extractor/keboola.ex-http/adopted-extractor"
+
+    def test_branch_and_row_paths_are_normalised_too(self) -> None:
+        assert ManifestBranch(id=1, path=r"main\nested").path == "main/nested"
+        assert ManifestConfigRow(id="r1", path=r"rows\first").path == "rows/first"
+
+    def test_posix_paths_are_left_alone(self) -> None:
+        """The common case must be untouched, not round-tripped through a rewrite."""
+        cfg = ManifestConfiguration(branchId=1, componentId="c", id="1", path="extractor/c/name")
+        assert cfg.path == "extractor/c/name"
+
+    def test_a_saved_manifest_holds_forward_slashes(self, tmp_path: Path) -> None:
+        """End to end: what lands in git is portable regardless of the writer's OS."""
+        manifest = Manifest(
+            project=ManifestProject(id=1, apiHost="connection.keboola.com"),
+            naming=ManifestNaming(),
+            branches=[ManifestBranch(id=1, path="main")],
+            configurations=[
+                ManifestConfiguration(branchId=1, componentId="c", id="1", path=r"extractor\c\name")
+            ],
+        )
+        save_manifest(tmp_path, manifest)
+
+        raw = (tmp_path / ".keboola" / "manifest.json").read_text(encoding="utf-8")
+        assert "extractor/c/name" in raw
+        assert "\\\\" not in raw, "a backslash in the tracked manifest breaks POSIX checkouts"

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "keboola-cli"
-version = "0.80.3"
+version = "0.80.4"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
A sync manifest written on Windows is unusable by everyone else on the team.

`.keboola/manifest.json` is a **tracked** file — sharing the synced tree through git is the entire point of the sync workflow — but `sync push --adopt-existing` recorded config paths using the host separator. A Windows machine commits:

```
"path": "extractor\\keboola.ex-http\\adopted-extractor"
```

## Why nobody noticed

The asymmetry. `Path()` on Windows accepts forward slashes, so a POSIX-written manifest resolves fine everywhere and the workflow looks healthy. On POSIX, `extractor\keboola.ex-http\name` is a **single filename that happens to contain backslashes** and matches nothing.

So only the Windows → POSIX direction breaks, and it breaks for the *teammate*, not for the person who wrote it — which is the worst way for a bug in a collaboration tool to fail.

## Fix

- write with `as_posix()`;
- normalise on load with a field validator, so a manifest already committed by a Windows kbagent **repairs itself on the next read** instead of needing a hand edit.

Component and config names are slugified by `sync/naming.py` long before they reach a path, so a backslash there is always a separator, never part of a real name.

## How it was found — which is the point of this PR

**This is the first Windows-only defect the project caught itself**, rather than being told about by @MichalProchazkaP3 or @papousek-radan.

It surfaced while working through the Windows test-suite failures. That suite has never run in CI: the windows-latest job runs a narrow slice (wheel build, semantic-layer export, the self-update runner, a smoke `--help`), and a real full run is **55 failures**. Fifty-five red is unusable as a gate, so nobody enabled it — and a permanently-red suite is worse than no suite, because it gives the feeling of coverage while hiding things. The idempotency `WinError 5` bug fixed in 0.80.1 had been sitting in there too.

This one was hiding among otherwise routine test-portability noise (POSIX-only permission assertions, unguarded `fcntl` imports), which is exactly the shape of thing that gets skimmed past.

## Tests

Four. Three fail without the fix; the fourth asserts POSIX paths are left untouched, guarding the opposite mistake. Verified on real Windows — `test_sync_reconcile.py`, which is where this first showed up, now passes there.

Local: 5417 passed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->