### PR TITLE
fix(data-app): read setup.sh code, not its comments, in validate-repo

### DIFF
--- a/src/keboola_agent_cli/services/repo_validate_service.py
+++ b/src/keboola_agent_cli/services/repo_validate_service.py
@@ -76,6 +76,38 @@ _NGINX_PROXY_PASS_PORT_RE = re.compile(r"proxy_pass\s+http://[^:]+:(\d+)")
 _APP_CONF_PORT_RE = re.compile(r"--port[=\s]+(\d+)|:(\d+)\b")
 
 
+def _strip_shell_comments(text: str) -> str:
+    """Return ``text`` with ``#`` comments removed, quoted ``#`` preserved.
+
+    The setup.sh rules below grep for what the script *runs*, so they have to
+    see code and not prose. Without this, a comment warning against the wrong
+    installer -- exactly what a careful author writes above the right one --
+    is read as the violation it warns about and blocks the repo. The inverse
+    also matters: a comment merely mentioning ``uv sync`` must not satisfy the
+    check that the script actually invokes it.
+
+    Deliberately not a shell parser. It tracks single/double quotes so a
+    ``#`` inside a string survives, and treats a ``#`` at line start or after
+    whitespace as starting a comment -- which covers real setup.sh files
+    without pretending to handle heredocs or ``${...#...}`` expansions.
+    """
+    out: list[str] = []
+    for line in text.splitlines():
+        quote: str | None = None
+        cut = len(line)
+        for i, char in enumerate(line):
+            if quote:
+                if char == quote:
+                    quote = None
+            elif char in "\"'":
+                quote = char
+            elif char == "#" and (i == 0 or line[i - 1].isspace()):
+                cut = i
+                break
+        out.append(line[:cut])
+    return "\n".join(out)
+
+
 # Severities. Order matters for verdict aggregation (worst wins).
 SEVERITY_OK = "OK"
 SEVERITY_WARN = "WARN"
@@ -355,7 +387,9 @@ def validate_keboola_repo(
         )
 
     if setup_sh_present and snapshot.setup_sh is not None:
-        if _PIP_INSTALL_RE.search(snapshot.setup_sh):
+        # Both rules below ask what the script RUNS, so they read code only.
+        setup_sh_code = _strip_shell_comments(snapshot.setup_sh)
+        if _PIP_INSTALL_RE.search(setup_sh_code):
             results.append(
                 CheckResult(
                     name="golden-rule.setup-sh-no-pip",
@@ -377,7 +411,7 @@ def validate_keboola_repo(
             )
 
         if pyproject_has_deps:
-            if _UV_SYNC_RE.search(snapshot.setup_sh):
+            if _UV_SYNC_RE.search(setup_sh_code):
                 results.append(
                     CheckResult(
                         name="golden-rule.setup-sh-uv-sync",

--- a/tests/test_data_app_validate_repo_service.py
+++ b/tests/test_data_app_validate_repo_service.py
@@ -95,6 +95,44 @@ class TestPureValidatorSetupSh:
         names = {r.name: r.severity for r in results}
         assert names["golden-rule.setup-sh-no-pip"] == SEVERITY_BLOCKING
 
+    def test_pip_install_only_in_a_comment_does_not_block(self) -> None:
+        """A comment warning against pip is not an invocation of pip.
+
+        The rule greps for what the script RUNS. Reading prose as code
+        penalises exactly the author who documents the rule above the
+        command that follows it -- i.e. the one complying with it.
+        """
+        snap = _good_snapshot(
+            setup_sh="#!/bin/bash\n# always uv sync here, never pip install\nuv sync\n"
+        )
+        results = validate_keboola_repo(snap, type_="python-js")
+        names = {r.name: r.severity for r in results}
+        assert names["golden-rule.setup-sh-no-pip"] == SEVERITY_OK
+        assert names["golden-rule.setup-sh-uv-sync"] == SEVERITY_OK
+
+    def test_pip_install_with_a_trailing_comment_still_blocks(self) -> None:
+        """Stripping comments must not smuggle a real invocation past the rule."""
+        snap = _good_snapshot(setup_sh="#!/bin/bash\npip install flask  # legacy\n")
+        results = validate_keboola_repo(snap, type_="python-js")
+        names = {r.name: r.severity for r in results}
+        assert names["golden-rule.setup-sh-no-pip"] == SEVERITY_BLOCKING
+
+    def test_hash_inside_a_quoted_string_is_not_a_comment(self) -> None:
+        """Only unquoted `#` starts a comment, so quoted code stays visible."""
+        snap = _good_snapshot(
+            setup_sh='#!/bin/bash\necho "install deps # step 1"\npip install flask\n'
+        )
+        results = validate_keboola_repo(snap, type_="python-js")
+        names = {r.name: r.severity for r in results}
+        assert names["golden-rule.setup-sh-no-pip"] == SEVERITY_BLOCKING
+
+    def test_uv_sync_only_in_a_comment_still_warns(self) -> None:
+        """The inverse false reading: prose must not satisfy the rule either."""
+        snap = _good_snapshot(setup_sh="#!/bin/bash\n# remember to uv sync\necho hello\n")
+        results = validate_keboola_repo(snap, type_="python-js")
+        names = {r.name: r.severity for r in results}
+        assert names["golden-rule.setup-sh-uv-sync"] == SEVERITY_WARN
+
     def test_setup_sh_without_uv_sync_warns(self) -> None:
         # Setup.sh present but no `uv sync` invocation; pyproject.toml
         # declares deps so the WARN should fire.


### PR DESCRIPTION
## The bug

`kbagent data-app validate-repo` checks that `keboola-config/setup.sh` does not use the pip installer (the data-app runtime blocks it; `uv sync` is the supported path). It enforces that by grepping the **raw file**:

```python
_PIP_INSTALL_RE = re.compile(r"\bpip\s+install\b")
...
if _PIP_INSTALL_RE.search(snapshot.setup_sh):   # -> SEVERITY_BLOCKING
```

Comments are part of the raw file, so this setup.sh is rejected:

```bash
#!/bin/bash
# always uv sync here, never pip install
uv sync
```

It does the right thing and says so, and the saying is what blocks it. The rule penalises precisely the author who documents it for their colleagues.

The same misreading runs the other way for the companion rule. `golden-rule.setup-sh-uv-sync` warns when pyproject declares dependencies but setup.sh does not invoke `uv sync` — and a comment merely *mentioning* `uv sync` satisfied it. A script that installed nothing could pass.

## Worth flagging

The module comment above these regexes justifies the heuristics like this:

> Heuristic regexes -- tightening any of these is preferred over a real parser because [...] false positives are operationally cheap (**a WARN, not a BLOCKING**).

That holds for the other regexes there. It does not hold for this one: `setup-sh-no-pip` emits `SEVERITY_BLOCKING`. The stated rationale for tolerating imprecision never covered the one check where imprecision is expensive.

## The fix

Both rules ask what the script *runs*, so both now read comment-stripped code.

`_strip_shell_comments` is deliberately **not** a shell parser. It tracks single/double quotes so a `#` inside a string survives, and treats a `#` at line start or after whitespace as opening a comment. That covers real setup.sh files without pretending to handle heredocs or `${...#...}` expansions — consistent with the heuristic-over-parser choice the module already made.

## Tests

Four added. Two of them target the bug and **fail on `main`**:

- `test_pip_install_only_in_a_comment_does_not_block` — was BLOCKING, now OK
- `test_uv_sync_only_in_a_comment_still_warns` — was OK, now WARN

Two are regression guards against over-stripping, and pass either way:

- `test_pip_install_with_a_trailing_comment_still_blocks` — a real invocation with a trailing comment must not slip through
- `test_hash_inside_a_quoted_string_is_not_a_comment` — quoted `#` must not truncate the line

Full suite: **5832 passed, 61 skipped**. `ruff check`, `ruff format --check`, `ty check` clean.

## Notes

Found while building a sample data app for the E2E fixtures — the repo was rejected over its own comment. No version bump or changelog entry; the version is being bumped once across several PRs.

Related but **not** addressed here: `validate-repo` never inspects the nginx `listen` port, which is a hardcoded platform contract (`8888`). A repo can report 0 BLOCKING and still fail to start. Happy to open that separately.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->