### PR TITLE
fix(changelog): unbreak main -- 0.84.1's Tests note was shown cut off

### DIFF
--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -57,7 +57,7 @@ CHANGELOG: dict[str, list[str]] = {
         "Validation runs only on `create_config`; `config update` and `config row-create` "
         "do not validate against a schema and are unaffected.",
         "Tests: the mock schema in `tests/test_config_create_service.py` was itself the "
-        "reason this shipped -- it wrapped everything in a `parameters` property, a shape "
+        "reason this shipped. It wrapped everything in a `parameters` property, a shape "
         "no real component ever returns, so the off-by-one-level validation matched it and "
         "CI stayed green. It is now the real parameters-level shape, and six regression "
         "tests cover the contract: sibling keys do not fail validation, the POSTed body "


### PR DESCRIPTION
**main is red right now.** `test_newest_release_notes_are_not_truncated` fails on `275f96d`.

## What happened

#591 added a test asserting the newest version's release notes are not truncated in `kbagent changelog` / the "What's new" banner. #589 was written and CI'd before that test existed, and was never re-run against the newer main, so both PRs were green and merging them in order produced a red main.

Its `Tests:` note opens with a 161-character sentence — one character over `CHANGELOG_HEADLINE_MAX_CHARS` — so the summary broke off at "... and CI stayed green …".

## The fix

One dash becomes a period. Same words, same order, nothing dropped:

| | chars | summary |
|---|---|---|
| before | 161 | `... a shape no real component ever returns, so the off-by-one-level validation matched it and CI stayed green …` |
| after | 99 | `Tests: the mock schema in \`tests/test_config_create_service.py\` was itself the reason this shipped.` |

## Note

This is exactly the failure mode in #585 — CI checks the merge commit, but only recomputes it when the PR is updated, so a branch that sits while main moves reports a green result for a merge that no longer exists. #560 hit the same thing earlier today (33 commits stale) and was caught only because the merge was simulated by hand first. Here it landed.

Worth deciding on #585's option 1 (require branches up to date) — this is the second occurrence in one day.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->