### PR TITLE
ci: disable the winget release job until the package is bootstrapped in winget-pkgs

### DIFF
--- a/.github/workflows/release-kbagent.yml
+++ b/.github/workflows/release-kbagent.yml
@@ -493,9 +493,18 @@ jobs:
           choco push "keboola-cli2.$env:VERSION.nupkg" -s https://push.chocolatey.org
 
   # ── WinGet: submit a PR to microsoft/winget-pkgs via wingetcreate.
+  #
+  # DISABLED (if: false): `wingetcreate update` fails on every tag because the
+  # `Keboola.KeboolaCLI2` package has never had its FIRST submission to
+  # microsoft/winget-pkgs -- there is no manifest to update, so the job has been
+  # red on every release since it was added, masking real failures. Re-enable by
+  # restoring the original condition (kept below) AFTER the bootstrap submission
+  # lands; see the NOTE in the first step for what that submission must contain.
   winget:
     needs: [version, chocolatey, publish-s3]
-    if: needs.version.outputs.IS_PRERELEASE == 'false' && startsWith(github.ref, 'refs/tags/')
+    # Original condition, restore when re-enabling:
+    #   needs.version.outputs.IS_PRERELEASE == 'false' && startsWith(github.ref, 'refs/tags/')
+    if: false
     runs-on: windows-latest
     environment: release
     env:


### PR DESCRIPTION
## Summary

Gates the `winget` release job with `if: false`. It has failed on **every** stable tag since it was added (`v0.85.0` included) with the same signature:

```
Retrieving latest manifest for Keboola.KeboolaCLI2
ERROR: repos/microsoft/winget-pkgs/contents/manifests/k/Keboola/KeboolaCLI2 was not found.
```

Root cause: `wingetcreate update` can only bump an existing manifest, and `Keboola.KeboolaCLI2` never had its initial submission to microsoft/winget-pkgs. Until that bootstrap lands, the job can only fail -- and a permanently red release pipeline masks real failures.

The job body and the bootstrap NOTE stay in place; the original `if:` condition is kept as a comment for one-line re-enablement after the first submission.

No other job depends on `winget` (`test-install` needs `publish-s3` + `homebrew`), so nothing else changes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->