### PR TITLE
chore(release): renumber the unreleased 0.83.0 to 0.82.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.83.0",
+      "version": "0.82.1",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.83.0",
+  "version": "0.82.1",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/plugins/kbagent/agents/keboola-expert.md
+++ b/plugins/kbagent/agents/keboola-expert.md
@@ -167,7 +167,7 @@ API quirks live in [`gotchas.md`](../skills/kbagent/references/gotchas.md) --
 read it when a trigger fires. Each `(X.Y.Z+)` tag is the version floor.
 
 **Migrating an `mcp_tool` agent task**
-- No migration command exists; you do the argv mapping. Recipe in gotchas.md. (0.83.0+)
+- No migration command exists; you do the argv mapping. Recipe in gotchas.md. (0.82.1+)
 
 **Upgrading kbagent itself**
 - `install_channel` in `kbagent --json version` => native binary; `kbagent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-cli"
-version = "0.83.0"
+version = "0.82.1"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -24,7 +24,7 @@ from .constants import CHANGELOG_HEADLINE_MAX_CHARS
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
-    "0.83.0": [
+    "0.82.1": [
         "Note (#390): there will be NO `kbagent agent migrate-mcp-tasks` command. Migrating "
         "a scheduled `--type mcp_tool` task to `--type cli_command` before v0.85.0 is a "
         "manual step -- or an AI-assisted one, which is the point: the parity map knows "

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "keboola-cli"
-version = "0.83.0"
+version = "0.82.1"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
v0.82.0 shipped while #581 was in review, and it carried 0.81.0 with it via the
catch-up mechanism. That leaves exactly one unreleased change: the #581
documentation note recording that no mcp_tool migration command will be built.

A minor bump for a docs-only note is inflation -- nothing in it changes
behaviour, adds a command or moves an interface. 0.82.1 says what actually
happened.

Renumbered in pyproject.toml, the changelog key, and the `(0.83.0+)` since-tag
in keboola-expert.md; plugin.json / marketplace.json / uv.lock follow via
`make version-sync`. No content change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->