### PR TITLE
test: stop the suite from writing the developer's real version cache

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,32 @@ def _no_wheel_asset_probe(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(version_service.httpx, "head", _head)
 
 
+@pytest.fixture(autouse=True)
+def _redirect_version_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Keep the version cache out of the developer's real config directory.
+
+    ``auto_update._get_cache_path`` resolves through ``platformdirs``, so it
+    ignores ``--config-dir`` and always points at the machine's own
+    ``version_cache.json``. Any test that reaches the real ``_write_cache``
+    -- ``TestMaybeAutoUpdate`` has two that mock ``_read_cache`` but not the
+    write -- therefore stamps the canonical fake latest version ``1.0.0``
+    into that file. The CLI then believes for a full
+    ``AUTO_UPDATE_CHECK_INTERVAL`` (1 hour) that a release tag which does not
+    exist is available, prints an update banner on every command, and fails
+    the reinstall: running ``make test`` broke auto-update for whoever ran it.
+
+    Redirecting the module attribute (not the file's top-level import, which
+    ``TestGetCachePath`` still exercises against the real resolver) fixes it
+    for the whole suite, including tests written later that forget to mock
+    the write. ``test_suite_never_resolves_to_the_real_user_cache`` fails if
+    this fixture is removed.
+    """
+    from keboola_agent_cli import auto_update
+
+    cache_file = tmp_path / "version_cache.json"
+    monkeypatch.setattr(auto_update, "_get_cache_path", lambda: cache_file)
+
+
 @pytest.fixture
 def tmp_config_dir(tmp_path: Path) -> Path:
     """Provide a temporary directory for configuration files."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,29 +63,42 @@ def _no_wheel_asset_probe(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _redirect_version_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Keep the version cache out of the developer's real config directory.
+def _redirect_global_state_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Keep auto-update bookkeeping out of the developer's real config directory.
 
-    ``auto_update._get_cache_path`` resolves through ``platformdirs``, so it
-    ignores ``--config-dir`` and always points at the machine's own
-    ``version_cache.json``. Any test that reaches the real ``_write_cache``
-    -- ``TestMaybeAutoUpdate`` has two that mock ``_read_cache`` but not the
-    write -- therefore stamps the canonical fake latest version ``1.0.0``
-    into that file. The CLI then believes for a full
+    Both writers below resolve through ``platformdirs.user_config_dir``, so
+    neither honours ``--config-dir``: they always address the machine's own
+    files. That is correct for the shipped CLI -- the version cache and a
+    pending update are per-machine, not per-project -- and exactly why the
+    test suite has to redirect them rather than the production code.
+
+    ``auto_update._get_cache_path`` backs ``version_cache.json``. Any test
+    reaching the real ``_write_cache`` -- ``TestMaybeAutoUpdate`` has two that
+    mock ``_read_cache`` but not the write -- stamps the canonical fake latest
+    version ``1.0.0`` into it. The CLI then believes for a full
     ``AUTO_UPDATE_CHECK_INTERVAL`` (1 hour) that a release tag which does not
     exist is available, prints an update banner on every command, and fails
     the reinstall: running ``make test`` broke auto-update for whoever ran it.
 
-    Redirecting the module attribute (not the file's top-level import, which
-    ``TestGetCachePath`` still exercises against the real resolver) fixes it
-    for the whole suite, including tests written later that forget to mock
-    the write. ``test_suite_never_resolves_to_the_real_user_cache`` fails if
+    ``update_runner.state_dir`` backs the deferred-update marker / exit / log
+    files. No test reaches it today (the deferral tests mock
+    ``request_deferred_update``, and ``should_defer()`` is False off Windows),
+    but it is the same latent bug: on Windows ``should_defer()`` defaults to
+    True, and ``report_finished_deferred_update`` -- which runs ahead of every
+    skip gate -- consumes and unlinks a genuine pending report while reading
+    it, so a developer's own update outcome would vanish into a test run.
+
+    Redirecting the module attributes (not the top-level import in
+    ``test_auto_update.py``, which ``TestGetCachePath`` still exercises
+    against the real resolver) covers tests written later that forget to mock
+    the writer. ``test_suite_never_resolves_to_the_real_user_cache`` fails if
     this fixture is removed.
     """
-    from keboola_agent_cli import auto_update
+    from keboola_agent_cli import auto_update, update_runner
 
     cache_file = tmp_path / "version_cache.json"
     monkeypatch.setattr(auto_update, "_get_cache_path", lambda: cache_file)
+    monkeypatch.setattr(update_runner, "state_dir", lambda: tmp_path)
 
 
 @pytest.fixture

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -682,6 +682,30 @@ class TestGetCachePath:
         assert path.name == "version_cache.json"
         assert "keboola-agent-cli" in str(path)
 
+    def test_suite_never_resolves_to_the_real_user_cache(self):
+        """Guard for the `_redirect_version_cache` autouse fixture.
+
+        `_get_cache_path` resolves through `platformdirs`, so it is NOT
+        `--config-dir`-aware and points at the developer's own
+        `version_cache.json`. Two tests in `TestMaybeAutoUpdate` reach the
+        real `_write_cache` (they mock `_read_cache`, not the write), which
+        stamped the canonical fake latest version `1.0.0` into that file --
+        after which every `kbagent` command on the machine spent an hour
+        (`AUTO_UPDATE_CHECK_INTERVAL`) trying to install a release tag that
+        does not exist. The conftest fixture redirects the module attribute
+        per test; this asserts it is actually in force, so deleting the
+        fixture fails here instead of silently on someone's laptop.
+
+        Uses the module attribute, not the name imported at the top of this
+        file -- the latter is bound to the original function object and is
+        deliberately left unpatched for the test above.
+        """
+        import platformdirs
+
+        real_dir = Path(platformdirs.user_config_dir("keboola-agent-cli")).resolve()
+        resolved = auto_update_module._get_cache_path().resolve()
+        assert real_dir != resolved.parent
+
 
 # ---------------------------------------------------------------------------
 # `kbagent changelog` does not duplicate "What's new" output

--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -683,7 +683,7 @@ class TestGetCachePath:
         assert "keboola-agent-cli" in str(path)
 
     def test_suite_never_resolves_to_the_real_user_cache(self):
-        """Guard for the `_redirect_version_cache` autouse fixture.
+        """Guard for the `_redirect_global_state_paths` autouse fixture.
 
         `_get_cache_path` resolves through `platformdirs`, so it is NOT
         `--config-dir`-aware and points at the developer's own
@@ -702,9 +702,17 @@ class TestGetCachePath:
         """
         import platformdirs
 
+        from keboola_agent_cli import update_runner
+
         real_dir = Path(platformdirs.user_config_dir("keboola-agent-cli")).resolve()
-        resolved = auto_update_module._get_cache_path().resolve()
-        assert real_dir != resolved.parent
+        assert real_dir != auto_update_module._get_cache_path().resolve().parent
+        # `update_runner.state_dir` resolves through the very same call and backs
+        # the deferred-update marker / exit / log files. `should_defer()` is True
+        # by default on Windows, so a test reaching the scheduler there would
+        # write real state -- and `report_finished_deferred_update`, which runs
+        # before every skip gate, unlinks a genuine pending report while reading
+        # it. Same class of bug, so the fixture covers both.
+        assert real_dir != update_runner.state_dir().resolve()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The incident

Running `make test` broke `kbagent` auto-update for whoever ran it. Observed on a dev machine today:

```
$ kbagent project list
Updating kbagent v0.84.2 -> v1.0.0...
Auto-update failed; continuing with current version. Recover with: uv tool install --force --reinstall 'keboola-cli[server] @ git+https://github.com/keboola/cli@v1.0.0'

$ kbagent version
kbagent v0.84.2    up to date
```

There is no `v1.0.0` release — no tag, no draft, nothing in `pyproject.toml` history. The number came out of the test suite.

## Root cause

`auto_update._get_cache_path()` resolves through `platformdirs`, so it ignores `--config-dir` and always points at the machine's own `version_cache.json`. Two tests in `TestMaybeAutoUpdate` mock `_read_cache` but **not** `_write_cache`, and the class's autouse `_no_real_mcp_calls` fixture forces the per-stage skip helpers to `False` — which also bypasses the `_is_dev_install()` gate that would otherwise stop the orchestrator in a dev tree. So both reach the real writer:

| test | writes |
|---|---|
| `test_version_comparison_none_no_update` | `latest_version: "1.0.0"` (the canonical fake latest) |
| `test_fetch_failure_continues` | `latest_version: <__version__>` (the `None` fallback) |

`AUTO_UPDATE_CHECK_INTERVAL` is 1 hour, so for the next hour every `kbagent` command served `1.0.0` from cache, printed an update banner, and failed the reinstall against a tag that does not exist.

`kbagent version` disagreed because it is excluded from the startup hook (`_should_skip_all` → `_top_level_subcommand_is_versioning`) and `VersionService` calls `_fetch_kbagent_latest_version()` directly, with no cache — a live GitHub fetch, correctly reporting `0.84.2`.

## The fix

- **`tests/conftest.py`**: autouse `_redirect_version_cache` fixture repoints the `auto_update._get_cache_path` module attribute at `tmp_path`. Fixing it in conftest rather than in the two tests also covers tests written later that forget to mock the write.
- **`tests/test_auto_update.py`**: `test_suite_never_resolves_to_the_real_user_cache` fails if the fixture is removed. The file's top-level `_get_cache_path` import stays bound to the original function, so `TestGetCachePath::test_returns_path_with_filename` still exercises the real resolver.

No `src/` change: `_get_cache_path` staying platformdirs-based is correct for the shipped CLI — the cache is per-machine, not per-project.

## Verification

Written test-first (RED on the guard, GREEN after the fixture). Verified by positive evidence rather than a sentinel file, because a concurrent suite run on the same machine can write that file too — both writes now land inside `tmp_path`:

```
/tmp/kbpt2/test_version_comparison_none_n0/version_cache.json -> {"latest_version": "1.0.0", ...}
/tmp/kbpt2/test_fetch_failure_continues0/version_cache.json   -> {"latest_version": "0.84.2", ...}
```

Full suite: 5748 passed, 166 skipped. `ruff check`, `ruff format --check` and `ty check` clean.

Tests only — no version bump, no changelog entry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/604" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->