### PR TITLE
test(agent-prompt): gate the documented prompt budget against the enforced one (#585)

### DIFF
--- a/tests/test_agent_prompt.py
+++ b/tests/test_agent_prompt.py
@@ -12,6 +12,7 @@ for this suite.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -37,7 +38,32 @@ PLUGIN_JSON = PLUGIN_DIR / ".claude-plugin" / "plugin.json"
 # exhaustive per-command detail belongs in `AGENT_CONTEXT` (loaded on demand),
 # and the real answer to sustained growth is splitting keboola-expert into
 # per-domain specialists, not another bump. Trim before you add.
+#
+# This is the SINGLE SOURCE OF TRUTH for the budget. Prose elsewhere that
+# hardcodes its own figure instead of quoting this one drifts silently:
+# CONTRIBUTING.md and kbagent-pr-reviewer.md both said "60 KB" long after
+# v0.48.0 moved the ceiling to 62 000 B, and both still said "62 000 B"
+# after v0.88.0 moved it again to 70 000 B, until each was caught by hand.
+# test_documented_budget_matches_enforced_budget below is the gate that
+# keeps them honest going forward.
 PROMPT_BYTE_BUDGET = 70_000
+
+# Docs that state the prompt budget in prose. Each must quote it as
+# "<PROMPT_BYTE_BUDGET> B" (space-grouped, e.g. "70 000 B") next to the
+# word "budget" -- see _BUDGET_MENTION_RE below.
+BUDGET_DOC_SITES = [
+    "CONTRIBUTING.md",
+    "plugins/kbagent/agents/kbagent-pr-reviewer.md",
+]
+
+# Matches a budget figure immediately followed by "budget" (optionally
+# "prompt budget"), in either the enforced byte form ("70 000 B" / "70000 B")
+# or the deprecated kilobyte form ("60 KB"). Grouping punctuation (spaces or
+# commas) inside the number is tolerated so "70 000", "70,000" and "70000"
+# all match -- only the digits are compared against PROMPT_BYTE_BUDGET.
+_BUDGET_MENTION_RE = re.compile(
+    r"(?P<number>\d[\d ,]*\d|\d)\s*(?P<unit>KB|B)\s+(?:prompt\s+)?budget"
+)
 
 
 @pytest.fixture(scope="module")
@@ -80,6 +106,42 @@ class TestPilotAgentFile:
             f"Agent prompt is {size} bytes (~{size // 4} tokens); "
             f"budget is {PROMPT_BYTE_BUDGET} bytes. Trim or split into specialists."
         )
+
+    def test_documented_budget_matches_enforced_budget(self) -> None:
+        """Every doc site's budget figure must match PROMPT_BYTE_BUDGET.
+
+        A doc site that hardcodes its own figure instead of quoting this
+        module's constant is a silent-drift surface: CONTRIBUTING.md and
+        kbagent-pr-reviewer.md both sat on a stale figure for a full release
+        span after the constant moved, until someone caught it by hand. The
+        expected string is derived from PROMPT_BYTE_BUDGET rather than a
+        second hardcoded literal, so a legitimate future budget change (the
+        constant and the docs moving together) never fails this test --
+        only a doc site left behind does.
+
+        _BUDGET_MENTION_RE also matches the deprecated "KB" form, so a site
+        that regresses to kilobytes is caught even though its digits happen
+        to equal PROMPT_BYTE_BUDGET's byte figure (which would never
+        legitimately occur, but the point is to catch the wrong *unit* too).
+        """
+        expected_bytes = str(PROMPT_BYTE_BUDGET)
+        for relative_path in BUDGET_DOC_SITES:
+            text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+            mentions = _BUDGET_MENTION_RE.findall(text)
+            assert mentions, (
+                f"{relative_path} does not mention the prompt budget in the "
+                f"expected '<number> B budget' form. It must quote the "
+                f"enforced value (PROMPT_BYTE_BUDGET in {Path(__file__).name}), "
+                f"not its own figure."
+            )
+            for number, unit in mentions:
+                digits = re.sub(r"[ ,]", "", number)
+                assert unit == "B" and digits == expected_bytes, (
+                    f"{relative_path} states the prompt budget as "
+                    f"'{number} {unit}', but PROMPT_BYTE_BUDGET is "
+                    f"{expected_bytes} B ({Path(__file__).name} is the single "
+                    f"source of truth). Update the doc to match."
+                )
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds `test_documented_budget_matches_enforced_budget` and corrects the four doc sites that quoted a stale prompt-budget figure.

## Why — a correction to the issue's premise first

The issue reports that the 62 000 B budget on `plugins/kbagent/agents/keboola-expert.md` is unenforced. **It is enforced**, and has been since v0.48.0:

```
tests/test_agent_prompt.py::TestPilotAgentFile::test_agent_prompt_under_token_budget
```

That test is in the per-PR CI suite (`ci.yml`, `pull_request` trigger), and `actions/checkout` checks out the merge commit — so it already fails the *merge*, which is the scenario the issue is about. The proposed new test would have duplicated it.

The reason `grep -rn 62000 scripts/ tests/ .github/ Makefile` found nothing: the constant is spelled `PROMPT_BYTE_BUDGET = 62_000` with a PEP 515 underscore separator, which that pattern cannot match.

## Why — the real defect underneath

Chasing that miss surfaced a genuine drift. Four places state the budget in prose, and all four were stale:

| Site | Claimed | Enforced |
|---|---|---|
| `CONTRIBUTING.md:381` | 60 KB | 62 000 B |
| `CONTRIBUTING.md:464` | 60 KB | 62 000 B |
| `CONTRIBUTING.md:594` | 60 KB | 62 000 B |
| `plugins/kbagent/agents/kbagent-pr-reviewer.md:138` | 60 KB | 62 000 B |

v0.48.0 raised the ceiling 60 kB → 62 kB in the test and left every doc site behind. The file sits at 61 990 B today — over the documented budget, under the enforced one. So the prose was actively misleading in both directions: an author trimming to 60 KB cut ~2 kB of signal for nothing, and `/kbagent:review` (which reads `kbagent-pr-reviewer.md`) was telling reviewers the wrong number.

## Changes

- **`tests/test_agent_prompt.py`** — new `test_documented_budget_matches_enforced_budget`: every path in `BUDGET_DOC_SITES` must quote `PROMPT_BYTE_BUDGET` as `62 000 B` and must not carry a `60 KB prompt budget` claim. Raising the cap now forces the docs to move with it.
- **`tests/test_agent_prompt.py`** — comment spells the literal in plain digits so `grep 62000` hits, and names the constant as the single source of truth.
- **`CONTRIBUTING.md`** — three sites corrected; the first now also names the enforcing test, notes that CI builds the merge commit, and gives `wc -c` as the pre-flight check.
- **`plugins/kbagent/agents/kbagent-pr-reviewer.md`** — corrected and pointed at the test.

No behavior change; docs and test only. No version bump, no changelog entry.

## How it was tested

- `make check` — clean: lint, format, changelog-check, **5490 passed**, 12 skipped.
- Negative check on the new test: reverting one `CONTRIBUTING.md` site to `60 KB` makes it fail with the drifted path named; restoring makes it pass. A drift gate that cannot fail is worthless, so this was verified rather than assumed.
- Current size confirmed at 61 990 B (`wc -c`), within budget.

## Note on headroom

The issue flags ~15 bytes free. Real headroom on this branch is **10 bytes** (61 990 of 61 999 usable — the assertion is strict `<`). The next addition to that file hits the ceiling immediately; this PR does not change that, it only makes the number people trim against the correct one. Splitting `keboola-expert.md` into per-domain specialists is the standing recommendation in the test's own comment and is out of scope here.

Fixes #585