### PR TITLE
chore(deps): bump nanoid to 3.3.18 in web/frontend and web/backend

### DIFF
--- a/web/backend/package-lock.json
+++ b/web/backend/package-lock.json
@@ -2094,9 +2094,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/web/frontend/package-lock.json
+++ b/web/frontend/package-lock.json
@@ -4293,9 +4293,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Closes the last outstanding `npm audit` finding in the two web trees, which Dependabot does not cover.

## What

`npm audit` reports a **high**-severity advisory for `nanoid@3.3.16` — [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8), "custom generators can loop indefinitely when size is zero" — in both trees. It arrives transitively through postcss:

- `web/frontend`: `postcss@8.5.24 -> nanoid@3.3.16`
- `web/backend`: `vitest -> vite -> postcss@8.5.24 -> nanoid@3.3.16`

Dependabot never raised an alert for it (confirmed via `gh api repos/keboola/cli/dependabot/alerts`), so it would not have been fixed on its own.

## Why a plain `npm update` and not an `overrides` block

`postcss@8.5.24` declares `nanoid: ^3.3.16`, and the fixed `3.3.18` already satisfies that range. The lockfiles were pinned to `3.3.16` only because that was the newest release when they were generated — `npm ci` then reproduces it faithfully.

An `overrides` entry (the mechanism already used for `dompurify` in `web/frontend/package.json`) is only warranted when the fixed version falls *outside* the declared range. Here it does not, so `npm update nanoid` is sufficient and leaves nothing extra to maintain. The diff is two lockfile entries; no `package.json` changes.

## Impact

Low. postcss and nanoid run only at build time (`vite build` / `vitest`); nanoid never reaches the SPA bundle shipped in `_ui_dist`. This is hygiene rather than an incident — which is also why it is a standalone PR rather than something rushed into a release.

## Verification

- `npm ci` succeeds in both `web/frontend` and `web/backend` (lockfiles are internally consistent)
- `npm run build` (`tsc -b && vite build`) passes in `web/frontend` — the SPA is compiled into the wheel by `hatch_build.py`, so a broken build would ship a UI-less wheel
- `npm audit` reports **0 vulnerabilities** in both trees
- `npm ls nanoid` confirms `3.3.18` resolved in both

## Context

Follow-up to the six Dependabot security PRs merged just before this one (#554, #555, #558, #559, #563, #564), which together closed 12 open Dependabot alerts. This covers the one finding `npm audit` sees but Dependabot does not.

Dependency-only change: no version bump and no changelog entry, matching how those six were handled.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->