### PR TITLE
docs(rfc): correct the stale presence-detection note for rebase_config

### DIFF
--- a/docs/merge-requests-layer3-rfc.md
+++ b/docs/merge-requests-layer3-rfc.md
@@ -376,8 +376,9 @@ New `tests/test_merge_request_client.py`, using `pytest_httpx` like `tests/test_
 - **JSON encoding** — the second-most-likely mistake, since the surrounding file does the
   opposite: assert `Content-Type: application/json`, real nested JSON (not strings), JSON
   numbers for `version` / `branchFromId` / `branchIntoId`, `true`/`false` booleans.
-- **Presence detection** — `create` / `update` omit unset optionals; `rebase_config` sends
-  `is_disabled=False` but omits `is_disabled=None`; `rows=[]` is sent, not treated as absent.
+- **Presence detection** — `create` / `update` omit unset optionals; `rebase_config` always
+  sends the replaced body (`name` / `rows` / `configuration` / `isDisabled`) and omits only
+  `description=None` and an unset `change_description`; `rows=[]` is sent, not treated as absent.
 - **The `diff` envelope** — `version` at the top level, every content field inside `diff`,
   nothing content-like at the top level. Pin explicitly: a regression to the flat pre-envelope
   body would not fail loudly in a round-trip test, it would just build the wrong request.


### PR DESCRIPTION
One stale bullet in the RFC's Testing section, spotted while re-reviewing #556 for approval. Targets `ms/dmd-1833`.

It still described the pre-#606 behaviour:

> `rebase_config` sends `is_disabled=False` but omits `is_disabled=None`

`is_disabled` is `bool` since #606, so `None` cannot be passed at all. The bullet now describes what the method actually does — always sends the replaced body, omits only `description=None` and an unset `change_description`.

My miss in #606: I updated D1 and the signature table but not this bullet. It refers to the parameters by describing their behaviour rather than naming the signature, so grepping for `rebase_config` did not surface it — it took a grep for `is_disabled=None`.

Docs only, no code touched. `make check` green (5774 passed, `ty` clean, all gates OK). Note that no CI will run here either — `ci.yml` is scoped to `pull_request: branches: [main]`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->