### PR TITLE
fix(ci): stop the live vNEXT gate turning main and every PR red

### DIFF
--- a/tests/test_check_version_gates.py
+++ b/tests/test_check_version_gates.py
@@ -145,17 +145,44 @@ class TestVnextResidue:
 
 
 class TestLiveRepositoryVnext:
-    def test_no_unresolved_placeholder_survives_a_release(self) -> None:
-        """``main`` carries a released version, so every placeholder must be rewritten.
+    """The live tree is scanned -- but a placeholder found in it is NOT a failure.
 
-        This is the check that used to be a hand-run grep the release
-        checklist admitted could never come back empty.
+    Between releases ``main`` legitimately carries `(since vNEXT)` markers. The
+    #648 process has every feature PR write the placeholder and ONLY the release
+    PR rewrite them; CLAUDE.md states it outright ("Writing `vNEXT` in a feature
+    PR is correct and stays green"), and TestReleaseModeSelection below spells
+    out why arming outside a release PR "would demand a contributor delete a
+    placeholder the process requires them to write".
+
+    An unconditional "the live tree has no placeholders" assertion contradicts
+    exactly that. It is green only in the window right after a release, and goes
+    red for main AND for every open PR the moment the first feature PR of the
+    next cycle lands. That is not hypothetical: it was added in #670 days after
+    0.90.0 shipped -- tree empty, so it passed -- and detonated on #675, taking
+    main and every in-flight PR with it.
+
+    The release-time requirement is real, but deciding whether the gate arms
+    needs the BASE branch's version, which a unit test cannot see. That check
+    already exists where it can: the "Unresolved vNEXT placeholder check" step
+    in .github/workflows/ci.yml passes `--release-if-newer-than`, and
+    `make vnext-check` is its local twin. What is left for a test is that the
+    live scan actually WORKS -- which is what the two below assert.
+    """
+
+    def test_live_scan_reports_well_formed_gates(self) -> None:
+        """Whatever the tree currently carries, every hit must be real.
+
+        This is the half that has a stable answer: the globs resolve, the files
+        are readable, and each reported gate points at a line that genuinely
+        contains the placeholder. A hit count of zero is just as valid as ten --
+        it depends on where in the release cycle the tree happens to be.
         """
-        found = residue(check_version_gates.resolve_paths())
-        assert found == [], (
-            "unresolved vNEXT gate(s) shipped -- an agent cannot satisfy them: "
-            f"{[(gate.path, gate.line) for gate in found[:3]]}"
-        )
+        for gate in residue(check_version_gates.resolve_paths()):
+            lines = Path(gate.path).read_text(errors="replace").splitlines()
+            assert 1 <= gate.line <= len(lines), f"{gate.path}:{gate.line} is out of range"
+            assert check_version_gates.VNEXT_TOKEN in lines[gate.line - 1], (
+                f"{gate.path}:{gate.line} was reported but does not carry the placeholder"
+            )
 
     def test_prose_mentions_are_still_present_and_ignored(self) -> None:
         """Guards the guard: a rule that matched nothing would pass vacuously."""

--- a/tests/test_check_version_gates.py
+++ b/tests/test_check_version_gates.py
@@ -178,7 +178,15 @@ class TestLiveRepositoryVnext:
         it depends on where in the release cycle the tree happens to be.
         """
         for gate in residue(check_version_gates.resolve_paths()):
-            lines = Path(gate.path).read_text(errors="replace").splitlines()
+            # `gate.path` is REPO-ROOT-RELATIVE (find_vnext_residue stores
+            # `path.relative_to(REPO_ROOT)`), so it must be re-anchored rather
+            # than resolved against the cwd -- otherwise this only works when
+            # pytest happens to be invoked from the repo root. Its one fallback
+            # branch stores an absolute path instead; `REPO_ROOT / <absolute>`
+            # yields that path unchanged, so both cases are covered.
+            lines = (
+                (check_version_gates.REPO_ROOT / gate.path).read_text(errors="replace").splitlines()
+            )
             assert 1 <= gate.line <= len(lines), f"{gate.path}:{gate.line} is out of range"
             assert check_version_gates.VNEXT_TOKEN in lines[gate.line - 1], (
                 f"{gate.path}:{gate.line} was reported but does not carry the placeholder"


### PR DESCRIPTION
## Symptom

`main` is red, and so is every open PR (a PR run tests the merge commit):

```
FAILED tests/test_check_version_gates.py::TestLiveRepositoryVnext::test_no_unresolved_placeholder_survives_a_release
AssertionError: unresolved vNEXT gate(s) shipped -- an agent cannot satisfy them:
  [('plugins/kbagent/skills/kbagent/references/gotchas.md', 4438)]
```

Verified directly against `origin/main`:

```
unresolved vNEXT placeholders on origin/main: 1
   plugins/kbagent/skills/kbagent/references/gotchas.md:4438
   ## Multi-project `job list` now merges chronologically, not grouped by project (since vNEXT)
```

## Why it fires

The test asserts the live tree carries no `(since vNEXT)` placeholder. That is the opposite of the documented process.

Since #648, a feature PR that documents version-gated behaviour writes the literal `vNEXT` placeholder, and only the release PR rewrites it. CLAUDE.md states it outright:

> `make version-gate-check` ignores the placeholder … **Writing `vNEXT` in a feature PR is correct and stays green** — the placeholder only becomes fatal in a version-raising PR.

And `TestReleaseModeSelection`, added by the very same PR as this assertion, spells out the reasoning:

> arming there would demand a contributor delete a placeholder the process requires them to write

So `main` legitimately carries placeholders for most of a release cycle. The assertion was a time bomb: #670 landed a few days after 0.90.0 had rewritten every placeholder, so it passed on an empty tree. #675 added the first placeholder of the next cycle and detonated it.

The CI **step** is correctly gated — it passes `--release-if-newer-than "$base"` and arms only on a version-raising PR. Only the pytest mirror is ungated, because a unit test cannot see the base branch's version.

## The change

Drop the false invariant; keep the enforcement where it can actually see the base version (the ci.yml step and `make vnext-check`).

Replaced with the half that *does* have a stable answer: every gate the live scanner reports must point at a real line that really contains the placeholder. Zero hits and ten hits are both valid depending on where in the release cycle the tree sits. The neighbouring `test_prose_mentions_are_still_present_and_ignored` already guards against the globs silently matching nothing.

## Verification

- `make check` green on this branch — `6077 passed, 12 skipped`
- The replacement test exercises a non-empty result today (main carries one placeholder), so it is not passing vacuously

## Scope

Found while working on #676 (CI cost). Split out deliberately: this is unrelated to that change, blocks every open PR, and should merge on its own.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->