### PR TITLE
fix(config): validate the parameters section, not the whole config body (#587)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "kbagent",
-      "version": "0.84.0",
+      "version": "0.84.1",
       "source": "./plugins/kbagent",
       "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
       "category": "development"

--- a/plugins/kbagent/.claude-plugin/plugin.json
+++ b/plugins/kbagent/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kbagent",
-  "version": "0.84.0",
+  "version": "0.84.1",
   "description": "AI-friendly interface to Keboola Connection projects — explore configs, jobs, lineage, call MCP tools, manage dev branches, and debug SQL in workspaces",
   "author": {
     "name": "Keboola",

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -1160,6 +1160,37 @@ events and emits a final `done` SSE frame mirroring the same record.
   plus `project_alias`, `branch_id`, `validation_status`, and
   `validation_errors` (always present, even if empty). Shape-symmetric with
   `config detail` single-config mode and `config row-create`.
+- **Validation reads the `parameters` section, not the whole body (since
+  v0.84.1).** A component's `configurationSchema` describes the CONTENTS of
+  `parameters`, so error paths are reported as `parameters.<field>`. Sibling
+  keys (`storage`, `runtime`, `authorization`) are not covered by the schema
+  and never fail validation. **Before v0.84.1 the whole configuration object
+  was validated against that schema**, which inverted the result: a correct
+  body (`{"parameters": {"db": ...}}`) was rejected with the misleading
+  `<root>: 'db' is a required property`, while a body missing the
+  `parameters` wrapper validated clean. If you are on <= 0.84.0 and hit that
+  `<root>:` error on a body you know is correct, the config is fine and the
+  validator is wrong -- upgrade rather than reaching for `--no-validate`,
+  which switches off the checking that still works.
+- **A body with no `parameters` key is validated whole** -- that is the
+  keboola.flow shape (`phases` / `tasks` sit at the configuration root).
+  Consequence: a parameters-level body posted by mistake as the whole
+  configuration still validates `ok`, because it is indistinguishable from a
+  flow-style config. Always POST the full object.
+## Cloning a config by hand: copy the WHOLE object, not just `parameters`
+
+- A configuration's root has siblings of `parameters` that carry real
+  behavior: `runtime` (e.g. `runtime.parallelism`), `storage` (input/output
+  mapping), and `authorization` (OAuth). `config examples` shows only a
+  `parameters` shape, so reconstructing a config from `config detail` output
+  by copying `configuration["parameters"]` alone **silently drops them**.
+- The failure is silent and slow, not loud: a dropped `runtime.parallelism`
+  makes Keboola fall back to `parallelism: 1`, so a 65-row writer runs
+  strictly sequentially instead of 20-at-a-time. Nothing errors -- you only
+  see it in per-row job start/end timestamps (issue #587).
+- There is **no `config clone` command**. To duplicate a config, take the
+  whole `configuration` object from `config detail` and pass it verbatim to
+  `config new --push --configuration-file`, changing only what must differ.
 ## `data-app` JSON output: key for the app's own id is `app_id` (since v0.33.0)
 
 - Every `kbagent --json data-app <subcommand>` envelope emits the

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -1177,7 +1177,8 @@ events and emits a final `done` SSE frame mirroring the same record.
   Consequence: a parameters-level body posted by mistake as the whole
   configuration still validates `ok`, because it is indistinguishable from a
   flow-style config. Always POST the full object.
-## Cloning a config by hand: copy the WHOLE object, not just `parameters`
+
+## Cloning a config by hand: copy the WHOLE object, not just `parameters` (documented since v0.84.1, issue #587)
 
 - A configuration's root has siblings of `parameters` that carry real
   behavior: `runtime` (e.g. `runtime.parallelism`), `storage` (input/output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keboola-cli"
-version = "0.84.0"
+version = "0.84.1"
 description = "AI-friendly CLI for managing Keboola projects"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -47,6 +47,13 @@ CHANGELOG: dict[str, list[str]] = {
         "shape (`phases` / `tasks` ARE the configuration root); the known limit of that "
         "fallback is that a parameters-level body posted by mistake as the whole "
         "configuration is indistinguishable from a flow config and still validates `ok`. "
+        "A schema that itself declares a top-level `parameters` property is also validated "
+        "whole, since such a schema self-evidently describes the entire configuration "
+        "object -- deciding on the body alone would have REGRESSED such a component, which "
+        "worked before this fix precisely because every body used to be validated whole. "
+        "The mirror case (a parameters-level schema whose own fields include one named "
+        "`parameters`) is misvalidated today as well, so preferring the schema signal never "
+        "trades a working case for a broken one. "
         "Validation runs only on `create_config`; `config update` and `config row-create` "
         "do not validate against a schema and are unaffected.",
         "Tests: the mock schema in `tests/test_config_create_service.py` was itself the "

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -24,6 +24,40 @@ from .constants import CHANGELOG_HEADLINE_MAX_CHARS
 
 # Ordered newest-first.  Each value is a list of brief one-line descriptions.
 CHANGELOG: dict[str, list[str]] = {
+    "0.84.1": [
+        "Fix: `kbagent config new --push` schema validation now validates the body's "
+        "`parameters` section instead of the whole configuration object (closes #587). A "
+        "component's `configurationSchema` describes the CONTENTS of `parameters` -- a "
+        'writer schema says `required: ["db"]` while the configuration it describes is '
+        '`{"parameters": {"db": ...}, "runtime": {...}}`. Validating the whole object was '
+        "off by one level, which inverted every outcome: a CORRECT configuration was "
+        "rejected with the misleading `<root>: 'db' is a required property`, while a "
+        "MALFORMED one missing the `parameters` wrapper validated clean. Both were "
+        "confirmed live against the AI Service before and after the fix. The practical "
+        "damage was second-order: the reporter reached for `--no-validate` to get past the "
+        "bogus error, and with validation off also lost the check that would have caught a "
+        "dropped `runtime.parallelism` -- a 65-row Snowflake writer then ran sequentially "
+        "instead of 20-at-a-time (140 min vs the expected 60-90), silently, with nothing "
+        "in any tool output pointing at it. Error paths are now reported as "
+        "`parameters.<field>` so they name the section to fix, and sibling keys "
+        "(`storage`, `runtime`, `authorization`), which the schema does not describe, no "
+        "longer fail validation. Unwrapping affects validation ONLY -- the POSTed body "
+        "still carries every sibling key, verified by its own regression test. A body with "
+        "no `parameters` key at all is still validated whole, which is the keboola.flow "
+        "shape (`phases` / `tasks` ARE the configuration root); the known limit of that "
+        "fallback is that a parameters-level body posted by mistake as the whole "
+        "configuration is indistinguishable from a flow config and still validates `ok`. "
+        "Validation runs only on `create_config`; `config update` and `config row-create` "
+        "do not validate against a schema and are unaffected.",
+        "Tests: the mock schema in `tests/test_config_create_service.py` was itself the "
+        "reason this shipped -- it wrapped everything in a `parameters` property, a shape "
+        "no real component ever returns, so the off-by-one-level validation matched it and "
+        "CI stayed green. It is now the real parameters-level shape, and six regression "
+        "tests cover the contract: sibling keys do not fail validation, the POSTed body "
+        "keeps its siblings, error paths are prefixed `parameters.`, empty `parameters` "
+        "still fails a schema with required fields, and the no-`parameters` flow-style "
+        "fallback both passes valid bodies and still reports real errors.",
+    ],
     "0.84.0": [
         "New: `kbagent auth login-password --email EMAIL (--password PASSWORD | "
         "--password-stdin) [--totp-secret SECRET]` -- the deliberate unattended exception "

--- a/src/keboola_agent_cli/services/config_service.py
+++ b/src/keboola_agent_cli/services/config_service.py
@@ -1822,12 +1822,22 @@ class ConfigService(BaseService):
         # ("<root>: 'db' is a required property") while a body missing the
         # ``parameters`` wrapper validated clean.
         #
-        # Configurations that carry no ``parameters`` key at all are validated
-        # whole: for keboola.flow, ``phases`` / ``tasks`` ARE the configuration
-        # root and the schema describes that root, so there is nothing to
-        # unwrap. This also keeps any future parameters-less component working
-        # exactly as it does today.
-        unwrapped = "parameters" in body
+        # Two shapes are validated WHOLE instead, and both are decided before
+        # unwrapping:
+        #
+        # 1. The body carries no ``parameters`` key. For keboola.flow,
+        #    ``phases`` / ``tasks`` ARE the configuration root and the schema
+        #    describes that root, so there is nothing to unwrap.
+        # 2. The schema itself declares a top-level ``parameters`` property,
+        #    which means it describes the whole configuration object. Deciding
+        #    on the body alone would regress such a component: every body used
+        #    to be validated whole, so it worked before this fix. Whereas the
+        #    mirror case -- a parameters-level schema whose fields happen to
+        #    include one named ``parameters`` -- is misvalidated today too, so
+        #    preferring the schema signal here never trades a working case for
+        #    a broken one.
+        schema_is_whole_body = "parameters" in (schema.get("properties") or {})
+        unwrapped = "parameters" in body and not schema_is_whole_body
         target = body["parameters"] if unwrapped else body
 
         try:

--- a/src/keboola_agent_cli/services/config_service.py
+++ b/src/keboola_agent_cli/services/config_service.py
@@ -1776,6 +1776,14 @@ class ConfigService(BaseService):
     ) -> tuple[str, list[str]]:
         """Validate a configuration body against the component's JSON schema.
 
+        The schema describes the contents of the body's ``parameters`` key, so
+        that section is what gets validated; sibling keys (``storage``,
+        ``runtime``, ``authorization``) are not covered by it and are left
+        alone. A body with no ``parameters`` key is validated as a whole
+        (keboola.flow-style configurations). Reported error paths are prefixed
+        with ``parameters.`` so they point at the section the caller must fix.
+        Unwrapping affects validation only -- the POSTed body is never altered.
+
         Returns:
             ``("ok", [])`` when the body matches the schema.
             ``("failed", [errors])`` when validation reports issues.
@@ -1805,11 +1813,30 @@ class ConfigService(BaseService):
         if not schema:
             return ("skipped", [])
 
+        # A component's ``configurationSchema`` describes the CONTENTS of the
+        # ``parameters`` key -- NOT the whole configuration object (issue #587).
+        # A writer schema says ``required: ["db"]`` while the configuration it
+        # describes is ``{"parameters": {"db": ...}, "runtime": {...}}``, so the
+        # body has to be unwrapped before it is validated. Validating the whole
+        # object inverted every outcome: a correct configuration was rejected
+        # ("<root>: 'db' is a required property") while a body missing the
+        # ``parameters`` wrapper validated clean.
+        #
+        # Configurations that carry no ``parameters`` key at all are validated
+        # whole: for keboola.flow, ``phases`` / ``tasks`` ARE the configuration
+        # root and the schema describes that root, so there is nothing to
+        # unwrap. This also keeps any future parameters-less component working
+        # exactly as it does today.
+        unwrapped = "parameters" in body
+        target = body["parameters"] if unwrapped else body
+
         try:
             validator = jsonschema.Draft7Validator(schema)
             errors: list[str] = []
-            for err in validator.iter_errors(body):
-                path = ".".join(str(p) for p in err.absolute_path) or "<root>"
+            for err in validator.iter_errors(target):
+                segments = ["parameters"] if unwrapped else []
+                segments.extend(str(p) for p in err.absolute_path)
+                path = ".".join(segments) or "<root>"
                 errors.append(f"{path}: {err.message}")
         except jsonschema.SchemaError:
             # Component schema itself is malformed -- don't block the create.

--- a/tests/test_config_create_service.py
+++ b/tests/test_config_create_service.py
@@ -58,6 +58,22 @@ FLOW_SCHEMA = {
     "required": ["phases", "tasks"],
 }
 
+# A schema that declares a top-level ``parameters`` property describes the
+# WHOLE configuration object, so it must NOT be unwrapped. Before the #587 fix
+# every body was validated whole, so such a component worked; keying the unwrap
+# on the body alone would have regressed it.
+WHOLE_BODY_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "parameters": {
+            "type": "object",
+            "properties": {"table": {"type": "string"}},
+            "required": ["table"],
+        }
+    },
+    "required": ["parameters"],
+}
+
 
 def _make_service(
     tmp_config_dir: Path,
@@ -490,6 +506,46 @@ class TestParametersLevelSchemaValidation:
 
         storage.create_config.assert_called_once()
         assert result["validation_status"] == "ok"
+
+    def test_schema_declaring_a_parameters_property_is_validated_whole(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """A schema with a top-level ``parameters`` property describes the whole
+        configuration object, so unwrapping would validate the wrong level.
+
+        Keying the unwrap on the body alone would have regressed such a
+        component: before #587 every body was validated whole, so it worked.
+        The parameters-level read must not be applied to a schema that is
+        self-evidently whole-body.
+        """
+        service, storage, _ = _make_service(tmp_config_dir, schema=WHOLE_BODY_SCHEMA)
+
+        result = service.create_config(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            name="My Config",
+            configuration=VALID_BODY,
+        )
+
+        storage.create_config.assert_called_once()
+        assert result["validation_status"] == "ok", result
+
+    def test_whole_body_schema_still_reports_errors_at_root(self, tmp_config_dir: Path) -> None:
+        """Whole-body schemas keep whole-body error paths -- no `parameters.`
+        prefix is invented for a level that was never unwrapped.
+        """
+        service, _, _ = _make_service(tmp_config_dir, schema=WHOLE_BODY_SCHEMA)
+
+        result = service.create_config(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            name="My Config",
+            configuration=INVALID_BODY,
+            dry_run=True,
+        )
+
+        assert result["validation_status"] == "failed"
+        assert result["validation_errors"] == ["parameters: 'table' is a required property"]
 
     def test_config_without_parameters_key_still_reports_its_errors(
         self, tmp_config_dir: Path

--- a/tests/test_config_create_service.py
+++ b/tests/test_config_create_service.py
@@ -32,22 +32,31 @@ SAMPLE_CREATED = {
     "created": "2026-05-11T10:00:00+00:00",
 }
 
-# A trivial JSON schema that requires a top-level "parameters" object with
-# a required "table" string field. Used to drive the validation branch.
+# A trivial JSON schema in the shape the AI Service actually returns: a
+# component's ``configurationSchema`` describes the CONTENTS of the
+# ``parameters`` key, NOT the whole configuration object (issue #587). A real
+# writer schema says ``required: ["db"]`` while ``db`` lives at
+# ``configuration.parameters.db`` -- so the body must be unwrapped before it is
+# validated. This fixture previously wrapped everything in a ``parameters``
+# property, a shape no component ever ships, which is why the off-by-one-level
+# validation bug stayed green in CI.
 TABLE_SCHEMA = {
     "type": "object",
-    "properties": {
-        "parameters": {
-            "type": "object",
-            "properties": {"table": {"type": "string"}},
-            "required": ["table"],
-        }
-    },
-    "required": ["parameters"],
+    "properties": {"table": {"type": "string"}},
+    "required": ["table"],
 }
 
 VALID_BODY = {"parameters": {"table": "orders"}}
 INVALID_BODY = {"parameters": {"limit": 100}}  # missing required "table"
+
+# A keboola.flow-style schema + body: conditional flows carry no ``parameters``
+# key at all -- ``phases`` / ``tasks`` sit at the configuration root and the
+# schema describes that root (see resources/flow/conditional-flow-schema.json).
+FLOW_SCHEMA = {
+    "type": "object",
+    "properties": {"phases": {"type": "array"}, "tasks": {"type": "array"}},
+    "required": ["phases", "tasks"],
+}
 
 
 def _make_service(
@@ -368,3 +377,131 @@ class TestCreateConfigSchemaValidation:
         )
 
         ai.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Parameters-level schema validation (issue #587)
+# ---------------------------------------------------------------------------
+
+
+class TestParametersLevelSchemaValidation:
+    """A component's ``configurationSchema`` describes the contents of the
+    ``parameters`` key, so the body must be unwrapped before validating.
+
+    Validating the whole configuration object against it inverted the outcome:
+    a CORRECT Keboola configuration (``{"parameters": {"db": ...}}``) was
+    rejected with ``<root>: 'db' is a required property``, while a MALFORMED
+    one (``{"db": ...}``, missing the wrapper) validated clean. Reporters hit
+    this on ``config new --push``, worked around it with ``--no-validate``, and
+    thereby lost the one check that would have caught an unrelated mistake.
+    """
+
+    def test_sibling_keys_next_to_parameters_do_not_fail_validation(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """runtime / storage / authorization are siblings of parameters and are
+        not described by the parameters schema -- their presence must not fail.
+        """
+        service, storage, _ = _make_service(tmp_config_dir, schema=TABLE_SCHEMA)
+
+        result = service.create_config(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            name="My Config",
+            configuration={
+                "parameters": {"table": "orders"},
+                "runtime": {"parallelism": "20"},
+                "storage": {"input": {"tables": []}},
+            },
+        )
+
+        storage.create_config.assert_called_once()
+        assert result["validation_status"] == "ok"
+        assert result["validation_errors"] == []
+
+    def test_whole_body_is_posted_even_though_only_parameters_is_validated(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """Unwrapping happens for validation ONLY -- the POSTed configuration
+        keeps every sibling key, otherwise the fix would drop the very data
+        (``runtime.parallelism``) whose loss prompted issue #587.
+        """
+        service, storage, _ = _make_service(tmp_config_dir, schema=TABLE_SCHEMA)
+        body = {"parameters": {"table": "orders"}, "runtime": {"parallelism": "20"}}
+
+        service.create_config(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            name="My Config",
+            configuration=body,
+        )
+
+        posted = storage.create_config.call_args.kwargs["configuration"]
+        assert posted == body
+
+    def test_validation_error_path_points_inside_parameters(self, tmp_config_dir: Path) -> None:
+        """The reported path must name the parameters section the user has to
+        fix, not ``<root>`` -- the misleading path was the reporter's whole
+        symptom in issue #587.
+        """
+        service, _, _ = _make_service(tmp_config_dir, schema=TABLE_SCHEMA)
+
+        result = service.create_config(
+            alias="prod",
+            component_id="keboola.ex-db-snowflake",
+            name="My Config",
+            configuration=INVALID_BODY,
+            dry_run=True,
+        )
+
+        assert result["validation_status"] == "failed"
+        assert result["validation_errors"] == ["parameters: 'table' is a required property"]
+
+    def test_empty_parameters_still_fails_a_schema_that_requires_fields(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """Unwrapping must not turn validation into a no-op: a body whose
+        ``parameters`` is empty still has to fail a schema with required fields.
+        """
+        service, storage, _ = _make_service(tmp_config_dir, schema=TABLE_SCHEMA)
+
+        with pytest.raises(ConfigError, match="failed schema validation"):
+            service.create_config(
+                alias="prod",
+                component_id="keboola.ex-db-snowflake",
+                name="My Config",
+                configuration={"parameters": {}},
+            )
+        storage.create_config.assert_not_called()
+
+    def test_config_without_parameters_key_is_validated_whole(self, tmp_config_dir: Path) -> None:
+        """keboola.flow-style configs have no ``parameters`` key -- phases and
+        tasks ARE the configuration root, so the whole body is the thing the
+        schema describes and must still be validated.
+        """
+        service, storage, _ = _make_service(tmp_config_dir, schema=FLOW_SCHEMA)
+
+        result = service.create_config(
+            alias="prod",
+            component_id="keboola.flow",
+            name="My Flow",
+            configuration={"phases": [], "tasks": []},
+        )
+
+        storage.create_config.assert_called_once()
+        assert result["validation_status"] == "ok"
+
+    def test_config_without_parameters_key_still_reports_its_errors(
+        self, tmp_config_dir: Path
+    ) -> None:
+        """The no-parameters fallback validates for real -- it is not a bypass."""
+        service, storage, _ = _make_service(tmp_config_dir, schema=FLOW_SCHEMA)
+
+        with pytest.raises(ConfigError, match="failed schema validation"):
+            service.create_config(
+                alias="prod",
+                component_id="keboola.flow",
+                name="My Flow",
+                configuration={"phases": []},  # 'tasks' missing
+            )
+        storage.create_config.assert_not_called()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -540,6 +540,9 @@ class TestFullE2E:
         _step("19b", "config new --push", "one-shot remote create (0.33.0+)")
         self._test_config_new_push()
 
+        _step("19c", "config new --push validation", "real schema vs real body (#587)")
+        self._test_config_new_push_schema_validation()
+
         # ==============================================================
         # PHASE 5: Component commands
         # ==============================================================
@@ -2184,6 +2187,97 @@ class TestFullE2E:
                 "--config-id",
                 new_config_id,
             )
+
+    def _test_config_new_push_schema_validation(self) -> None:
+        """Test ``config new --push`` schema validation against a REAL schema (issue #587).
+
+        ``_test_config_new_push`` only covers the empty-shell path, where
+        validation auto-skips -- so nothing there exercises a real component
+        schema against a real body. That is the exact gap issue #587 fell
+        through: a component's ``configurationSchema`` describes the CONTENTS
+        of ``parameters``, the validator compared it against the WHOLE
+        configuration object, and the unit-test mock schema was written in the
+        same wrong shape, so CI stayed green while a correct configuration was
+        rejected and a malformed one accepted.
+
+        Every step is ``--dry-run``: no configuration is created.
+
+        Tolerant by design -- not every stack serves a schema for every
+        component. The load-bearing assertion is one-directional and holds
+        either way: **a valid configuration must never come back "failed"**.
+        The negative case only runs when the stack actually returned a schema.
+        """
+        # A well-formed writer body: parameters + a runtime sibling, which the
+        # parameters schema does not describe and must therefore not trip on.
+        valid_body = json.dumps(
+            {
+                "parameters": {
+                    "db": {
+                        "host": "mysql.example.com",
+                        "port": 3306,
+                        "database": "e2e",
+                        "user": "e2e",
+                        "#password": "e2e",
+                    }
+                },
+                "runtime": {"parallelism": "20"},
+            }
+        )
+
+        valid = self._run_ok(
+            "config",
+            "new",
+            "--component-id",
+            "keboola.ex-db-mysql",
+            "--project",
+            self.alias,
+            "--name",
+            f"{RUN_ID} validation (dry)",
+            "--push",
+            "--no-files",
+            "--configuration",
+            valid_body,
+            "--dry-run",
+        )["data"]
+
+        assert valid["validation_status"] in ("ok", "skipped"), (
+            f"A valid configuration must never fail validation, got: {valid}"
+        )
+        # Unwrapping is for validation only -- the planned POST keeps every
+        # sibling key. Dropping `runtime` is the silent data loss of #587.
+        assert set(valid["configuration"]) == {"parameters", "runtime"}, valid
+        assert valid["configuration"]["runtime"] == {"parallelism": "20"}, valid
+
+        if valid["validation_status"] == "skipped":
+            print(
+                f"  {_DIM}   (stack served no schema for keboola.ex-db-mysql; "
+                f"negative case skipped){_RESET}"
+            )
+            return
+
+        # The stack DID serve a schema, so a body with junk parameters must be
+        # rejected -- proving the unwrap did not turn validation into a no-op.
+        invalid = self._run_ok(
+            "config",
+            "new",
+            "--component-id",
+            "keboola.ex-db-mysql",
+            "--project",
+            self.alias,
+            "--name",
+            f"{RUN_ID} validation-bad (dry)",
+            "--push",
+            "--no-files",
+            "--configuration",
+            json.dumps({"parameters": {"nonsense": 1}}),
+            "--dry-run",
+        )["data"]
+
+        assert invalid["validation_status"] == "failed", invalid
+        assert invalid["validation_errors"], invalid
+        # Paths name the section to fix. Before #587 this read "<root>: ...",
+        # which pointed the reader at the wrong level of their own config.
+        assert all(e.startswith("parameters") for e in invalid["validation_errors"]), invalid
 
     def _test_component_commands(self) -> None:
         """List components and get detail for one.

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "keboola-cli"
-version = "0.84.0"
+version = "0.84.1"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Closes #587.

## The bug

A component's `configurationSchema` (AI Service) describes the **contents of the `parameters` key**, not the whole configuration object. `_validate_config_body` validated the whole body against it, so it was off by one level — which inverted every outcome.

Confirmed live against the AI Service (`keboola.ex-db-mysql`, `--dry-run`, nothing created):

| body sent | what it is | before | after |
|---|---|---|---|
| `{"parameters": {"db": {…}}, "runtime": {…}}` | **valid** Keboola config | ❌ `failed` — `<root>: 'db' is a required property` | ✅ `ok` |
| `{"parameters": {"nonsense": 1}}` | invalid `parameters` | ✅ `failed` | ✅ `failed` — `parameters: 'db' is a required property` |
| `{"db": {…}}` | **malformed** (no wrapper) | ✅ `ok` (wrong) | unchanged — see *Known limit* |

Not platform-specific despite the Windows environment in the report — reproduced on macOS.

## Why it mattered more than a bad error message

Faced with a bogus failure on a body they knew was correct, the reporter passed `--no-validate` to get past it, and thereby also switched off the checking that *did* work. What slipped through was a dropped `runtime.parallelism`. Keboola treats a missing `runtime` as `parallelism: 1`, so a 65-row Snowflake writer ran strictly sequentially — **140 minutes instead of the expected 60–90** — with nothing in any tool output pointing at it. It was caught by hand-comparing per-row job timestamps after the fact.

## The fix

`services/config_service.py` — validation targets `body["parameters"]`, and error paths are prefixed `parameters.` so they name the section to fix. Sibling keys (`storage`, `runtime`, `authorization`), which the schema does not describe, no longer fail validation.

Unwrapping affects **validation only** — the POSTed body still carries every sibling key. That has its own regression test, since dropping siblings is the very failure this issue is about.

A body with **no** `parameters` key is still validated whole: that is the `keboola.flow` shape, where `phases` / `tasks` *are* the configuration root (cf. `resources/flow/conditional-flow-schema.json`, whose `required` is `["phases","tasks"]`).

**Known limit:** a parameters-level body posted by mistake as the whole configuration is indistinguishable from a flow-style config and still validates `ok`. That is unchanged from today's behavior, not a new gap — the two shapes cannot be told apart from the body alone.

**Scope:** validation runs only in `create_config`. `config update` and `config row-create` do not validate against a schema and are untouched.

## Why CI never caught it

The mock schema in `tests/test_config_create_service.py` was itself the reason this shipped: it wrapped everything in a `parameters` property — a shape no real component returns — so the off-by-one-level validation matched it and the suite stayed green. It is now the real parameters-level shape.

Six tests cover the new contract, of which **three are true regression tests** — verified to fail against the pre-fix code:

- siblings next to `parameters` do not fail validation
- the POSTed body keeps its siblings
- error paths are prefixed `parameters.`

The other three pass against both old and new code by design, and are guards rather than regression proofs: the two flow-style fallback cases (which must keep behaving exactly as before) and the empty-`parameters` case (which raises under both implementations, for different reported reasons).

Because unit-test mocking is what failed here in the first place, `tests/test_e2e.py` gains step **19c**: a valid wrapped body posted against a real `keboola.ex-db-mysql` schema (dry-run only, nothing created), asserting the invariant that holds on any stack — *a valid configuration must never come back `failed`* — plus, when the stack does serve a schema, that junk `parameters` are still rejected.

`make check`: 5495 passed, 12 skipped.

## Not addressed here

Issue #587 raises two further asks, both worth their own issues:

1. **A real `config clone` command** — copy an entire existing configuration and override only named fields, removing the "forgot a sibling key" class of bug at the source.
2. **`config examples` / `config new --help` should say** that a configuration may carry `runtime` / `storage` / `authorization` next to `parameters`. Documented in `gotchas.md` in this PR, but not yet surfaced in the CLI itself.

Review also flagged a third, in `component_service._resolve_parameters` (the scaffold generator): it still probes `schema["properties"]["parameters"]["properties"]` — the same wrong mental model — before falling back to the correct flat read. Harmless today because the fallback catches it, but it is a different code path with its own tests, so it is a follow-up rather than scope creep here.