### PR TITLE
[DMD-1833] Require the replaced body fields on rebase; keyword-only MR optional fields

### DIFF
--- a/docs/merge-requests-layer3-rfc.md
+++ b/docs/merge-requests-layer3-rfc.md
@@ -135,9 +135,24 @@ per source branch, ever; both guards are **404**, not 400 (`MergeRequestCreateAc
 
 **D1 — Explicit typed parameters, not payload dicts.** House style is named parameters with
 presence detection inside the method — see `update_config` (`client/configs.py:352`, *"Only
-provided (non-None) fields are sent"*). `is_disabled: bool | None` stays tri-state for
-consistency with `update_config` / `update_config_row`, not because the API forces it (inside a
-non-empty `diff` envelope, omitting it defaults to `false` server-side).
+provided (non-None) fields are sent"*).
+
+Presence detection is the right idiom for `update_config`, which **patches**, and the wrong one
+for `rebase_config`, which **replaces**: there, an omitted key is not "leave unchanged" but
+"take the server-side default". `diff.configuration` defaults to `{}` and `diff.isDisabled` to
+`false` (see *Rules* above), so a tri-state `is_disabled: bool | None` and an optional
+`configuration` would make silent data loss the signature's default — a caller resolving a
+conflict on a disabled config and passing only `name` / `rows` would wipe the configuration body
+and re-enable the config, then merge that into production. Both are therefore **required**
+parameters, for the same reason `name` and `rows` are: on a replacement endpoint every field the
+backend fills in must be supplied deliberately. `description` and `change_description` stay
+optional — the backend maps an absent key to null / a default change message rather than
+substituting content.
+
+The same reasoning applies to `_optional_mr_fields` in `client/merge_requests.py`, where
+presence detection *is* correct (create and update genuinely patch): the helper is keyword-only,
+because four of its five parameters are `str | None` and a positional transposition would
+type-check cleanly and surface only as a backend 422.
 
 **D2 — JSON bodies throughout, deviating from `configs.py`.** Per *Request bodies are JSON*:
 `json=`, real nested objects, no `json.dumps`, no `"1"` / `"0"` booleans. Every method gets a
@@ -329,7 +344,7 @@ Branch-scoped; `branch_id` required (D5).
 | Method | Endpoint |
 |---|---|
 | `get_config_diff(component_id, config_id, branch_id) -> dict` | `GET …/branch/{branch_id}/components/{c}/configs/{cfg}/diff` |
-| `rebase_config(component_id, config_id, branch_id, version, name, rows, configuration=None, description=None, change_description=None, is_disabled=None) -> dict` | `POST …/rebase` (keep) |
+| `rebase_config(component_id, config_id, branch_id, version, name, rows, configuration, is_disabled, description=None, change_description=None) -> dict` | `POST …/rebase` (keep) |
 | `rebase_config_delete(component_id, config_id, branch_id, version) -> dict` | `POST …/rebase` (delete) |
 
 `get_config_diff` returns the three-way diff (`base` = dev branch v1, `ours` = dev head,
@@ -337,8 +352,8 @@ Branch-scoped; `branch_id` required (D5).
 Flattening the nested `diff` payload is Layer 2's job.
 
 The Python signatures are flat; only the body construction knows about the envelope.
-`rebase_config` sends `version` at the top level and puts `name` and `rows` (always) plus any
-non-`None` optional inside `diff`; `is_disabled=None` is omitted, `is_disabled=False` is sent.
+`rebase_config` sends `version` at the top level and puts the four required content fields
+(`name`, `rows`, `configuration`, `is_disabled`) plus any non-`None` optional inside `diff`.
 `rebase_config_delete` sends exactly `{"version": N, "diff": {}}`. Component and configuration
 ids are `quote()`d, as everywhere in `configs.py`.
 

--- a/docs/merge-requests-layer3-rfc.md
+++ b/docs/merge-requests-layer3-rfc.md
@@ -140,14 +140,21 @@ provided (non-None) fields are sent"*).
 Presence detection is the right idiom for `update_config`, which **patches**, and the wrong one
 for `rebase_config`, which **replaces**: there, an omitted key is not "leave unchanged" but
 "take the server-side default". `diff.configuration` defaults to `{}` and `diff.isDisabled` to
-`false` (see *Rules* above), so a tri-state `is_disabled: bool | None` and an optional
-`configuration` would make silent data loss the signature's default — a caller resolving a
-conflict on a disabled config and passing only `name` / `rows` would wipe the configuration body
-and re-enable the config, then merge that into production. Both are therefore **required**
-parameters, for the same reason `name` and `rows` are: on a replacement endpoint every field the
-backend fills in must be supplied deliberately. `description` and `change_description` stay
-optional — the backend maps an absent key to null / a default change message rather than
-substituting content.
+`false`, and an absent `diff.description` to null (`RebaseRequest::mapValidatedData`). So a
+tri-state `is_disabled: bool | None` and optional `configuration` / `description` would make
+silent data loss the signature's default — a caller resolving a conflict on a disabled config
+and passing only `name` / `rows` would wipe the configuration body, drop the description and
+re-enable the config, then merge that into production.
+
+`ConfigurationRebaseService` settles which fields that covers: `$name` / `$description` /
+`$configuration` / `$isDisabled` are *"the complete 3-way diff result"* and *"fully replace"* the
+resolved version's body. All four are therefore **required** parameters, alongside `rows` (which
+the backend rejects the request without). `description` is required-but-nullable — `None` is a
+legitimate resolved value meaning "no description", and it omits the key rather than sending an
+explicit null, which costs no expressiveness because the two are indistinguishable server-side.
+
+`change_description` is the one genuine optional: it is not part of the replaced body, and null
+selects a default rebase message rather than clearing anything.
 
 The same reasoning applies to `_optional_mr_fields` in `client/merge_requests.py`, where
 presence detection *is* correct (create and update genuinely patch): the helper is keyword-only,
@@ -344,7 +351,7 @@ Branch-scoped; `branch_id` required (D5).
 | Method | Endpoint |
 |---|---|
 | `get_config_diff(component_id, config_id, branch_id) -> dict` | `GET …/branch/{branch_id}/components/{c}/configs/{cfg}/diff` |
-| `rebase_config(component_id, config_id, branch_id, version, name, rows, configuration, is_disabled, description=None, change_description=None) -> dict` | `POST …/rebase` (keep) |
+| `rebase_config(component_id, config_id, branch_id, version, name, rows, configuration, is_disabled, description, change_description=None) -> dict` | `POST …/rebase` (keep) |
 | `rebase_config_delete(component_id, config_id, branch_id, version) -> dict` | `POST …/rebase` (delete) |
 
 `get_config_diff` returns the three-way diff (`base` = dev branch v1, `ours` = dev head,
@@ -352,8 +359,10 @@ Branch-scoped; `branch_id` required (D5).
 Flattening the nested `diff` payload is Layer 2's job.
 
 The Python signatures are flat; only the body construction knows about the envelope.
-`rebase_config` sends `version` at the top level and puts the four required content fields
-(`name`, `rows`, `configuration`, `is_disabled`) plus any non-`None` optional inside `diff`.
+`rebase_config` sends `version` at the top level and puts the five required content fields
+(`name`, `rows`, `configuration`, `is_disabled`, `description`) plus `change_description` when
+set inside `diff`. `description=None` is required-but-nullable: it omits the key, which is how
+"the resolved config has no description" is expressed.
 `rebase_config_delete` sends exactly `{"version": N, "diff": {}}`. Component and configuration
 ids are `quote()`d, as everywhere in `configs.py`.
 

--- a/src/keboola_agent_cli/client/configs.py
+++ b/src/keboola_agent_cli/client/configs.py
@@ -685,10 +685,10 @@ class _ConfigsMixin(_CoreClient):
         version: int,
         name: str,
         rows: list[dict[str, Any]],
-        configuration: dict[str, Any] | None = None,
+        configuration: dict[str, Any],
+        is_disabled: bool,
         description: str | None = None,
         change_description: str | None = None,
-        is_disabled: bool | None = None,
     ) -> dict[str, Any]:
         """Rebase a dev-branch configuration onto a newer default-branch version.
 
@@ -698,11 +698,17 @@ class _ConfigsMixin(_CoreClient):
 
         The resolved content travels in a ``diff`` envelope mirroring the
         shape ``get_config_diff`` returns each side in, so a resolved diff
-        side posts back nearly 1:1. ``name`` and ``rows`` are required by the
-        backend for a keep rebase (``rows=[]`` legitimately deletes all
-        rows); to resolve a conflict by DELETING the config, use
-        ``rebase_config_delete`` -- the two rebase kinds are separate methods
-        on purpose, so no illegal combination is expressible (RFC, D6).
+        side posts back nearly 1:1. Rebase REPLACES the configuration rather
+        than patching it, so every field the backend fills in on a missing
+        key is required here, not optional: ``name`` and ``rows`` because
+        the backend rejects the request without them (``rows=[]``
+        legitimately deletes all rows), ``configuration`` and ``is_disabled``
+        because it substitutes ``{}`` and ``false`` -- omitting those two
+        wipes the configuration body and re-enables a disabled config, which
+        a caller reading "optional" would not expect. To resolve a conflict
+        by DELETING the config, use ``rebase_config_delete`` -- the two
+        rebase kinds are separate methods on purpose, so no illegal
+        combination is expressible (RFC, D6).
 
         ``branch_id`` is required with no production fallback (see
         ``get_config_diff``); the endpoint also requires the
@@ -722,28 +728,32 @@ class _ConfigsMixin(_CoreClient):
                 (``{id?, name?, description?, isDisabled?, configuration?}``);
                 missing/null ``id`` means a new row, duplicates are rejected,
                 array order becomes sort order.
-            configuration: Resolved configuration body (backend default: {}).
+            configuration: Resolved configuration body. Required: on a
+                missing key the backend substitutes ``{}``, wiping it.
+            is_disabled: Resolved disabled flag. Required: on a missing key
+                the backend substitutes ``false``, re-enabling a config that
+                was disabled. Not the tri-state of ``update_config``
+                (RFC, D1) -- that method patches, this one replaces.
             description: Resolved description. ``None`` omits the key --
-                which loses nothing: server-side an explicit JSON null and
-                an absent key are indistinguishable (``isset`` mapping).
+                which costs no expressiveness: server-side an explicit JSON
+                null and an absent key are indistinguishable (``isset``
+                mapping).
             change_description: Change log message; when ``None``/omitted
                 the backend uses a default rebase message.
-            is_disabled: When None, omitted (backend defaults to False);
-                False is sent explicitly -- tri-state for consistency with
-                ``update_config`` (RFC, D1).
 
         Returns:
             The rebased configuration dict.
         """
-        diff: dict[str, Any] = {"name": name, "rows": rows}
-        if configuration is not None:
-            diff["configuration"] = configuration
+        diff: dict[str, Any] = {
+            "name": name,
+            "rows": rows,
+            "configuration": configuration,
+            "isDisabled": is_disabled,
+        }
         if description is not None:
             diff["description"] = description
         if change_description is not None:
             diff["changeDescription"] = change_description
-        if is_disabled is not None:
-            diff["isDisabled"] = is_disabled
         return self._rebase_request(component_id, config_id, branch_id, version, diff)
 
     def rebase_config_delete(

--- a/src/keboola_agent_cli/client/configs.py
+++ b/src/keboola_agent_cli/client/configs.py
@@ -687,7 +687,7 @@ class _ConfigsMixin(_CoreClient):
         rows: list[dict[str, Any]],
         configuration: dict[str, Any],
         is_disabled: bool,
-        description: str | None = None,
+        description: str | None,
         change_description: str | None = None,
     ) -> dict[str, Any]:
         """Rebase a dev-branch configuration onto a newer default-branch version.
@@ -699,15 +699,19 @@ class _ConfigsMixin(_CoreClient):
         The resolved content travels in a ``diff`` envelope mirroring the
         shape ``get_config_diff`` returns each side in, so a resolved diff
         side posts back nearly 1:1. Rebase REPLACES the configuration rather
-        than patching it, so every field the backend fills in on a missing
-        key is required here, not optional: ``name`` and ``rows`` because
-        the backend rejects the request without them (``rows=[]``
-        legitimately deletes all rows), ``configuration`` and ``is_disabled``
-        because it substitutes ``{}`` and ``false`` -- omitting those two
-        wipes the configuration body and re-enables a disabled config, which
-        a caller reading "optional" would not expect. To resolve a conflict
-        by DELETING the config, use ``rebase_config_delete`` -- the two
-        rebase kinds are separate methods on purpose, so no illegal
+        than patching it: server-side, ``name`` / ``description`` /
+        ``configuration`` / ``isDisabled`` are "the complete 3-way diff
+        result" and "fully replace" the resolved version's body
+        (``ConfigurationRebaseService``). So all four are required here, not
+        optional -- an omitted key is not "leave unchanged" but "take the
+        server-side default", which for ``configuration`` is ``{}``, for
+        ``isDisabled`` is ``false`` and for ``description`` is null. ``rows``
+        is required too, because the backend rejects a keep rebase without
+        it (``rows=[]`` legitimately deletes all rows). Only
+        ``change_description`` is genuinely optional: it is not part of the
+        replaced body, and null selects a default rebase message. To resolve
+        a conflict by DELETING the config, use ``rebase_config_delete`` --
+        the two rebase kinds are separate methods on purpose, so no illegal
         combination is expressible (RFC, D6).
 
         ``branch_id`` is required with no production fallback (see
@@ -734,10 +738,13 @@ class _ConfigsMixin(_CoreClient):
                 the backend substitutes ``false``, re-enabling a config that
                 was disabled. Not the tri-state of ``update_config``
                 (RFC, D1) -- that method patches, this one replaces.
-            description: Resolved description. ``None`` omits the key --
-                which costs no expressiveness: server-side an explicit JSON
-                null and an absent key are indistinguishable (``isset``
-                mapping).
+            description: Resolved description. Required, but ``None`` is a
+                legitimate resolved value -- it means the rebased config
+                ends up with no description. ``None`` omits the key rather
+                than sending an explicit null, which costs no expressiveness
+                because server-side the two are indistinguishable (``isset``
+                mapping). It has no default precisely because that default
+                would silently drop an existing description.
             change_description: Change log message; when ``None``/omitted
                 the backend uses a default rebase message.
 

--- a/src/keboola_agent_cli/client/merge_requests.py
+++ b/src/keboola_agent_cli/client/merge_requests.py
@@ -79,6 +79,7 @@ class _ClientRequester:
 
 
 def _optional_mr_fields(
+    *,
     description: str | None,
     reviewer_ids: _IntList | None,
     auto_merge_strategy: str | None,
@@ -88,7 +89,10 @@ def _optional_mr_fields(
     """Build the optional-field part of a create/update body.
 
     Shared so the two bodies cannot drift: only provided (non-None) fields
-    are included, under their wire (camelCase) names.
+    are included, under their wire (camelCase) names. Keyword-only by
+    signature: four of the five parameters are ``str | None``, so a
+    positional transposition would type-check cleanly and only surface as a
+    backend 422 -- the one drift mode this helper otherwise cannot catch.
     """
     body: dict[str, Any] = {}
     if description is not None:
@@ -194,7 +198,11 @@ class MergeRequests:
         }
         body.update(
             _optional_mr_fields(
-                description, reviewer_ids, auto_merge_strategy, auto_merge_at, external_id
+                description=description,
+                reviewer_ids=reviewer_ids,
+                auto_merge_strategy=auto_merge_strategy,
+                auto_merge_at=auto_merge_at,
+                external_id=external_id,
             )
         )
         return self._requester.request("POST", _BASE, json=body).json()
@@ -222,7 +230,11 @@ class MergeRequests:
         PUTs ``{}``, which the backend treats as a no-op returning the MR.
         """
         body = _optional_mr_fields(
-            description, reviewer_ids, auto_merge_strategy, auto_merge_at, external_id
+            description=description,
+            reviewer_ids=reviewer_ids,
+            auto_merge_strategy=auto_merge_strategy,
+            auto_merge_at=auto_merge_at,
+            external_id=external_id,
         )
         if title is not None:
             body["title"] = title

--- a/tests/test_merge_request_client.py
+++ b/tests/test_merge_request_client.py
@@ -347,7 +347,7 @@ class TestRebaseEnvelope:
     def test_keep_rebase_omits_unset_optionals_and_sends_empty_rows(
         self, client, httpx_mock
     ) -> None:
-        """description/change_description are omitted; rows=[] is sent (it deletes all rows)."""
+        """description=None and an unset change_description are omitted; rows=[] is sent."""
         httpx_mock.add_response(url=self.REBASE_URL, json={})
 
         client.rebase_config(
@@ -359,6 +359,7 @@ class TestRebaseEnvelope:
             rows=[],
             configuration={},
             is_disabled=False,
+            description=None,
         )
 
         body = _sent_json(httpx_mock.get_requests()[0])
@@ -372,7 +373,7 @@ class TestRebaseEnvelope:
     def test_keep_rebase_always_sends_configuration_and_is_disabled(
         self, client, httpx_mock
     ) -> None:
-        """Rebase REPLACES, so neither field may be left to a server-side default.
+        """Rebase REPLACES, so no body field may be left to a server-side default.
 
         A missing ``diff.configuration`` is substituted with ``{}`` and a missing
         ``diff.isDisabled`` with ``false``, so omitting either would wipe the
@@ -390,18 +391,34 @@ class TestRebaseEnvelope:
             rows=[],
             configuration={"parameters": {"keep": "me"}},
             is_disabled=True,
+            description="kept",
         )
 
         diff = _sent_json(httpx_mock.get_requests()[0])["diff"]
         assert diff["configuration"] == {"parameters": {"keep": "me"}}
         assert diff["isDisabled"] is True
+        assert diff["description"] == "kept"
 
-    def test_keep_rebase_requires_configuration_and_is_disabled(self, client) -> None:
-        """Omitting either is a TypeError at the call, not silent data loss on the wire."""
-        with pytest.raises(TypeError):
-            client.rebase_config(
-                "keboola.ex-http", "cfg-1", branch_id=123, version=7, name="N", rows=[]
-            )
+    def test_keep_rebase_requires_every_replaced_body_field(self, client) -> None:
+        """Omitting any replaced body field is a TypeError, not silent loss on the wire.
+
+        ``name`` / ``description`` / ``configuration`` / ``isDisabled`` are the
+        tuple the backend calls "the complete 3-way diff result" and fully
+        replaces the resolved version's body with, so none of them may carry a
+        default here. ``change_description`` is not part of that tuple and stays
+        optional -- omitting it selects a default rebase message.
+        """
+        required = {
+            "name": "N",
+            "rows": [],
+            "configuration": {},
+            "is_disabled": False,
+            "description": None,
+        }
+        for omitted in required:
+            kwargs = {k: v for k, v in required.items() if k != omitted}
+            with pytest.raises(TypeError):
+                client.rebase_config("keboola.ex-http", "cfg-1", branch_id=123, version=7, **kwargs)
 
     def test_delete_rebase_sends_empty_diff_object(self, client, httpx_mock) -> None:
         """Delete resolution is exactly {"version": N, "diff": {}} -- diff a JSON object."""

--- a/tests/test_merge_request_client.py
+++ b/tests/test_merge_request_client.py
@@ -8,6 +8,7 @@ delete resolution, implicit merge-job waiting, ``include=activityLog``, and
 the namespace-never-touches-the-client seam.
 """
 
+import inspect
 import json
 from typing import Any
 
@@ -15,7 +16,7 @@ import httpx
 import pytest
 
 from keboola_agent_cli.client import KeboolaClient
-from keboola_agent_cli.client.merge_requests import MergeRequests
+from keboola_agent_cli.client.merge_requests import MergeRequests, _optional_mr_fields
 from keboola_agent_cli.errors import ErrorCode, KeboolaApiError
 
 STACK_URL = "https://connection.keboola.com"
@@ -325,9 +326,9 @@ class TestRebaseEnvelope:
             name="My config",
             rows=[{"id": "r1", "name": "Row 1"}],
             configuration={"parameters": {"baseUrl": "https://example.com"}},
+            is_disabled=False,
             description="resolved",
             change_description="rebase onto v7",
-            is_disabled=False,
         )
 
         body = _sent_json(httpx_mock.get_requests()[0])
@@ -346,15 +347,61 @@ class TestRebaseEnvelope:
     def test_keep_rebase_omits_unset_optionals_and_sends_empty_rows(
         self, client, httpx_mock
     ) -> None:
-        """is_disabled=None is omitted; rows=[] is sent (it deletes all rows)."""
+        """description/change_description are omitted; rows=[] is sent (it deletes all rows)."""
         httpx_mock.add_response(url=self.REBASE_URL, json={})
 
         client.rebase_config(
-            "keboola.ex-http", "cfg-1", branch_id=123, version=7, name="My config", rows=[]
+            "keboola.ex-http",
+            "cfg-1",
+            branch_id=123,
+            version=7,
+            name="My config",
+            rows=[],
+            configuration={},
+            is_disabled=False,
         )
 
         body = _sent_json(httpx_mock.get_requests()[0])
-        assert body["diff"] == {"name": "My config", "rows": []}
+        assert body["diff"] == {
+            "name": "My config",
+            "rows": [],
+            "configuration": {},
+            "isDisabled": False,
+        }
+
+    def test_keep_rebase_always_sends_configuration_and_is_disabled(
+        self, client, httpx_mock
+    ) -> None:
+        """Rebase REPLACES, so neither field may be left to a server-side default.
+
+        A missing ``diff.configuration`` is substituted with ``{}`` and a missing
+        ``diff.isDisabled`` with ``false``, so omitting either would wipe the
+        configuration body and re-enable a disabled config. Both are required
+        parameters; this pins that they always reach the wire.
+        """
+        httpx_mock.add_response(url=self.REBASE_URL, json={})
+
+        client.rebase_config(
+            "keboola.ex-http",
+            "cfg-1",
+            branch_id=123,
+            version=7,
+            name="My config",
+            rows=[],
+            configuration={"parameters": {"keep": "me"}},
+            is_disabled=True,
+        )
+
+        diff = _sent_json(httpx_mock.get_requests()[0])["diff"]
+        assert diff["configuration"] == {"parameters": {"keep": "me"}}
+        assert diff["isDisabled"] is True
+
+    def test_keep_rebase_requires_configuration_and_is_disabled(self, client) -> None:
+        """Omitting either is a TypeError at the call, not silent data loss on the wire."""
+        with pytest.raises(TypeError):
+            client.rebase_config(
+                "keboola.ex-http", "cfg-1", branch_id=123, version=7, name="N", rows=[]
+            )
 
     def test_delete_rebase_sends_empty_diff_object(self, client, httpx_mock) -> None:
         """Delete resolution is exactly {"version": N, "diff": {}} -- diff a JSON object."""
@@ -388,6 +435,40 @@ class TestRequesterSeam:
 
         assert namespace.list() == [SAMPLE_MR]
         assert calls == [("GET", "/v2/storage/merge-request")]
+
+
+class TestOptionalFieldHelper:
+    """_optional_mr_fields is keyword-only, so create/update cannot transpose."""
+
+    def test_every_field_is_keyword_only(self) -> None:
+        """No parameter may be positional -- a transposition would type-check cleanly.
+
+        Asserted on the signature rather than by making a deliberately wrong
+        call: a positional call is a static error too (which is the point), so
+        writing one would just mean fighting ``ty`` to prove ``ty`` is right.
+        """
+        kinds = {
+            name: param.kind
+            for name, param in inspect.signature(_optional_mr_fields).parameters.items()
+        }
+        assert set(kinds) == {
+            "description",
+            "reviewer_ids",
+            "auto_merge_strategy",
+            "auto_merge_at",
+            "external_id",
+        }
+        assert all(kind is inspect.Parameter.KEYWORD_ONLY for kind in kinds.values()), kinds
+
+    def test_helper_omits_unset_fields(self) -> None:
+        """Only non-None fields are included, under their camelCase wire names."""
+        assert _optional_mr_fields(
+            description=None,
+            reviewer_ids=[7],
+            auto_merge_strategy=None,
+            auto_merge_at=None,
+            external_id="DMD-1701",
+        ) == {"reviewerIds": [7], "externalId": "DMD-1701"}
 
     def test_namespace_is_cached_on_the_client(self) -> None:
         """client.merge_requests returns the same namespace instance every time."""


### PR DESCRIPTION
## What

Addresses finding 1 and finding 3 from my review of #556. **Targets `ms/dmd-1833`, not `main`** — merge this into your branch (or cherry-pick, or close it and do it your way; the analysis is the point, not the patch).

Only touches things my review flagged. No new endpoints, no behavior change beyond the two below.

## 1. `rebase_config`: the whole replaced body becomes required

`/rebase` **replaces** a configuration rather than patching it, so an omitted key is not "leave unchanged" but "take the server-side default". Your own RFC documents those defaults (lines 109-110, from `RebaseRequest::validateDiff`): `diff.configuration` → `{}`, `diff.isDisabled` → `false`.

With both optional, this call is the natural one to write — it passes exactly the fields the signature marks as required:

```python
client.rebase_config(component_id, config_id, branch_id=123, version=7, name="X", rows=[...])
```

and it sends `{"version": 7, "diff": {"name": "X", "rows": [...]}}`. The backend fills in the rest, so the rebased config loses its whole `parameters` block and a disabled config comes back enabled. Merge the MR and that reaches production.

`name` and `rows` are required precisely to make that class of loss unrepresentable (D6). This extends the same reasoning to the two fields where the backend substitutes content instead of rejecting the request.

The same applies to `description`, which the first commit left optional and the second makes required after checking the source (see below). It stays `str | None` — `None` is a legitimate resolved value meaning "the config ends up with no description", and it still omits the key rather than sending an explicit null, which costs no expressiveness because the two are indistinguishable server-side. What it no longer has is a *default*, because that default was the silent-loss path.

`change_description` is the one genuine optional: it is not part of the replaced body, and null selects a default rebase message rather than clearing anything.

D1 in the RFC is updated to say why presence detection is right for `update_config` (which patches) and wrong here (which replaces), rather than reading as an unexplained inconsistency later.

## 2. `_optional_mr_fields` becomes keyword-only

The helper exists so the create and update bodies "cannot drift" — but both call sites passed five arguments positionally and four are `str | None`. A transposition of `auto_merge_strategy` and `auto_merge_at` type-checks cleanly, passes ruff and ty, and surfaces only as a backend 422; the existing coverage asserts `autoMergeStrategy` for `create` only. `*` in the signature closes it the way `_billing_get` hardcodes its verb — a guarantee no source-scanning test has to catch.

## Not included

- **Finding 2** (the `merge()` terminal-error guard) — yours in #603, with a wider blast radius than I traced. Nothing here.
- **The `_do_request` write-retry hazard** — agreed it is a separate `http_base` concern.

## The open question, now resolved (second commit)

The first commit left `description` optional and flagged that I could not tell from the RFC whether an absent `diff.description` **preserves** the previous description or nulls it. Devin's review flagged the same gap. Rather than leave it to you, I checked the Connection source:

- `RebaseRequest::mapValidatedData` — `description: isset($diff->description) ? (string) $diff->description : null`, so a missing key becomes null.
- `ConfigurationRebaseService` — *"The resolved config body (`$name`/`$description`/`$configuration`/`$isDisabled`) is the complete 3-way diff result and **fully replaces** version 2's body."*

So an omitted description is written as null: the same silent-loss mode, and `description` belongs in the required set. That is the second commit. The same two sources also confirm the first commit's premise rather than just the RFC's summary of it, and they draw the line for `change_description`, which is absent from that four-field tuple and documented as `null → default rebase message`.

## Testing

- `make check` green: 5774 passed, 12 skipped, `ty` clean (only the 3 pre-existing warnings), all repo gates OK.
- New tests: the replaced body fields always reach the wire; omitting *any* of them is a `TypeError` at the call site rather than silent loss on the wire (the test iterates the whole set, so an optional-with-default reintroduced on any one of them fails); every `_optional_mr_fields` parameter is `KEYWORD_ONLY`.
- The keyword-only test asserts on `inspect.signature` rather than making a deliberately-wrong call — a positional call is a static error too, so writing one would mean fighting `ty` to prove `ty` is right.
- `test_keep_rebase_omits_unset_optionals_and_sends_empty_rows` was updated: it can no longer be about `is_disabled`, so it now covers `description` / `change_description`.
