### PR TITLE
feat(ui): render the Changelog page as a typed release timeline

### DIFF
--- a/web/frontend/src/changelogNotes.test.ts
+++ b/web/frontend/src/changelogNotes.test.ts
@@ -62,6 +62,27 @@ describe("splitHeadline", () => {
     const { headline } = splitHeadline("exit code 5! And more.");
     expect(headline).toBe("exit code 5!");
   });
+
+  // The abbreviation set is an exact port of _HEADLINE_ABBREVIATIONS in
+  // changelog.py; every member must suppress the split here too, or a note
+  // reads differently on the page than under `kbagent changelog`.
+  it.each(["e.g", "i.e", "vs", "etc", "cf", "no", "al", "inc"])(
+    "does not break after the %s. abbreviation",
+    (abbr) => {
+      const { headline } = splitHeadline(`before ${abbr}. after. Second sentence.`);
+      expect(headline).toBe(`before ${abbr}. after.`);
+    },
+  );
+
+  it("breaks after an abbreviation-like word outside the ported set", () => {
+    const { headline } = splitHeadline("shipped incl. extras. More.");
+    expect(headline).toBe("shipped incl.");
+  });
+
+  it("resolves the trailing token to its final word, digits and underscores aside", () => {
+    const { headline } = splitHeadline("the flag kbagent_no. after. More.");
+    expect(headline).toBe("the flag kbagent_no. after.");
+  });
 });
 
 describe("toRuns", () => {

--- a/web/frontend/src/changelogNotes.test.ts
+++ b/web/frontend/src/changelogNotes.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { parseNote, splitHeadline, toRuns } from "./changelogNotes";
+
+describe("parseNote", () => {
+  it("extracts label, tone and PR numbers from a decorated prefix", () => {
+    const n = parseNote("New (#658, #664): a Ctrl+K command palette. It jumps to any page.");
+    expect(n.label).toBe("New");
+    expect(n.tone).toBe("green");
+    expect(n.prs).toEqual([658, 664]);
+    expect(n.headline).toBe("a Ctrl+K command palette.");
+    expect(n.rest).toBe("It jumps to any page.");
+  });
+
+  it("recognises prefixes case-insensitively and non-PR decorations", () => {
+    const n = parseNote("BREAKING (sec-20 follow-up): tokens rotate.");
+    expect(n.label).toBe("BREAKING");
+    expect(n.tone).toBe("red");
+    expect(n.prs).toEqual([]);
+  });
+
+  it("prefers the longest prefix alternative", () => {
+    expect(parseNote("Plugin docs: refreshed.").label).toBe("Plugin docs");
+    expect(parseNote("Plugin docs: refreshed.").tone).toBe("dim");
+  });
+
+  it("leaves unprefixed notes label-less with the full text as body", () => {
+    const n = parseNote("Just a plain remark. With detail.");
+    expect(n.label).toBeNull();
+    expect(n.headline).toBe("Just a plain remark.");
+    expect(n.rest).toBe("With detail.");
+  });
+
+  it("maps every documented prefix to its CLI tone", () => {
+    expect(parseNote("Fix: x.").tone).toBe("amber");
+    expect(parseNote("Change: x.").tone).toBe("blue");
+    expect(parseNote("UX: x.").tone).toBe("magenta");
+    expect(parseNote("Note: x.").tone).toBe("cyan");
+    expect(parseNote("Security: x.").tone).toBe("red");
+    expect(parseNote("Internal: x.").tone).toBe("dim");
+  });
+});
+
+describe("splitHeadline", () => {
+  it("does not break inside version numbers", () => {
+    const { headline } = splitHeadline("since 0.57.0 the flow works. Detail here.");
+    expect(headline).toBe("since 0.57.0 the flow works.");
+  });
+
+  it("does not break after e.g.", () => {
+    const { headline, rest } = splitHeadline("some flags, e.g. `--json`, help. More.");
+    expect(headline).toBe("some flags, e.g. `--json`, help.");
+    expect(rest).toBe("More.");
+  });
+
+  it("returns the whole text when there is a single sentence", () => {
+    const { headline, rest } = splitHeadline("One sentence only.");
+    expect(headline).toBe("One sentence only.");
+    expect(rest).toBe("");
+  });
+
+  it("treats ! and ? as sentence ends even after a digit", () => {
+    const { headline } = splitHeadline("exit code 5! And more.");
+    expect(headline).toBe("exit code 5!");
+  });
+});
+
+describe("toRuns", () => {
+  it("splits backtick spans into code runs", () => {
+    expect(toRuns("run `kbagent serve --ui` today")).toEqual([
+      { code: false, text: "run " },
+      { code: true, text: "kbagent serve --ui" },
+      { code: false, text: " today" },
+    ]);
+  });
+
+  it("passes through text without backticks", () => {
+    expect(toRuns("plain")).toEqual([{ code: false, text: "plain" }]);
+  });
+});

--- a/web/frontend/src/changelogNotes.ts
+++ b/web/frontend/src/changelogNotes.ts
@@ -1,0 +1,141 @@
+/**
+ * Client-side parser for changelog notes.
+ * =======================================
+ *
+ * `GET /changelog` returns the raw bullet strings from `changelog.py`, which
+ * follow the authoring contract the CLI renderer already exploits
+ * (`commands/changelog.py`): a leading `Prefix (#PR):` tag, a self-contained
+ * first sentence, and inline backtick spans. This module ports that parsing
+ * so the web page can render the same semantics -- typed badges, PR links,
+ * headline-first collapsing -- instead of dumping the raw text.
+ *
+ * Keep the prefix list and sentence rules in sync with
+ * `commands/changelog.py` (`_PREFIX_RE`) and `changelog.py` (`headline()`).
+ */
+
+/** Visual grouping for a note type; maps 1:1 to the CLI's Rich styles. */
+export type NoteTone = "red" | "green" | "amber" | "blue" | "magenta" | "cyan" | "dim";
+
+export interface ParsedNote {
+  /** Canonical prefix label, e.g. "New", "Fix", "BREAKING". Null when the note has no recognised prefix. */
+  label: string | null;
+  tone: NoteTone;
+  /** PR numbers pulled from the prefix decoration, e.g. "(#658, #664)" -> [658, 664]. */
+  prs: number[];
+  /** First sentence of the body (prefix stripped) -- the collapsed view. */
+  headline: string;
+  /** Body text after the headline; empty string when the headline is the whole note. */
+  rest: string;
+}
+
+/** One piece of a rendered text run: plain text or an inline code span. */
+export interface TextRun {
+  code: boolean;
+  text: string;
+}
+
+// Longest-alternative-first, mirroring _PREFIX_RE in commands/changelog.py.
+const PREFIX_RE = new RegExp(
+  "^(Plugin docs|Review fixes|Observability|Breaking|Security|Closed|Tests|" +
+    "Internal|Change|Note|Fix|New|UX|E2E|Why)" +
+    "(\\s*\\(([^)]*)\\))?" + // optional "(#274)" / "(sec-20 follow-up)" decoration
+    ":\\s+",
+  "i",
+);
+
+const TONES: Record<string, NoteTone> = {
+  breaking: "red",
+  security: "red",
+  new: "green",
+  fix: "amber",
+  change: "blue",
+  closed: "blue",
+  ux: "magenta",
+  note: "cyan",
+  tests: "dim",
+  "plugin docs": "dim",
+  internal: "dim",
+  observability: "dim",
+  e2e: "dim",
+  "review fixes": "dim",
+  why: "dim",
+};
+
+/** Render the label the way the changelog writes it: BREAKING stays shouted, the rest title-case. */
+const LABELS: Record<string, string> = {
+  breaking: "BREAKING",
+  security: "Security",
+  new: "New",
+  fix: "Fix",
+  change: "Change",
+  closed: "Closed",
+  ux: "UX",
+  note: "Note",
+  tests: "Tests",
+  "plugin docs": "Plugin docs",
+  internal: "Internal",
+  observability: "Observability",
+  e2e: "E2E",
+  "review fixes": "Review fixes",
+  why: "Why",
+};
+
+// Abbreviations whose trailing period is not a sentence end; subset of
+// _HEADLINE_ABBREVIATIONS in changelog.py that actually occurs in notes.
+const ABBREVIATIONS = new Set(["e.g", "i.e", "etc", "vs", "cf", "incl", "resp"]);
+
+/**
+ * First-sentence split, porting `headline()`'s rules: a `.`/`!`/`?` followed
+ * by whitespace ends the sentence, unless the period sits inside a version
+ * number (digit before it) or terminates a known abbreviation.
+ */
+export function splitHeadline(text: string): { headline: string; rest: string } {
+  const boundary = /[.!?](?=\s)/g;
+  let m: RegExpExecArray | null = boundary.exec(text);
+  while (m !== null) {
+    const dot = m.index;
+    const before = dot > 0 ? text[dot - 1] : "";
+    const isDigitPeriod = text[dot] === "." && before >= "0" && before <= "9";
+    const tokenMatch = /[\w.]+$/.exec(text.slice(0, dot));
+    const token = tokenMatch ? tokenMatch[0].replace(/\.+$/, "").toLowerCase() : "";
+    if (!isDigitPeriod && !ABBREVIATIONS.has(token)) {
+      return {
+        headline: text.slice(0, dot + 1),
+        rest: text.slice(dot + 1).trim(),
+      };
+    }
+    m = boundary.exec(text);
+  }
+  return { headline: text, rest: "" };
+}
+
+export function parseNote(note: string): ParsedNote {
+  const m = PREFIX_RE.exec(note);
+  let label: string | null = null;
+  let tone: NoteTone = "dim";
+  let prs: number[] = [];
+  let body = note;
+  if (m) {
+    const key = m[1].toLowerCase();
+    label = LABELS[key] ?? m[1];
+    tone = TONES[key] ?? "dim";
+    prs = [...(m[3] ?? "").matchAll(/#(\d+)/g)].map((g) => Number(g[1]));
+    body = note.slice(m[0].length);
+  }
+  const { headline, rest } = splitHeadline(body);
+  return { label, tone, prs, headline, rest };
+}
+
+/** Split text into plain/inline-code runs on backtick spans (`` `like this` ``). */
+export function toRuns(text: string): TextRun[] {
+  const runs: TextRun[] = [];
+  for (const part of text.split(/(`[^`\n]+`)/)) {
+    if (!part) continue;
+    if (part.startsWith("`") && part.endsWith("`") && part.length >= 2) {
+      runs.push({ code: true, text: part.slice(1, -1) });
+    } else {
+      runs.push({ code: false, text: part });
+    }
+  }
+  return runs;
+}

--- a/web/frontend/src/changelogNotes.ts
+++ b/web/frontend/src/changelogNotes.ts
@@ -80,9 +80,16 @@ const LABELS: Record<string, string> = {
   why: "Why",
 };
 
-// Abbreviations whose trailing period is not a sentence end; subset of
-// _HEADLINE_ABBREVIATIONS in changelog.py that actually occurs in notes.
-const ABBREVIATIONS = new Set(["e.g", "i.e", "etc", "vs", "cf", "incl", "resp"]);
+// Abbreviations whose trailing period is not a sentence end. Exact port of
+// _HEADLINE_ABBREVIATIONS in changelog.py -- a note must split the same way
+// here and in `kbagent changelog`, so this set carries no additions of its own.
+const ABBREVIATIONS = new Set(["e.g", "i.e", "vs", "etc", "cf", "no", "al", "inc"]);
+
+// Final alphabetic token (internal dots included) before a period, tested
+// against ABBREVIATIONS. Port of _TRAILING_TOKEN: letters only, so a token
+// carrying digits or underscores resolves to its trailing word exactly as it
+// does in Python ("kbagent_no." -> "no").
+const TRAILING_TOKEN = /[A-Za-z][A-Za-z.]*$/;
 
 /**
  * First-sentence split, porting `headline()`'s rules: a `.`/`!`/`?` followed
@@ -96,7 +103,7 @@ export function splitHeadline(text: string): { headline: string; rest: string } 
     const dot = m.index;
     const before = dot > 0 ? text[dot - 1] : "";
     const isDigitPeriod = text[dot] === "." && before >= "0" && before <= "9";
-    const tokenMatch = /[\w.]+$/.exec(text.slice(0, dot));
+    const tokenMatch = TRAILING_TOKEN.exec(text.slice(0, dot));
     const token = tokenMatch ? tokenMatch[0].replace(/\.+$/, "").toLowerCase() : "";
     if (!isDigitPeriod && !ABBREVIATIONS.has(token)) {
       return {

--- a/web/frontend/src/pages/Changelog.tsx
+++ b/web/frontend/src/pages/Changelog.tsx
@@ -1,9 +1,110 @@
+/**
+ * Changelog page -- the release rail.
+ *
+ * Renders `GET /changelog` the way the CLI renders `kbagent changelog`, but
+ * readable: each version is a node on a vertical timeline, every note is
+ * collapsed to its first sentence behind a typed badge (New / Fix / BREAKING
+ * ... in the CLI's own colours), PR references become GitHub links, and the
+ * running version is highlighted on the rail. Parsing lives in
+ * `../changelogNotes.ts`, shared semantics with `commands/changelog.py`.
+ */
 import { useQuery } from "@tanstack/react-query";
+import { ChevronRight } from "lucide-react";
+import { useState } from "react";
 import { api } from "../api/client";
+import { type NoteTone, type TextRun, parseNote, toRuns } from "../changelogNotes";
 import { ErrorBox, Loading, PageTitle } from "../components/Empty";
 
 interface ChangelogResp {
   entries: Array<{ version: string; highlights: string[] }>;
+}
+
+interface VersionResp {
+  kbagent: { version: string };
+}
+
+const BADGE_TONES: Record<NoteTone, string> = {
+  red: "border-red-300 text-red-700 dark:border-red-700/50 dark:text-red-400",
+  green: "border-keboola/40 text-keboola-600 dark:text-keboola",
+  amber: "border-neon-amber/50 text-amber-700 dark:border-neon-amber/40 dark:text-neon-amber",
+  blue: "border-sky-300 text-sky-700 dark:border-sky-700/50 dark:text-sky-400",
+  magenta: "border-fuchsia-300 text-fuchsia-700 dark:border-fuchsia-700/50 dark:text-fuchsia-400",
+  cyan: "border-cyan-300 text-cyan-700 dark:border-cyan-700/50 dark:text-cyan-400",
+  dim: "border-zinc-300 text-zinc-500 dark:border-zinc-700 dark:text-zinc-500",
+};
+
+/** Inline text with `code` spans rendered like the rest of the UI's inline code. */
+function Runs({ runs }: { runs: TextRun[] }) {
+  return (
+    <>
+      {runs.map((r, i) =>
+        r.code ? (
+          <code
+            key={i}
+            className="px-1 py-px rounded bg-zinc-100 border border-zinc-200 text-[0.92em] text-zinc-700 dark:bg-zinc-950 dark:border-zinc-800 dark:text-zinc-300"
+          >
+            {r.text}
+          </code>
+        ) : (
+          <span key={i}>{r.text}</span>
+        ),
+      )}
+    </>
+  );
+}
+
+function Note({ note, expanded, onToggle }: { note: string; expanded: boolean; onToggle: () => void }) {
+  const p = parseNote(note);
+  const hasDetail = p.rest.length > 0;
+  return (
+    <li className="group">
+      <button
+        type="button"
+        onClick={onToggle}
+        disabled={!hasDetail}
+        aria-expanded={hasDetail ? expanded : undefined}
+        className={`w-full text-left flex items-start gap-2 rounded px-2 py-1.5 -mx-2 ${
+          hasDetail ? "hover:bg-zinc-100/70 dark:hover:bg-zinc-800/40 cursor-pointer" : "cursor-default"
+        }`}
+      >
+        <ChevronRight
+          className={`w-3.5 h-3.5 mt-1 shrink-0 transition-transform ${
+            hasDetail
+              ? `text-zinc-400 group-hover:text-zinc-600 dark:group-hover:text-zinc-300 ${expanded ? "rotate-90" : ""}`
+              : "invisible"
+          }`}
+        />
+        {p.label ? (
+          <span
+            className={`inline-flex shrink-0 mt-0.5 px-1.5 py-px rounded border text-[10px] font-bold uppercase tracking-wide ${BADGE_TONES[p.tone]}`}
+          >
+            {p.label}
+          </span>
+        ) : null}
+        <span className="text-sm leading-relaxed text-zinc-800 dark:text-zinc-200 min-w-0">
+          <Runs runs={toRuns(p.headline)} />
+          {p.prs.map((pr) => (
+            <a
+              key={pr}
+              href={`https://github.com/keboola/cli/pull/${pr}`}
+              target="_blank"
+              rel="noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              className="ml-1.5 text-xs text-zinc-400 hover:text-keboola transition-colors"
+            >
+              #{pr}
+            </a>
+          ))}
+          {hasDetail && !expanded ? <span className="ml-1.5 text-xs text-zinc-400">&hellip;</span> : null}
+        </span>
+      </button>
+      {hasDetail && expanded ? (
+        <p className="ml-[3.75rem] mr-2 mb-1.5 text-xs leading-relaxed text-zinc-500 dark:text-zinc-400">
+          <Runs runs={toRuns(p.rest)} />
+        </p>
+      ) : null}
+    </li>
+  );
 }
 
 export function ChangelogPage() {
@@ -11,25 +112,90 @@ export function ChangelogPage() {
     queryKey: ["changelog"],
     queryFn: () => api.get("/changelog"),
   });
+  // Same key + staleTime as the status bar, so this shares the cache.
+  const versionQ = useQuery<VersionResp>({
+    queryKey: ["version"],
+    queryFn: () => api.get<VersionResp>("/version"),
+    staleTime: 5 * 60_000,
+  });
+  const running = versionQ.data?.kbagent.version;
+
+  const [expandAll, setExpandAll] = useState(false);
+  // Per-note overrides on top of the global toggle; cleared when it flips.
+  const [overrides, setOverrides] = useState<Record<string, boolean>>({});
+  const isExpanded = (key: string) => overrides[key] ?? expandAll;
+  const toggleNote = (key: string) =>
+    setOverrides((o) => ({ ...o, [key]: !(o[key] ?? expandAll) }));
+  const toggleAll = () => {
+    setExpandAll((v) => !v);
+    setOverrides({});
+  };
+
+  const entries = q.data?.entries ?? [];
+
   return (
-    <div className="space-y-4">
-      <PageTitle title="Changelog" description="Release history of the kbagent kernel." />
+    <div>
+      <PageTitle
+        title="Changelog"
+        description="Release history of the kbagent kernel."
+        actions={
+          entries.length > 0 ? (
+            <button type="button" className="nerd-btn text-xs" onClick={toggleAll}>
+              {expandAll ? "collapse all" : "expand all"}
+            </button>
+          ) : undefined
+        }
+      />
       {q.isLoading ? <Loading /> : null}
       {q.error ? <ErrorBox message={(q.error as Error).message} /> : null}
-      <div className="space-y-3">
-        {(q.data?.entries ?? []).map((e) => (
-          <div key={e.version} className="nerd-card">
-            <h3 className="font-bold text-keboola">v{e.version}</h3>
-            <ul className="mt-2 text-sm space-y-1">
-              {e.highlights.map((h, i) => (
-                <li key={i} className="text-zinc-700 dark:text-zinc-300">
-                  • {h}
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))}
-      </div>
+
+      <ol className="relative ml-1.5 border-l border-zinc-200 dark:border-zinc-800">
+        {entries.map((e, idx) => {
+          const isRunning = e.version === running;
+          return (
+            <li key={e.version} className="relative pl-6 pb-8 last:pb-2">
+              {/* Rail node: filled + glowing for the running version. */}
+              <span
+                aria-hidden
+                className={`absolute -left-[5px] top-1.5 w-[9px] h-[9px] rounded-full border ${
+                  isRunning
+                    ? "bg-keboola border-keboola shadow-[0_0_6px_theme(colors.keboola.DEFAULT)]"
+                    : "bg-white border-zinc-300 dark:bg-zinc-900 dark:border-zinc-600"
+                }`}
+              />
+              <div className="flex items-baseline gap-2.5 flex-wrap">
+                <h3
+                  className={`font-bold text-base ${
+                    isRunning ? "text-keboola" : "text-zinc-900 dark:text-zinc-100"
+                  }`}
+                >
+                  v{e.version}
+                </h3>
+                {isRunning ? <span className="nerd-pill-green text-[10px]">running now</span> : null}
+                {idx === 0 && !isRunning ? (
+                  <span className="nerd-pill text-[10px]">latest</span>
+                ) : null}
+                <span className="text-xs text-zinc-400">
+                  {e.highlights.length} {e.highlights.length === 1 ? "change" : "changes"}
+                </span>
+              </div>
+              <ul className="mt-2 space-y-0.5">
+                {e.highlights.map((h, i) => {
+                  const key = `${e.version}:${i}`;
+                  return (
+                    <Note
+                      key={key}
+                      note={h}
+                      expanded={isExpanded(key)}
+                      onToggle={() => toggleNote(key)}
+                    />
+                  );
+                })}
+              </ul>
+            </li>
+          );
+        })}
+      </ol>
     </div>
   );
 }


### PR DESCRIPTION
## Why

The web UI's Changelog page dumped each version's raw bullet strings into a card — no structure, no colour, a wall of text (screenshot: before). The CLI renderer already exploits the changelog authoring contract from `commands/changelog.py` (typed `New:`/`Fix:`/`BREAKING:` prefixes, `(#PR)` decorations, inline backticks, headline-first summaries); the web page ignored all of it.

## What

- **Headline-first collapsing.** Each note collapses to its first sentence, expandable per note or via an *expand all* toggle — the web mirror of the CLI's default summary + `--full`. Sentence detection ports `headline()`'s rules (no break inside `0.57.0`, no break after `e.g.`).
- **Typed badges** in the CLI's own colour semantics (`_PREFIX_STYLES`): New green, Fix amber, Change blue, BREAKING/Security red, UX magenta, Note cyan, Internal/Tests/... dim.
- **PR links.** `(#658, #664)` prefix decorations become links to the GitHub PRs.
- **Inline code chips** for backtick spans, matching the inline-code treatment used elsewhere in the UI.
- **Release rail.** Versions sit on a vertical timeline; the running version (shared `["version"]` query cache — no extra request) gets a glowing node and a *running now* pill, the newest entry a *latest* pill.

Parsing lives in `web/frontend/src/changelogNotes.ts` with a vitest suite (11 tests); the prefix list and sentence rules are ports of `_PREFIX_RE` and `headline()` and carry a keep-in-sync note. No Python surface touched; `GET /changelog` payload unchanged.

## Testing

- `npm test` — 64 passed (4 files), including the new `changelogNotes.test.ts`
- `npm run build` — tsc + vite clean
- Verified live via `kbagent serve --ui --ui-dist web/frontend/dist`: light + dark mode, per-note expand, expand-all, PR link hrefs, running-version highlight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->