### PR TITLE
ci: gate web/frontend PRs on tsc --noEmit + vite build

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,68 @@
+# ──────────────────────────────────────────────────────────────────────────
+# Frontend gate for the React SPA in web/frontend (PR #658 finding NB-1).
+#
+# ci.yml covers only the Python side, so a frontend PR's type errors used to
+# ship to main undetected -- PR #658 landed a types.ts field-name mismatch
+# (`configId` vs the Queue API's actual `config`) that rendered a whole table
+# column empty, and only a manual `tsc` run caught it.
+#
+# This lives in its OWN workflow (not a job in ci.yml) because `paths:`
+# filtering is trigger-level, not job-level: keeping it separate means a
+# Python-only PR never even schedules a runner for it. That is safe here
+# because the main ruleset has no required_status_checks rule (the merge gate
+# is the human review) -- a skipped run cannot leave a required check pending
+# forever. If frontend checks ever become REQUIRED, this filter must be
+# rethought (change-detection inside an always-running job, or a paths-ignore
+# mirror that reports success).
+#
+# Deliberately NO `vitest` step: there are zero *.test.* / *.spec.* files
+# under web/frontend/src, and `vitest run` on an empty suite exits 1
+# ("No test files found"), which would fail every frontend PR. When the first
+# test lands, add `npm test` here -- vitest's fail-on-empty default then
+# guards against the suite silently vanishing.
+# ──────────────────────────────────────────────────────────────────────────
+name: Frontend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "web/**"
+      - ".github/workflows/frontend.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "web/**"
+      - ".github/workflows/frontend.yml"
+
+jobs:
+  frontend:
+    name: Type check + build (web/frontend)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web/frontend
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          # Node 20 matches web/backend's `engines` floor and the version
+          # ci.yml's build-windows job uses for the wheel's SPA build hook.
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: web/frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        # `npm run build` (tsc -b && vite build) type-checks too, but a
+        # dedicated step pins a type error to a "Type check" failure
+        # annotation instead of burying it inside the build step.
+        run: npx tsc --noEmit
+
+      - name: Build
+        # The same command hatch_build.py runs when bundling the SPA into the
+        # wheel -- if this fails, `uv tool install` from git fails too.
+        run: npm run build


### PR DESCRIPTION
## Why

Follow-up to PR #658 non-blocking finding **NB-1**, deferred there so the CI change gets its own review instead of riding a large feature PR.

`.github/workflows/ci.yml` covers only the Python side. A frontend PR's type errors ship to `main` undetected — #658 carried three commits' worth of frontend bugs caught only by manual `tsc`/build runs and a live browser pass, including a `types.ts` field-name mismatch (`configId` vs the Queue API's actual `config`) that made a whole table column render empty and a new button never render.

## What

New `.github/workflows/frontend.yml` that runs in `web/frontend`:

1. `npm ci`
2. `npx tsc --noEmit`
3. `npm run build` (`tsc -b && vite build` — the same command `hatch_build.py` runs when bundling the SPA into the wheel)

**Path gating:** no existing workflow in this repo uses `paths:` filtering, so this introduces the scheme: triggers only on changes under `web/**` (plus the workflow file itself), so Python-only PRs never schedule a runner. It is a separate workflow file because `paths:` filters are trigger-level, not job-level. This is safe because the `main` ruleset has no `required_status_checks` rule (verified via `gh api repos/keboola/cli/rules/branches/main` — the merge gate is the human review), so a skipped run can never leave a required check pending. If frontend checks ever become required, the filter needs rethinking (in-job change detection, or a `paths-ignore` mirror that reports success).

## Deliberately NO vitest step — maintainer decision requested

There are zero `*.test.*` / `*.spec.*` files under `web/frontend/src`. Notably, `npx vitest run` on the empty suite does **not** pass vacuously — it exits 1 with `No test files found`, so adding it now would fail every frontend PR. Options:

- **(this PR)** type-check + build only; add `npm test` when the first test lands — vitest's fail-on-empty default then also guards against the suite silently vanishing;
- alternatively add `vitest run --passWithNoTests` now — rejected here because it *would* pass vacuously and hide that nothing is tested.

Say the word if you prefer the other option.

## Out of scope

`web/backend` (dev-mode BFF, TypeScript too) has no type-check gate either; it is not part of the wheel build. Can be added to this workflow later with an analogous job.

## Verification

- Locally: `npm ci`, `npx tsc --noEmit`, `npm run build` all pass in `web/frontend`.
- This PR itself triggers the workflow (the workflow file path is in its own `paths:` filter), so the run visible on this PR is the live verification.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->