### PR TITLE
chore(ci): bump artifact + release actions off the Node 20 runtime

### DIFF
--- a/.github/workflows/release-kbagent.yml
+++ b/.github/workflows/release-kbagent.yml
@@ -151,7 +151,10 @@ jobs:
           done
           if [ "$IS_PRERELEASE" = "true" ]; then args+=(--allow-missing); fi
           uv run python scripts/gen_release_notes.py "${args[@]}"
-      - uses: actions/upload-artifact@v4
+      # v6 is the first upload-artifact major whose runtime is Node 24 (v5 only
+      # carried "preliminary" Node 24 support and still declared `using: node20`),
+      # so a v4 -> v5 bump would keep emitting the Node 20 deprecation annotation.
+      - uses: actions/upload-artifact@v7
         with:
           name: release-notes
           path: release-notes.md
@@ -257,7 +260,7 @@ jobs:
         shell: bash
         run: bash build/package/zip_binary.sh "$PKG_NAME" "$VERSION" "${{ matrix.platform }}" "${{ matrix.arch }}" "$BIN_NAME"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: bin-${{ matrix.platform }}-${{ matrix.arch }}
           path: |
@@ -279,7 +282,11 @@ jobs:
           curl -fsSL "https://github.com/goreleaser/nfpm/releases/download/v2.41.1/nfpm_2.41.1_amd64.deb" -o /tmp/nfpm.deb
           echo "0a188f8bcf4ba4ba6414a514bc1f1d59f5cc92ba86160462d7aa7dab5930d327  /tmp/nfpm.deb" | sha256sum -c -
           sudo dpkg -i /tmp/nfpm.deb
-      - uses: actions/download-artifact@v4
+      # v7 is the first download-artifact major whose runtime is Node 24 (both v5
+      # and v6 still declare `using: node20`). v8 additionally turns a download
+      # digest mismatch into a hard failure instead of a warning — the right
+      # default for a release pipeline that signs and ships these bytes.
+      - uses: actions/download-artifact@v8
         with: { pattern: bin-linux-*, path: artifacts }
       - name: Write package signing keys
         env:
@@ -295,7 +302,7 @@ jobs:
           printf '%s' "$RPM_KEY_PRIVATE" > /tmp/keys/rpm.key && chmod 600 /tmp/keys/rpm.key
       - name: Build deb/rpm for each arch
         run: bash build/package/linux/build_packages.sh "$VERSION" artifacts
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with: { name: linux-packages, path: dist/* }
 
   # ── Create the GitHub Release with every binary + package attached (directly
@@ -312,14 +319,14 @@ jobs:
     env:
       VERSION: ${{ needs.version.outputs.VERSION }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with: { path: artifacts }
       - name: Collect release assets
         run: |
           mkdir -p release
           find artifacts -type f \( -name '*.zip' -o -name '*.sha256' -o -name '*.deb' -o -name '*.rpm' \) -exec cp {} release/ \;
           ls -al release/
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ env.VERSION }}
           files: release/*
@@ -404,7 +411,7 @@ jobs:
       PUBLISH_PREFIX: ${{ needs.version.outputs.PUBLISH_PREFIX }}
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with: { path: artifacts }
       - uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -441,7 +448,7 @@ jobs:
       VERSION: ${{ needs.version.outputs.VERSION }}
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with: { path: artifacts }
       - name: Render formula
         run: |


### PR DESCRIPTION
## Why

The v0.90.0 `release-kbagent.yml` run annotated the `gate`, `package-linux` and `homebrew` jobs with:

> Node.js 20 is deprecated... the following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/upload-artifact@v4`, `actions/download-artifact@v4`

Rather than fix only the two actions GitHub named, every `uses:` in `.github/` was audited by resolving `runs.using` from each pinned tag's own `action.yml` (release notes are less reliable than the field the runner actually reads).

## What changed

Only `release-kbagent.yml` contained node20 actions:

| action | before | after | why this major |
|---|---|---|---|
| `actions/upload-artifact` | v4 | **v7** | v5 still declares `using: node20` (its Node 24 support was "preliminary"); **v6** was the real switch. v7 is current. |
| `actions/download-artifact` | v4 | **v8** | v5 **and** v6 still declare `using: node20`; **v7** was the switch. v8 is current. |
| `softprops/action-gh-release` | v2 | **v3** | v2.x is node20; v3.0.0 moved the runtime to Node 24. |

A naive v4 → v5 bump on either artifact action would have kept emitting the same deprecation annotation — that non-obvious fact is now recorded as a comment at the first use of each.

## Breaking changes, checked against actual usage

- **`download-artifact` v5** changed the output path for *single-artifact-by-ID* downloads. Not applicable: this repo downloads by `pattern:` or whole-run, never with `artifact-ids:`.
- **`download-artifact` v8** turns a download digest mismatch into a hard error instead of a warning. Kept as-is — the correct default for a pipeline that GPG-signs and ships these exact bytes.
- **`download-artifact` v8** skips decompression for non-zipped downloads. Not applicable: artifacts here are always service-zipped (the inner `dist/*.zip` files are just members of that archive).
- **`upload-artifact` v7** direct/unzipped uploads only engage with `archive: false`, which is not used.
- **`action-gh-release` v3** keeps `tag_name` / `files` / `prerelease` — verified against v3's `action.yml` inputs.

## Already clean (no change needed)

`actions/checkout@v5`, `actions/setup-node@v6`, `actions/setup-python@v6`, `astral-sh/setup-uv@v7`, `aws-actions/configure-aws-credentials@v6` all already run on node24. `cpina/github-action-push-to-another-repository` is a `docker` action (stays SHA-pinned — it receives the tap PAT). `pypa/gh-action-pypi-publish@release/v1` is composite over node24 steps.

Note: the `node-version: "20"` in `.github/actions/setup-build` is the **Node used to build the React SPA**, not an action runtime — untouched here, since bumping the build toolchain is a separate decision.

## Verification

- Every workflow + the composite action parses under `yaml.safe_load`.
- Post-change sweep over all `uses:` in `.github/` resolves to `node24` / `docker` / `composite` — no `node20` remains.
- All jobs run on GitHub-hosted runners, so the node24 minimum runner version (2.327.1) is satisfied; there is no self-hosted fleet to update first.

Per repo rules: no version bump, no `changelog.py` entry (CI-only change).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->