### PR TITLE
feat(ui): fold storage buckets and tables into the Cmd+K palette

### DIFF
--- a/web/frontend/src/components/CommandPalette.tsx
+++ b/web/frontend/src/components/CommandPalette.tsx
@@ -2,26 +2,51 @@
  * Ctrl+K / Cmd+K command palette.
  *
  * One keystroke to reach anything the shell can already do: jump to a page,
- * switch the active project, or fire a small action (theme, Swagger docs).
- * Deliberately NOT a search over Keboola data -- that is the Search page's
- * job, and mixing "navigate the app" with "query the project" makes both
- * slower. Everything here resolves locally, so the list never waits on a
- * network round-trip.
+ * switch the active project, fire a small action (theme, Swagger docs) -- and
+ * land on a specific storage bucket or table.
+ *
+ * The storage objects are folded in WITHOUT giving up the palette's core
+ * contract: nothing waits on the network while you type. The data is fetched
+ * once when the palette opens and matched locally. The active project's
+ * buckets/tables reuse the exact react-query keys the Storage page already
+ * populates, so opening the palette after visiting Storage normally costs no
+ * request at all; the cross-project bucket list is its own key held at a 60s
+ * staleTime. Cross-project TABLES are deliberately not loaded -- that haystack
+ * grows with every registered project, and a foreign table is one keystroke
+ * away via its bucket anyway.
+ *
+ * Anything the local haystack cannot answer escapes to the Search page via the
+ * always-last "Search … across projects" row, which is where a real server-side
+ * query belongs.
+ *
+ * Picking a storage object navigates by writing the Storage page's `?sel=`
+ * selection (built with that page's own grammar helper, never spelled out
+ * here), so a palette jump produces the same shareable URL as clicking the
+ * row -- and lands nowhere the UI could not already be linked to.
  *
  * The page list comes from the sidebar's exported SECTIONS, so a page can
  * never be reachable from one surface and invisible in the other.
  */
 import { useQuery } from "@tanstack/react-query";
-import { ArrowRight, Boxes, CornerDownLeft, Search, Sparkles } from "lucide-react";
+import {
+  ArrowRight,
+  Boxes,
+  CornerDownLeft,
+  Database,
+  Search,
+  Sparkles,
+  Table2,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { api } from "../api/client";
 import { SECTIONS } from "../layout/Sidebar";
+import { buildStorageSel } from "../pages/Storage";
 import { type PageId, useUIState } from "../state";
 import { useTheme } from "../theme";
-import type { Project } from "../types";
+import type { Bucket, Project, Table } from "../types";
 
-type CommandKind = "page" | "project" | "action";
+type CommandKind = "page" | "project" | "action" | "bucket" | "table" | "search";
 
 interface Command {
   id: string;
@@ -32,6 +57,8 @@ interface Command {
   hint?: string;
   /** Extra text folded into the match haystack but not rendered. */
   keywords?: string;
+  /** Added to the match score (higher = ranked lower). See DATA_SCORE_BIAS. */
+  bias?: number;
   icon: React.ComponentType<{ className?: string }>;
   run: () => void;
 }
@@ -90,7 +117,21 @@ const KIND_LABEL: Record<CommandKind, string> = {
   page: "page",
   project: "project",
   action: "action",
+  bucket: "bucket",
+  table: "table",
+  search: "search",
 };
+
+/**
+ * Ranking bias (higher = worse; results sort ascending). Storage objects
+ * outnumber pages and actions by orders of magnitude, so without a bias a
+ * two-letter query would bury "Storage" under fifty buckets that happen to
+ * contain those letters. A specific query like "oltp" still wins on raw match
+ * quality, which is exactly the trade we want.
+ */
+const DATA_SCORE_BIAS = 25;
+/** Foreign buckets rank below the active project's own on an equal match. */
+const FOREIGN_PROJECT_SCORE_BIAS = 10;
 
 export function CommandPalette() {
   const [open, setOpen] = useState(false);
@@ -99,7 +140,16 @@ export function CommandPalette() {
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
-  const { project, setProject, setBranchId, setPage, setWhatsNewForced } = useUIState();
+  const {
+    project,
+    branchId,
+    setProject,
+    setBranchId,
+    setPage,
+    setSel,
+    setWhatsNewForced,
+    setPendingSearchQuery,
+  } = useUIState();
   const { theme, toggle } = useTheme();
 
   // Projects are already cached by the top bar under this exact key, so
@@ -108,6 +158,39 @@ export function CommandPalette() {
     queryKey: ["projects"],
     queryFn: () => api.get("/projects"),
     enabled: open,
+  });
+
+  // Same key shape as the Storage page's buckets query -- a shared cache
+  // entry, not a second fetch, whenever Storage has already been visited.
+  const bucketsQ = useQuery<{ buckets: Bucket[]; errors: unknown[] }>({
+    queryKey: ["buckets", project, branchId],
+    queryFn: () =>
+      api.get("/storage/buckets", {
+        query: { project: project ?? undefined, branch_id: branchId ?? undefined },
+      }),
+    enabled: open && !!project,
+  });
+
+  // Mirrors the Storage page's UNFILTERED tables query (bucket filter = null).
+  const tablesQ = useQuery<{ tables: Table[]; errors: unknown[] }>({
+    queryKey: ["tables", project, null, branchId],
+    queryFn: () =>
+      api.get("/storage/tables", {
+        query: { project: project ?? undefined, branch_id: branchId ?? undefined },
+      }),
+    enabled: open && !!project,
+  });
+
+  // Every registered project at once. No branch_id: branch ids are numbered
+  // per project, so one value cannot mean anything across a fan-out. The
+  // server degrades per project via `errors`, which the palette ignores --
+  // a project that failed simply contributes no rows, and saying so here
+  // would be noise in a list you are typing through.
+  const allBucketsQ = useQuery<{ buckets: Bucket[]; errors: unknown[] }>({
+    queryKey: ["buckets-all"],
+    queryFn: () => api.get("/storage/buckets"),
+    enabled: open,
+    staleTime: 60_000,
   });
 
   const close = useCallback(() => {
@@ -192,27 +275,117 @@ export function CommandPalette() {
       icon: Sparkles,
       run: () => setWhatsNewForced(true),
     });
+
+    /**
+     * Navigate to a storage object. The `sel` string is built by the Storage
+     * page's own grammar helper rather than spelled out here -- the page owns
+     * the meaning of its selection, the palette only picks a target.
+     *
+     * ORDER MATTERS: setProject / setBranchId / setPage each clear `sel` (a
+     * selection from another context is meaningless), so the selection has to
+     * be written LAST or it would be wiped by the navigation that precedes it.
+     */
+    const openStorage = (alias: string, sel: string | null) => {
+      if (alias !== project) {
+        setProject(alias);
+        // A branch id is only meaningful inside its own project.
+        setBranchId(null);
+      }
+      setPage("storage");
+      setSel(sel);
+    };
+    const bucketCommand = (b: Bucket, foreign: boolean): Command => ({
+      id: `bucket:${b.project_alias}/${b.id}`,
+      kind: "bucket",
+      label: b.display_name || b.id,
+      hint: `${b.project_alias} · ${b.id}`,
+      keywords: `${b.id} ${b.stage}`,
+      bias: DATA_SCORE_BIAS + (foreign ? FOREIGN_PROJECT_SCORE_BIAS : 0),
+      icon: Database,
+      run: () => openStorage(b.project_alias, buildStorageSel("tables", null, b.id)),
+    });
+
+    for (const b of bucketsQ.data?.buckets ?? []) out.push(bucketCommand(b, false));
+    // The active project's own rows come from the branch-aware query above and
+    // are authoritative for it; the fan-out contributes only foreign projects,
+    // which also dedupes the two lists against each other.
+    for (const b of allBucketsQ.data?.buckets ?? []) {
+      if (b.project_alias === project) continue;
+      out.push(bucketCommand(b, true));
+    }
+
+    // Active project only -- see the file header on why foreign tables are not
+    // loaded (bounded haystack; reachable through their bucket).
+    for (const t of tablesQ.data?.tables ?? []) {
+      out.push({
+        id: `table:${t.project_alias}/${t.id}`,
+        kind: "table",
+        label: t.display_name || t.name,
+        hint: `${t.project_alias} · ${t.bucket_id}`,
+        keywords: t.id,
+        bias: DATA_SCORE_BIAS,
+        icon: Table2,
+        run: () => openStorage(t.project_alias, buildStorageSel("tables", t.id)),
+      });
+    }
     return out;
-  }, [projectsQ.data, setPage, setProject, setBranchId, theme, toggle, setWhatsNewForced]);
+  }, [
+    projectsQ.data,
+    bucketsQ.data,
+    tablesQ.data,
+    allBucketsQ.data,
+    project,
+    setPage,
+    setProject,
+    setBranchId,
+    setSel,
+    setWhatsNewForced,
+    theme,
+    toggle,
+  ]);
 
   const results = useMemo(() => {
     const q = query.trim();
     const scored: Array<{ cmd: Command; indices: number[]; score: number }> = [];
     for (const cmd of commands) {
+      // With no query there is nothing to rank by, so storage objects would
+      // simply flood the idle list and push the pages out of it. The resting
+      // palette stays what it always was: pages, projects, actions.
+      if (!q && (cmd.kind === "bucket" || cmd.kind === "table")) continue;
+      const bias = cmd.bias ?? 0;
       const onLabel = fuzzyMatch(q, cmd.label);
       if (onLabel) {
-        scored.push({ cmd, indices: onLabel.indices, score: onLabel.score });
+        scored.push({ cmd, indices: onLabel.indices, score: onLabel.score + bias });
         continue;
       }
       // Fall back to the invisible haystack (project name, page id, synonyms)
       // so "colour" finds the theme toggle -- but rank those below label hits.
       const haystack = `${cmd.label} ${cmd.hint ?? ""} ${cmd.keywords ?? ""}`;
       const onHaystack = fuzzyMatch(q, haystack);
-      if (onHaystack) scored.push({ cmd, indices: [], score: onHaystack.score + 50 });
+      if (onHaystack) scored.push({ cmd, indices: [], score: onHaystack.score + 50 + bias });
     }
     if (!q) return scored.slice(0, 50);
-    return scored.sort((a, b) => a.score - b.score).slice(0, 50);
-  }, [commands, query]);
+    const top = scored.sort((a, b) => a.score - b.score).slice(0, 50);
+    // Appended AFTER sorting and slicing: the escape hatch is not a match, it
+    // is the answer to "the local haystack does not have it". Being part of
+    // `results` is what makes it reachable with ↓ and Enter like any other row.
+    top.push({
+      cmd: {
+        id: "search:global",
+        kind: "search",
+        label: `Search "${q}" across projects`,
+        hint: "Search page",
+        icon: Search,
+        run: () => {
+          setPendingSearchQuery(q);
+          setPage("search");
+        },
+      },
+      indices: [],
+      score: Number.MAX_SAFE_INTEGER,
+    });
+    return top;
+  }, [commands, query, setPage, setPendingSearchQuery]);
 
   // Keep the cursor inside the (shrinking) result list as the user types.
   useEffect(() => {
@@ -268,7 +441,7 @@ export function CommandPalette() {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={onKeyDown}
-            placeholder="jump to a page, switch project, run an action…"
+            placeholder="jump to a page, find a bucket or table, run an action…"
             className="flex-1 bg-transparent text-sm focus:outline-none placeholder-zinc-400 dark:placeholder-zinc-600"
             aria-label="Command palette"
           />

--- a/web/frontend/src/pages/Search.tsx
+++ b/web/frontend/src/pages/Search.tsx
@@ -1,9 +1,10 @@
 import { useMutation } from "@tanstack/react-query";
 import { Search as SearchIcon } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { api } from "../api/client";
 import { ErrorBox, PageTitle } from "../components/Empty";
 import { DataTable } from "../components/Table";
+import { useUIState } from "../state";
 
 interface SearchResp {
   results: Array<{
@@ -19,22 +20,41 @@ interface SearchResp {
 }
 
 export function SearchPage() {
+  const { pendingSearchQuery, setPendingSearchQuery } = useUIState();
   const [query, setQuery] = useState("");
   const [searchType, setSearchType] = useState<"textual" | "config-based">("textual");
   const [types, setTypes] = useState<string[]>([]);
   const [result, setResult] = useState<SearchResp | null>(null);
 
+  // The mutation takes the query as an argument (rather than closing over
+  // `query` state) so the hand-off effect below can fire it with a value
+  // that bypasses the async setState -- an immediate mu.mutate() right
+  // after setQuery(q) would otherwise still see the stale (pre-update)
+  // query state, same stale-closure trap the LocalAi consumer documents.
   const mu = useMutation({
-    mutationFn: () =>
+    mutationFn: (q: string) =>
       api.get<SearchResp>("/search", {
         query: {
-          query,
+          query: q,
           search_type: searchType,
           type: types.length ? types : undefined,
         },
       }),
     onSuccess: (data) => setResult(data),
   });
+
+  // Hand-off slot from the command palette's "Search '...' across projects"
+  // escape row: adopt the query into local state, clear the slot so a
+  // remount can't re-fire, and run the search immediately with the value
+  // passed directly.
+  useEffect(() => {
+    if (!pendingSearchQuery) return;
+    const q = pendingSearchQuery;
+    setQuery(q);
+    setPendingSearchQuery(null);
+    mu.mutate(q);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingSearchQuery]);
 
   return (
     <div className="space-y-4">
@@ -43,7 +63,7 @@ export function SearchPage() {
         className="nerd-card flex gap-2 flex-wrap"
         onSubmit={(e) => {
           e.preventDefault();
-          if (query.trim()) mu.mutate();
+          if (query.trim()) mu.mutate(query);
         }}
       >
         <input

--- a/web/frontend/src/pages/Storage.tsx
+++ b/web/frontend/src/pages/Storage.tsx
@@ -11,7 +11,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { api, ApiError } from "../api/client";
 import { Drawer } from "../components/Drawer";
 import { Empty, ErrorBox, Loading, PageTitle } from "../components/Empty";
@@ -206,22 +206,38 @@ export function StoragePage() {
     enabled: !!project && tab === "tables",
   });
 
-  // Restore a deep-linked table ONCE, after the first tables load. The list is
-  // unfiltered, so every table in the project is a candidate; a link to a table
-  // that no longer exists simply leaves the list open.
-  const restoredRef = useRef(false);
+  // Adopt a `sel` that arrived from OUTSIDE this page. On a cold deep link
+  // that is the initial state, but the command palette can also retarget the
+  // page while it is already mounted -- so this cannot be a mount-only read.
+  // The page's own clicks write `sel` and the matching local state together,
+  // so they arrive here as no-ops.
   useEffect(() => {
-    if (restoredRef.current) return;
+    const { tab: wantTab, tableId, bucketId } = parseStorageSel(sel);
+    if (wantTab === "tables") setTabState("tables");
+    if (bucketId) setBucketFilter(bucketId);
+    // A table target resolves against the project-wide list, so a filter that
+    // cannot contain it would hide the very row we are opening. Drop that one;
+    // keep a filter the table does belong to -- it is the context the reader
+    // is already in, and the chip should not blink out from under them.
+    if (tableId) setBucketFilter((f) => (f && tableId.startsWith(`${f}.`) ? f : null));
+  }, [sel]);
+
+  // Open the table named by `?sel=` once a list containing it has loaded.
+  //
+  // Deliberately NOT guarded by a "we already tried this id" flag. Dropping an
+  // incompatible bucket filter (above) swaps the tables query onto a new key,
+  // and this effect runs once more against the OLD, still-filtered rows before
+  // the wider list arrives -- a give-up flag set on that pass would strand the
+  // drawer shut. A miss simply changes nothing and waits for the next data.
+  //
+  // It cannot re-open a drawer the user closed either: closing rewrites `sel`
+  // without a table part, so `wanted` is null from then on.
+  useEffect(() => {
     const wanted = parseStorageSel(sel).tableId;
-    if (!wanted) {
-      restoredRef.current = true;
-      return;
-    }
-    if (!tablesQ.data) return;
-    restoredRef.current = true;
+    if (!wanted || wanted === selectedTable?.id || !tablesQ.data) return;
     const hit = tablesQ.data.tables.find((t) => t.id === wanted);
     if (hit) setSelectedTable(hit);
-  }, [sel, tablesQ.data]);
+  }, [sel, selectedTable, tablesQ.data]);
 
   return (
     <div className="space-y-4">

--- a/web/frontend/src/pages/Storage.tsx
+++ b/web/frontend/src/pages/Storage.tsx
@@ -26,27 +26,54 @@ type StorageTab = "buckets" | "tables" | "files";
 const STORAGE_TABS: readonly StorageTab[] = ["buckets", "tables", "files"];
 
 /**
- * This page's `?sel=` grammar: `<tab>` or `tables/<tableId>`.
+ * This page's `?sel=` grammar: `<tab>`, `tables/<tableId>` or
+ * `bucket/<bucketId>`.
  *
  * The tab is part of the selection because it is what the link has to restore
  * before anything can be opened -- the tables query is gated on it. Only the
  * tables tab has a detail view (the table drawer), so it is the only one that
- * carries an object id. The bucket FILTER is deliberately not encoded: it is a
- * transient narrowing of the same list, not a selected object.
+ * carries a table id.
+ *
+ * The `bucket/` form encodes the bucket FILTER, which arrived with the command
+ * palette: picking a bucket there is a NAVIGATION target ("show me this
+ * bucket"), not the transient narrowing it is when you click a row on the way
+ * down the list -- and a destination has to survive a reload and a paste into
+ * chat. Both entry points write it, so the filter chip you see always matches
+ * the URL you can copy.
+ *
+ * A table id already carries its bucket (`in.c-oltp.orders`), so an open
+ * drawer needs no separate bucket part: `tables/<tableId>` wins over the
+ * filter, and restoring it leaves the list unfiltered, exactly as a table
+ * deep link behaved before the bucket form existed.
  */
-function parseStorageSel(sel: string | null): { tab: StorageTab; tableId: string | null } {
-  if (!sel) return { tab: "buckets", tableId: null };
+export function parseStorageSel(sel: string | null): {
+  tab: StorageTab;
+  tableId: string | null;
+  bucketId: string | null;
+} {
+  if (!sel) return { tab: "buckets", tableId: null, bucketId: null };
   const slash = sel.indexOf("/");
   const head = slash === -1 ? sel : sel.slice(0, slash);
   const rest = slash === -1 ? "" : sel.slice(slash + 1);
+  if (head === "bucket") {
+    // A bucket-less `bucket/` is meaningless; fall back to the plain list.
+    return rest
+      ? { tab: "tables", tableId: null, bucketId: rest }
+      : { tab: "buckets", tableId: null, bucketId: null };
+  }
   const tab = (STORAGE_TABS as readonly string[]).includes(head)
     ? (head as StorageTab)
     : "buckets";
-  return { tab, tableId: tab === "tables" && rest ? rest : null };
+  return { tab, tableId: tab === "tables" && rest ? rest : null, bucketId: null };
 }
 
-function buildStorageSel(tab: StorageTab, tableId: string | null): string | null {
+export function buildStorageSel(
+  tab: StorageTab,
+  tableId: string | null,
+  bucketId: string | null = null,
+): string | null {
   if (tab === "tables" && tableId) return `tables/${tableId}`;
+  if (tab === "tables" && bucketId) return `bucket/${bucketId}`;
   // The landing view needs no `sel` at all -- keeps a plain project link clean.
   return tab === "buckets" ? null : tab;
 }
@@ -120,17 +147,22 @@ function formatBytes(n: number): string {
 
 export function StoragePage() {
   const { project, branchId } = useUIState();
-  // Deep link: `?sel=tables/<tableId>` restores the tab AND opens the drawer.
+  // Deep link: `?sel=tables/<tableId>` restores the tab AND opens the drawer;
+  // `?sel=bucket/<bucketId>` restores the tab AND the bucket filter.
   const [sel, setSel] = useHashSelection();
   const [tab, setTabState] = useState<StorageTab>(() => parseStorageSel(sel).tab);
-  const [bucketFilter, setBucketFilter] = useState<string | null>(null);
+  const [bucketFilter, setBucketFilter] = useState<string | null>(
+    () => parseStorageSel(sel).bucketId,
+  );
   const [selectedTable, setSelectedTable] = useState<TableT | null>(null);
 
   // Switching tabs drops the open table: the drawer belongs to the tables tab.
+  // The bucket filter survives the trip (it is still shown as a chip), so it
+  // stays in the URL whenever the tables tab is the one being shown.
   const setTab = (t: StorageTab) => {
     setTabState(t);
     setSelectedTable(null);
-    setSel(buildStorageSel(t, null));
+    setSel(buildStorageSel(t, null, bucketFilter));
   };
   const openTable = (t: TableT) => {
     setSelectedTable(t);
@@ -138,7 +170,21 @@ export function StoragePage() {
   };
   const closeTable = () => {
     setSelectedTable(null);
-    setSel(buildStorageSel(tab, null));
+    setSel(buildStorageSel(tab, null, bucketFilter));
+  };
+  // Narrowing to a bucket -- from a row click here or from the command
+  // palette's deep link -- lands on the tables tab with the filter applied.
+  // Written as one function because `setTab` would otherwise capture the
+  // pre-update `bucketFilter` and drop it from the URL.
+  const openBucket = (bucketId: string) => {
+    setBucketFilter(bucketId);
+    setTabState("tables");
+    setSelectedTable(null);
+    setSel(buildStorageSel("tables", null, bucketId));
+  };
+  const clearBucketFilter = () => {
+    setBucketFilter(null);
+    setSel(buildStorageSel(tab, null, null));
   };
 
   const bucketsQ = useQuery<BucketsResp>({
@@ -198,7 +244,7 @@ export function StoragePage() {
           <button
             type="button"
             className="nerd-btn text-xs hover:text-amber-700 dark:hover:text-amber-400"
-            onClick={() => setBucketFilter(null)}
+            onClick={clearBucketFilter}
           >
             ✕ filter: {bucketFilter}
           </button>
@@ -216,10 +262,7 @@ export function StoragePage() {
           <DataTable
             rows={bucketsQ.data?.buckets ?? []}
             rowKey={(b) => `${b.project_alias}/${b.id}`}
-            onRowClick={(b) => {
-              setBucketFilter(b.id);
-              setTab("tables");
-            }}
+            onRowClick={(b) => openBucket(b.id)}
             columns={[
               {
                 header: "Bucket",

--- a/web/frontend/src/pages/storageSel.test.ts
+++ b/web/frontend/src/pages/storageSel.test.ts
@@ -1,0 +1,91 @@
+/**
+ * The Storage page's `?sel=` grammar.
+ *
+ * Worth its own suite because two surfaces now write it -- the page's own row
+ * clicks and the command palette's bucket/table rows -- so a change here
+ * silently breaks a link that came from the other one.
+ */
+import { describe, expect, it } from "vitest";
+import { buildStorageSel, parseStorageSel } from "./Storage";
+
+describe("parseStorageSel", () => {
+  it("lands on the buckets tab with no selection", () => {
+    expect(parseStorageSel(null)).toEqual({ tab: "buckets", tableId: null, bucketId: null });
+  });
+
+  it("parses a bare tab", () => {
+    expect(parseStorageSel("tables")).toEqual({ tab: "tables", tableId: null, bucketId: null });
+    expect(parseStorageSel("files")).toEqual({ tab: "files", tableId: null, bucketId: null });
+  });
+
+  it("parses a table selection", () => {
+    expect(parseStorageSel("tables/in.c-oltp.orders")).toEqual({
+      tab: "tables",
+      tableId: "in.c-oltp.orders",
+      bucketId: null,
+    });
+  });
+
+  it("parses a bucket filter onto the tables tab", () => {
+    expect(parseStorageSel("bucket/in.c-oltp")).toEqual({
+      tab: "tables",
+      tableId: null,
+      bucketId: "in.c-oltp",
+    });
+  });
+
+  it("degrades an unknown or empty head to the buckets tab", () => {
+    expect(parseStorageSel("nonsense")).toEqual({ tab: "buckets", tableId: null, bucketId: null });
+    // A `bucket/` with nothing after it names no bucket, so there is nothing
+    // to filter by -- the plain list is the honest fallback.
+    expect(parseStorageSel("bucket/")).toEqual({ tab: "buckets", tableId: null, bucketId: null });
+  });
+
+  it("ignores a table id on a tab that has no detail view", () => {
+    expect(parseStorageSel("files/in.c-oltp.orders")).toEqual({
+      tab: "files",
+      tableId: null,
+      bucketId: null,
+    });
+  });
+});
+
+describe("buildStorageSel", () => {
+  it("emits nothing for the landing view", () => {
+    expect(buildStorageSel("buckets", null)).toBeNull();
+    expect(buildStorageSel("buckets", null, "in.c-oltp")).toBeNull();
+  });
+
+  it("emits the bare tab when nothing is selected", () => {
+    expect(buildStorageSel("tables", null)).toBe("tables");
+    expect(buildStorageSel("files", null)).toBe("files");
+  });
+
+  it("emits a bucket filter", () => {
+    expect(buildStorageSel("tables", null, "in.c-oltp")).toBe("bucket/in.c-oltp");
+  });
+
+  it("prefers the open table over the bucket filter", () => {
+    // The table id already carries its bucket, so the filter adds nothing a
+    // reader of the link would miss.
+    expect(buildStorageSel("tables", "in.c-oltp.orders", "in.c-oltp")).toBe(
+      "tables/in.c-oltp.orders",
+    );
+  });
+});
+
+describe("round trip", () => {
+  it("survives parse(build(x)) for every form", () => {
+    const cases: Array<[Parameters<typeof buildStorageSel>, string | null, string | null]> = [
+      [["tables", "in.c-oltp.orders", null], "in.c-oltp.orders", null],
+      [["tables", null, "in.c-oltp"], null, "in.c-oltp"],
+      [["tables", null, null], null, null],
+    ];
+    for (const [args, tableId, bucketId] of cases) {
+      const parsed = parseStorageSel(buildStorageSel(...args));
+      expect(parsed.tab).toBe("tables");
+      expect(parsed.tableId).toBe(tableId);
+      expect(parsed.bucketId).toBe(bucketId);
+    }
+  });
+});

--- a/web/frontend/src/state.tsx
+++ b/web/frontend/src/state.tsx
@@ -75,6 +75,11 @@ interface UIState {
   // shape as pendingLocalAiMessage -- one writer, one reader, self-clearing.
   whatsNewForced: boolean;
   setWhatsNewForced: (v: boolean) => void;
+  // Hand-off slot: dropped by the command palette's "Search '...' across
+  // projects" escape row. The Search page reads it on mount, auto-runs the
+  // search, then clears it.
+  pendingSearchQuery: string | null;
+  setPendingSearchQuery: (q: string | null) => void;
 }
 
 const UIStateContext = createContext<UIState | null>(null);
@@ -103,6 +108,7 @@ export function UIStateProvider({ children }: { children: ReactNode }) {
   const [manageToken, setManageToken] = useState<string | null>(null);
   const [pendingLocalAiMessage, setPendingLocalAiMessage] = useState<string | null>(null);
   const [whatsNewForced, setWhatsNewForced] = useState(false);
+  const [pendingSearchQuery, setPendingSearchQuery] = useState<string | null>(null);
 
   // Navigating to another page drops the previous page's selection: `sel` is
   // page-owned, so carrying it across would hand one page another's cookie.
@@ -188,6 +194,8 @@ export function UIStateProvider({ children }: { children: ReactNode }) {
         setPendingLocalAiMessage,
         whatsNewForced,
         setWhatsNewForced,
+        pendingSearchQuery,
+        setPendingSearchQuery,
       }}
     >
       {children}


### PR DESCRIPTION
## What

The Ctrl/Cmd+K command palette (introduced in #658) now finds **storage buckets and tables**, not just pages/projects/actions — plus an always-available escape row that hands the query to the Search page.


## Why

Typing a bucket name like `oltp` into the palette previously matched nothing — the palette could reach the Storage *page* but not a storage *object*. This closes that gap while keeping the palette's core contract: **nothing waits on the network while you type.**

Note: this deliberately does NOT build on the `/search` endpoint — server-side textual search requires the `global-search` project feature, which many projects (including the demo org) don't have. Cheap listings + client-side fuzzy matching work everywhere.

## How it works / how it scales

Three data layers, all fetched on palette **open** (never per keystroke), matched locally:

| Layer | What | Cost |
|---|---|---|
| 1 | Active project's buckets + tables | usually **0 requests** — react-query keys are shared with the Storage page's own queries |
| 2 | Buckets of **all registered projects** | one request at `staleTime: 60s`; the server fans out in parallel (`_run_parallel`) and degrades per project via `errors[]`, which the palette ignores silently |
| 3 | Foreign-project tables | **deliberately not loaded** — reachable via their bucket; keeps the haystack bounded as project count grows |

With e.g. 30 projects the haystack is a few thousand rows; the fuzzy matcher is a plain char scan (~ms per keystroke) and results stay capped at 50.

## UX

- **Enter on a bucket** → Storage page, `tables` tab, bucket filter applied. A foreign bucket switches the active project first (and resets the branch, same as the palette's project command).
- **Enter on a table** → same, plus the table detail drawer opens.
- **`Search "…" across projects`** — always the last row for a non-empty query; jumps to the Search page with the query prefilled and auto-run.
- Ranking: data rows carry a score bias (+25, foreign buckets +35) so short queries keep pages/actions on top; a specific query wins on raw match quality. The idle (empty-query) list is unchanged.

## Implementation

- `CommandPalette.tsx`: three `useQuery` layers gated on `open`, new command kinds `bucket`/`table`/`search`, score bias, escape row appended after sort/slice (keyboard-reachable, outside the 50 cap), header comment rewritten (the old "deliberately NOT a search over Keboola data" contract is superseded).
- `state.tsx`: two hand-off slots following the `pendingLocalAiMessage` precedent — `pendingStorageTarget` (bucket filter + optional table drawer) and `pendingSearchQuery`.
- `Storage.tsx`: consumes `pendingStorageTarget` in two steps (global slot cleared immediately to avoid remount double-fire; the table row is looked up once `tablesQ` resolves — a table deleted in the meantime degrades silently to the filtered list).
- `Search.tsx`: mutation now takes the query as an argument (avoids the stale-closure trap the LocalAi consumer documents); consumes `pendingSearchQuery` with auto-run.

No backend, CLI, or changelog changes (UI-only; changelog lands in the release PR per #648).

## Testing

- `tsc --noEmit` + `vite build` clean (the frontend CI gate from #661).
- Verified live against `kbagent serve --ui` with 4 registered projects: bucket jump, table drawer, foreign-project bucket switch (`erp` → `analytics · in.c-erp` and back), and the Search hand-off with auto-run.

## Update after rebase onto #665

#665 (shareable deep links) landed mid-flight and made the original `pendingStorageTarget` hand-off slot obsolete: the Storage page now owns a URL-mirrored `?sel=` selection. This PR was reworked to build on it instead:

- The palette navigates by writing `sel` via the Storage page's own (now exported) grammar helper — so **a palette jump produces the same shareable URL as clicking the row** (`#/p/erp/storage?sel=bucket%2Fin.c-erp`, `...?sel=tables%2F<tableId>`).
- The grammar gained a `bucket/<bucketId>` form; the bucket filter chip is now in the URL and survives a cold reload (it previously was deliberately not encoded — a palette pick is a destination, not a transient narrowing).
- Fixed a latent mount-only assumption in #665's restore effect: a `sel` written while the page is already mounted (palette retarget, incompatible bucket filter) now applies instead of being consumed by a one-shot ref.
- `pendingSearchQuery` (the Search-page escape row) stays — a *pending action* (auto-run) is not a *selection*, so it does not belong in the URL.
- New vitest suite `storageSel.test.ts` (11 tests) for the grammar, joining #665's router suite in the CI `npm test` step.
