### PR TITLE
ci(windows): gate on the full suite; stop reporting a lookup failure as a crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,25 @@ jobs:
       - name: Test lock-then-replace file stores on Windows (issue #427)
         run: uv run pytest tests/test_job_idempotency_store.py -v
 
+      # The whole suite, as a gate. It never ran here before: a real run was 55
+      # failures, and nobody can gate on that, so nothing did -- which let real
+      # Windows defects sit in the noise for entire releases. Two of them did:
+      # the WinError 5 above, and a manifest written with backslash paths into
+      # a git-tracked file (#576), which broke every POSIX teammate.
+      #
+      # The 55 were test portability, not product bugs, and are now expressed
+      # as explicit POSIX-only skips (mode bits are not Windows access control;
+      # fcntl does not exist there). Keeping this green is the point: a red
+      # suite nobody can act on is worse than no suite, because it reads as
+      # coverage while hiding things.
+      - name: Full test suite on Windows
+        run: >
+          uv run pytest tests/
+          --ignore=tests/test_e2e.py
+          --ignore=tests/test_e2e_auth.py
+          --ignore=tests/test_server_semantic_layer_routes_e2e.py
+          -q
+
       - name: Assert the SPA is bundled (Bug 1 fixed)
         run: python scripts/check_wheel_ui.py --expect-ui
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,14 @@ jobs:
       # fcntl does not exist there). Keeping this green is the point: a red
       # suite nobody can act on is worse than no suite, because it reads as
       # coverage while hiding things.
+      # The targeted steps above run against the default dependency set, but
+      # the full suite imports the `serve` tests, so it needs the same extras
+      # the Linux job installs. Without this the gate fails on
+      # `ModuleNotFoundError: No module named 'fastapi'` -- an artefact of the
+      # job's own setup rather than anything about Windows.
+      - name: Install server extras for the full run
+        run: uv sync --extra server
+
       - name: Full test suite on Windows
         run: >
           uv run pytest tests/

--- a/src/keboola_agent_cli/auto_update.py
+++ b/src/keboola_agent_cli/auto_update.py
@@ -763,9 +763,15 @@ def maybe_auto_update() -> None:
         if kbagent_plan.up_to_date is not False:
             return
         if kbagent_plan.command is None:
+            # Only offer a recovery line when there is one; `Recover with: None`
+            # is worse than saying nothing. A failed version lookup never gets
+            # here -- `up_to_date` is None then, and the guard above returns
+            # first, deliberately keeping a transient network blip silent
+            # instead of nagging on every single command.
+            recovery = kbagent_plan.recovery_command
             sys.stderr.write(
-                "Auto-update could not prepare a reinstall command. "
-                f"Recover with: {kbagent_plan.recovery_command}\n"
+                "Auto-update could not prepare a reinstall command."
+                + (f" Recover with: {recovery}\n" if recovery else "\n")
             )
             return
 

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -44,6 +44,30 @@ CHANGELOG: dict[str, list[str]] = {
         "contract `tool list` / `tool call` already use. `kbagent serve`'s `/agents` route "
         "carries the same key, so the Web UI flags them too -- that population is the least "
         "likely to ever run `kbagent doctor`.",
+        "UX: a failed version lookup no longer reports itself as a broken "
+        "self-update. `kbagent update` printed `update FAILED: Could not "
+        "prepare a self-update command. Recover with: uv tool install --force "
+        "--reinstall` -- wrong about the cause, and the command it offered had "
+        "no package in it, so pasting it did nothing. Both situations reached "
+        "one branch: not knowing WHAT to install (usually transient -- no "
+        "network, or GitHub's unauthenticated 60-requests/hour rate limit, "
+        "which is per IP and shared by every tool on your connection) and "
+        "knowing the version but failing to build a command (a real local "
+        "problem). They are now reported separately, the transient case says "
+        "so and says your install was left untouched, and a recovery command "
+        "is only printed when it is actually runnable.",
+        "Tests: the full suite now runs on Windows in CI as a gate. It never "
+        "did -- the windows-latest job ran a narrow slice, because a real run "
+        "was 55 failures and nothing can gate on that. Those were test "
+        "portability, not product bugs, and are now explicit POSIX-only skips "
+        "(mode bits are not the access-control mechanism on Windows; `fcntl` "
+        "does not exist there); the `auto_update` tests were fixed rather than "
+        "skipped, by pinning the install path they mean to exercise instead of "
+        "inheriting the platform default. Console width is pinned in conftest "
+        "so table assertions stop depending on the host. Two real Windows "
+        "defects had been sitting in that noise -- the WinError 5 idempotency "
+        "crash and the backslash manifest paths -- which is what a permanently "
+        "red suite costs: it reads as coverage while hiding things.",
     ],
     "0.80.4": [
         "Fix: a sync manifest written on Windows was unusable by everyone else "

--- a/src/keboola_agent_cli/services/version_service.py
+++ b/src/keboola_agent_cli/services/version_service.py
@@ -1139,6 +1139,29 @@ class VersionService:
                 ),
             }
 
+        # Two very different situations reach `command is None`, and reporting
+        # them identically sent users chasing the wrong thing: not knowing what
+        # to install is usually a transient network or GitHub rate-limit blip,
+        # while knowing the version but failing to build a command is a real
+        # local problem. Separate them, and never print a recovery command that
+        # is not runnable -- the old fallback rendered as a bare
+        # `uv tool install --force --reinstall` with no package to install.
+        if kbagent_latest is None:
+            return {
+                "planned": False,
+                "updated": False,
+                "up_to_date": up_to_date,
+                "current_version": old_version,
+                "latest_version": None,
+                "reason": "latest_version_unknown",
+                "message": (
+                    f"Could not determine the latest kbagent version, so v{old_version} "
+                    "was left untouched. This is usually temporary -- no network, or "
+                    "GitHub's unauthenticated API rate limit (60 requests/hour per IP, "
+                    "shared by every tool on your connection). Try again in a few minutes."
+                ),
+            }
+
         if plan.command is None:
             return {
                 "planned": True,
@@ -1147,8 +1170,14 @@ class VersionService:
                 "current_version": old_version,
                 "latest_version": kbagent_latest,
                 "message": (
-                    "Could not prepare a self-update command. "
-                    f"Recover with: {plan.recovery_command or 'uv tool install --force --reinstall'}"
+                    f"Could not prepare a self-update command for v{kbagent_latest}. "
+                    f"Recover with: {plan.recovery_command}"
+                    if plan.recovery_command
+                    else (
+                        f"Could not prepare a self-update command for v{kbagent_latest}. "
+                        "Reinstall kbagent from the release wheel for that version: "
+                        "https://github.com/keboola/cli/releases/latest"
+                    )
                 ),
                 "recovery_command": plan.recovery_command,
             }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,19 @@ from keboola_agent_cli.output import OutputFormatter
 
 
 @pytest.fixture(autouse=True)
+def _deterministic_console_width(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the width Rich renders at, so assertions do not depend on the host.
+
+    Rich truncates table cells to fit the console and infers that width from
+    the environment. A test asserting a value appears in a rendered table
+    therefore passes or fails according to the machine it runs on -- which is
+    how `organization-project` came to be silently cut in half on Windows CI
+    while passing locally. Wide enough that nothing under test is elided.
+    """
+    monkeypatch.setenv("COLUMNS", "200")
+
+
+@pytest.fixture(autouse=True)
 def _force_stdio_transport(monkeypatch: pytest.MonkeyPatch) -> None:
     """Force stdio transport in all tests to prevent spawning persistent server."""
     monkeypatch.setenv("KBAGENT_MCP_TRANSPORT", "stdio")

--- a/tests/test_agents_store_events.py
+++ b/tests/test_agents_store_events.py
@@ -6,6 +6,7 @@ These cover the new per-run JSONL files added in v0.10.x to enable
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -99,6 +100,10 @@ class TestAppendAndLoadEvents:
         assert loaded[0]["event"] == "ok"
         assert loaded[1]["event"] == "ok2"
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX mode bits are not the access-control mechanism on Windows: os.chmod cannot narrow an ACL and stat reports 0o666 for anything writable",
+    )
     def test_file_permissions_are_0600(self, store: AgentStore, tmp_path: Path) -> None:
         store.append_events("t", "r", [{"event": "x", "data": {}, "seq": 0}])
         path = tmp_path / "kbagent" / "agent_runs" / "t" / "r.jsonl"

--- a/tests/test_auth_state_store.py
+++ b/tests/test_auth_state_store.py
@@ -3,6 +3,7 @@
 import json
 import os
 import stat
+import sys
 import threading
 from datetime import UTC, datetime
 from pathlib import Path
@@ -31,6 +32,10 @@ def _make_session(stack_url: str = "https://connection.keboola.com") -> StackSes
     )
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX mode bits are not the access-control mechanism on Windows: os.chmod cannot narrow an ACL and stat reports 0o666 for anything writable",
+)
 class TestFilePermissions:
     def test_saved_file_is_0600(self, tmp_config_dir: Path) -> None:
         store = AuthStateStore(config_dir=tmp_config_dir)

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -24,7 +24,12 @@ from keboola_agent_cli.auto_update import (
     maybe_auto_update,
     report_finished_deferred_update,
 )
-from keboola_agent_cli.constants import ENV_AUTO_UPDATE, ENV_SKIP_UPDATE, MCP_UPGRADE_TIMEOUT
+from keboola_agent_cli.constants import (
+    ENV_AUTO_UPDATE,
+    ENV_DEFER_UPDATE,
+    ENV_SKIP_UPDATE,
+    MCP_UPGRADE_TIMEOUT,
+)
 from keboola_agent_cli.frozen_dist import FrozenChannel, FrozenDistribution
 from keboola_agent_cli.services.version_service import KbagentUpdatePlan, McpUpdatePlan
 from keboola_agent_cli.update_runner import (
@@ -38,6 +43,21 @@ from keboola_agent_cli.update_runner import (
 # ---------------------------------------------------------------------------
 # _should_skip
 # ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _pin_the_inline_update_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Decide the install path explicitly instead of inheriting the platform's.
+
+    `should_defer()` defaults to True on Windows, so tests here that exercise
+    the inline install + re-exec silently stopped exercising anything when run
+    on Windows -- `_perform_update` was simply never reached. Pinning the
+    documented escape hatch makes the path under test the same everywhere.
+
+    Tests that are *about* deferral patch `should_defer` directly, which
+    replaces the function and therefore wins over this env var.
+    """
+    monkeypatch.setenv(ENV_DEFER_UPDATE, "0")
+
+
 class TestTopLevelSubcommandVersioning:
     """_top_level_subcommand_is_versioning resolves the real subcommand (issue #353)."""
 

--- a/tests/test_config_store.py
+++ b/tests/test_config_store.py
@@ -3,6 +3,7 @@
 import json
 import os
 import stat
+import sys
 import threading
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -82,6 +83,10 @@ class TestSaveAndLoad:
         assert (nested_dir / "config.json").exists()
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX mode bits are not the access-control mechanism on Windows: os.chmod cannot narrow an ACL and stat reports 0o666 for anything writable",
+)
 class TestFilePermissions:
     """Tests for file permission security."""
 
@@ -671,6 +676,10 @@ class TestMissingDirectory:
         assert "test" in config.projects
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="relies on chmod to deny access, which Windows ACLs ignore for the file owner",
+)
 class TestPermissionDenied:
     """Tests for permission-related errors."""
 
@@ -704,6 +713,10 @@ class TestPermissionDenied:
             config_file.chmod(0o644)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX mode bits are not the access-control mechanism on Windows: os.chmod cannot narrow an ACL and stat reports 0o666 for anything writable",
+)
 class TestDirectoryPermissions:
     """Tests for S3: config directory permissions."""
 
@@ -1143,6 +1156,10 @@ class TestBackupOnSave:
         current = json.loads((tmp_config_dir / "config.json").read_text())
         assert set(current["projects"]) == {"a", "b"}
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX mode bits are not the access-control mechanism on Windows: os.chmod cannot narrow an ACL and stat reports 0o666 for anything writable",
+    )
     def test_backup_has_owner_only_permissions(self, tmp_config_dir: Path) -> None:
         """The backup contains tokens, so it must be 0600 like config.json."""
         store = ConfigStore(config_dir=tmp_config_dir)

--- a/tests/test_encrypt_cli.py
+++ b/tests/test_encrypt_cli.py
@@ -7,9 +7,11 @@ patched services in ctx.obj.
 """
 
 import json
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from typer.testing import CliRunner
 
 from keboola_agent_cli.cli import app
@@ -238,6 +240,10 @@ class TestEncryptValuesFileInput:
 class TestEncryptValuesOutputFile:
     """Tests for --output-file option."""
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX mode bits are not the access-control mechanism on Windows: os.chmod cannot narrow an ACL and stat reports 0o666 for anything writable",
+    )
     def test_encrypt_values_output_file(self, tmp_path: Path) -> None:
         """--output-file writes encrypted JSON with 0600 permissions."""
         config_dir = tmp_path / "config"

--- a/tests/test_file_locking.py
+++ b/tests/test_file_locking.py
@@ -1,11 +1,22 @@
-"""Tests for file locking in ConfigStore."""
+"""Tests for file locking in ConfigStore.
+
+POSIX-only as a module: every test here is about `fcntl.flock`, which does not
+exist on Windows. `_try_flock` degrades to a no-op there by design (see
+`config_store._HAS_FCNTL`), so there is no behaviour left to assert -- the
+cross-platform guarantee is the atomic `os.replace`, covered elsewhere.
+"""
 
 import os
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from keboola_agent_cli.config_store import ConfigStore, _try_flock
 from keboola_agent_cli.models import AppConfig, ProjectConfig
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="fcntl.flock is POSIX-only")
 
 
 class TestTryFlock:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -530,7 +530,10 @@ class TestFormatLineageTable:
 
     def test_lineage_table_with_edges(self) -> None:
         """format_lineage_table renders data flow table with edge details."""
-        console = Console(file=StringIO(), no_color=True, force_terminal=False)
+        # Explicit width: Rich truncates cells to fit, and the default it picks
+        # differs per host, so without this the assertions below depend on the
+        # machine rather than on the rendering.
+        console = Console(file=StringIO(), no_color=True, force_terminal=False, width=200)
         data = {
             "edges": [
                 {

--- a/tests/test_permissions_cli.py
+++ b/tests/test_permissions_cli.py
@@ -1,6 +1,7 @@
 """Tests for permissions CLI commands and enforcement via CliRunner."""
 
 import json
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -533,13 +534,17 @@ class TestInitReadOnly:
         assert "cli:write" in config_data["permissions"]["deny"]
         assert "tool:write" in config_data["permissions"]["deny"]
 
-        # Verify config.json is owner-read-only (0400)
-        import stat
+        # Verify config.json is owner-read-only (0400). POSIX only: Windows
+        # reports 0o666 for anything writable regardless of its ACL, so these
+        # bits carry no information there -- the policy assertions above are
+        # what matter on that platform, and they still run.
+        if sys.platform != "win32":
+            import stat
 
-        file_mode = local_config_path.stat().st_mode
-        assert not (file_mode & stat.S_IWUSR), "config.json should not be user-writable"
-        assert not (file_mode & stat.S_IRGRP), "config.json should not be group-readable"
-        assert file_mode & stat.S_IRUSR, "config.json should be owner-readable"
+            file_mode = local_config_path.stat().st_mode
+            assert not (file_mode & stat.S_IWUSR), "config.json should not be user-writable"
+            assert not (file_mode & stat.S_IRGRP), "config.json should not be group-readable"
+            assert file_mode & stat.S_IRUSR, "config.json should be owner-readable"
 
         # Verify .claude/settings.json was created with comprehensive deny rules
         claude_settings_path = work_dir / ".claude" / "settings.json"

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -2,6 +2,7 @@
 
 import os
 import stat
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -301,6 +302,10 @@ class TestReplFirewallPropagation:
         )
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX mode bits are not the access-control mechanism on Windows: os.chmod cannot narrow an ACL and stat reports 0o666 for anything writable",
+)
 class TestHistoryPathPermissions:
     """Issue #269 sec-04 -- REPL history file must be 0600 to avoid token leaks."""
 

--- a/tests/test_version_service.py
+++ b/tests/test_version_service.py
@@ -1798,4 +1798,71 @@ class TestFrozenBuildVersionOutput:
             result = VersionService().get_versions()
         assert "install_channel" not in result["kbagent"]
         assert "upgrade_hint" not in result["kbagent"]
-        assert "uv tool install" in result["kbagent"]["upgrade_command"]
+        # `uv` is resolved to an absolute path, which on Windows is
+        # `...\\uv.EXE` -- assert the command shape, not one spelling of it.
+        upgrade = result["kbagent"]["upgrade_command"]
+        assert "tool install" in upgrade
+        assert "uv" in upgrade.lower()
+
+
+class TestUnknownLatestVersionIsNotAFailure:
+    """A failed version lookup must not read as a broken install.
+
+    Both situations used to reach the same `command is None` branch and print
+    the same thing, so a transient GitHub rate limit -- 60 unauthenticated
+    requests per hour, shared by every tool behind one IP -- told the user
+    their self-update was broken and handed them
+    `uv tool install --force --reinstall`, a command with no package in it.
+    """
+
+    def test_unknown_latest_reports_the_real_cause_and_no_fake_command(self) -> None:
+        plan = KbagentUpdatePlan(
+            current_version="0.80.3",
+            latest_version=None,
+            up_to_date=None,
+            command=None,
+            recovery_command=None,
+        )
+
+        result = VersionService._update_kbagent(plan)
+
+        assert result["reason"] == "latest_version_unknown"
+        assert result["updated"] is False
+        # Nothing was attempted, so nothing was "planned" either.
+        assert result["planned"] is False
+        assert "Could not determine the latest kbagent version" in result["message"]
+        assert "rate limit" in result["message"]
+        assert "0.80.3 was left untouched" in result["message"].replace("v0.80.3", "0.80.3")
+        # The old text, and the unrunnable command it suggested, must be gone.
+        assert "Could not prepare a self-update command" not in result["message"]
+        assert "recovery_command" not in result
+
+    def test_known_latest_without_a_command_still_says_so(self) -> None:
+        """The genuine local failure keeps its own, different message."""
+        plan = KbagentUpdatePlan(
+            current_version="0.80.3",
+            latest_version="0.80.4",
+            up_to_date=False,
+            command=None,
+            recovery_command="uv tool install --force --reinstall 'keboola-cli @ x'",
+        )
+
+        result = VersionService._update_kbagent(plan)
+
+        assert "Could not prepare a self-update command for v0.80.4" in result["message"]
+        assert "uv tool install --force --reinstall 'keboola-cli @ x'" in result["message"]
+
+    def test_no_recovery_command_points_at_the_releases_page_instead(self) -> None:
+        """Never render `Recover with: None`, and never a command with no package."""
+        plan = KbagentUpdatePlan(
+            current_version="0.80.3",
+            latest_version="0.80.4",
+            up_to_date=False,
+            command=None,
+            recovery_command=None,
+        )
+
+        result = VersionService._update_kbagent(plan)
+
+        assert "Recover with: None" not in result["message"]
+        assert "releases/latest" in result["message"]


### PR DESCRIPTION
Two halves of the same problem: Windows defects were reaching users, and when one bit them the error pointed the wrong way.

## 1. The full suite now gates on Windows

It never has. The `windows-latest` job ran a narrow slice — wheel build, semantic-layer export, the self-update runner, a smoke `--help` — because a real full run was **55 failures**, and nothing can gate on that, so nothing did.

Those 55 were test portability, not product bugs. But **two real defects had been sitting in that noise for entire releases**:

- `job run --idempotency-key` raising `WinError 5` on every Windows call (fixed 0.80.1)
- manifest paths written with backslashes into a **git-tracked** file, breaking every POSIX teammate (fixed 0.80.4)

A permanently red suite is worse than no suite: it reads as coverage while hiding things.

| | before | after |
|---|---|---|
| Windows failures | 26 | **0** (5399 passed, 42 skipped) |

### Skipped where the behaviour genuinely does not exist

POSIX mode bits (`os.chmod` cannot narrow an ACL, `stat` reports `0o666` for anything writable) and `fcntl`, each following the idiom already in this repo.

### Fixed, not skipped, where skipping would have thrown away coverage

- **`auto_update`** — five tests exercise the inline install + re-exec, but `should_defer()` defaults to True on Windows, so `_perform_update` was never reached and they silently asserted nothing. They now pin the path they mean to test via the documented `KBAGENT_DEFER_UPDATE=0`, which makes them deterministic everywhere. Tests that are *about* deferral patch `should_defer` directly and still win.
- **`permissions_cli`** — only the mode-bit block is guarded; the policy content and `.claude/settings.json` assertions still run on Windows.
- **console width** is pinned in `conftest.py`. Rich truncates cells to fit and infers width from the environment, so a test asserting a value appears in a table depended on the machine — which is how `organization-project` came to be silently cut in half on Windows while passing locally.

## 2. A failed version lookup no longer reads as a broken install

Hit live while verifying this work:

```
kbagent v0.80.3 update FAILED: Could not prepare a self-update command.
Recover with: uv tool install --force --reinstall
```

Wrong about the cause, and the command it offers **has no package in it** — pasting it does nothing.

One branch was serving two very different situations:

- **not knowing what to install** — usually transient: no network, or GitHub's unauthenticated API limit of 60 requests/hour, which is **per IP and shared by every tool on the connection** (this is exactly what happened: `gh` usage from a second machine on the same address exhausted it);
- **knowing the version but failing to build a command** — a real local problem.

Now reported separately. The transient case says what actually happened and that the install was left untouched; a recovery command is only printed when it is runnable, and otherwise points at the releases page.

Three tests, confirmed to fail against the old message.

## Testing

- macOS: 5420 passed
- Windows: 5399 passed, 0 failed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->