### PR TITLE
docs: move (since vNEXT) tags out of markdown headings

### DIFF
--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -1337,7 +1337,9 @@ events and emits a final `done` SSE frame mirroring the same record.
   components sharing a config ID, a deleted parent config, or a failed lookup
   all yield `""` rather than a guess. A blank name never means the
   subscription is inactive.
-## Notification subscriptions can now be written, and the write path has sharp edges (since vNEXT)
+## Notification subscriptions can now be written, and the write path has sharp edges
+
+*(since vNEXT)*
 
 - **`notification replace-recipient` always mints a NEW `subscription_id`.**
   The Notification Service has **no update primitive** -- there is no PATCH or
@@ -4558,9 +4560,9 @@ shapes.
   today a deny policy gates only `/auth/*`, not the ~30 other routers a
   session token can otherwise reach.
 
-## `serve` honors the root-level `--config-dir` (since vNEXT)
+## `serve` honors the root-level `--config-dir`
 
-`serve` is the only subcommand carrying a `--config-dir` of its own, so the
+*(since vNEXT)* `serve` is the only subcommand carrying a `--config-dir` of its own, so the
 flag has two possible positions. The precedence is **most specific wins**,
 matching what `kbagent repl` does with the root flags:
 
@@ -4583,9 +4585,9 @@ resolution is left to the server, which lands on the same directory anyway.
   -- if the aliases are not the ones in the directory you named, the flag was
   in the position your version ignores.
 
-## `workspace load` now auto-CLONEs eligible tables instead of always COPYing (since vNEXT, closes #687)
+## `workspace load` now auto-CLONEs eligible tables instead of always COPYing
 
-Before this, `workspace load` always sent a plain `copy` (the API's own
+*(since vNEXT, closes #687)* Before this, `workspace load` always sent a plain `copy` (the API's own
 default when `loadType` is omitted) -- a 282 GB table load burned warehouse
 credits for hours where `clone` is metadata-only and finishes in seconds.
 kbagent now mirrors the server's `LoadTypeDecider` per table.

--- a/plugins/kbagent/skills/kbagent/references/workspace-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/workspace-workflow.md
@@ -91,9 +91,9 @@ kbagent --json workspace query \
   --sql "SELECT * FROM \"table1\" LIMIT 10"
 ```
 
-## Load types: clone / copy / view (since vNEXT, #687)
+## Load types: clone / copy / view
 
-`workspace load` supports three load types. **Default (no `--load-type`)**:
+*(since vNEXT, #687)* `workspace load` supports three load types. **Default (no `--load-type`)**:
 kbagent decides per table, mirroring the server's own eligibility rules --
 zero-copy `clone` when the table is on the same backend as the workspace
 with a full (unfiltered) load and no external-schema/Analytics-Hub source


### PR DESCRIPTION
## Why

CONTRIBUTING.md forbids version tags in markdown headings: the anchor slug is derived from the full heading text, so when the release PR resolves `vNEXT` to the real version, the slug changes and every inbound link to that section silently breaks (this bit 0.90.0).

## What

Moves the `(since vNEXT, ...)` tag from four headings onto each section's first body line as `*(since vNEXT, ...)*`, matching the pattern PR #691 applied to gotchas.md:

- `plugins/kbagent/skills/kbagent/references/workspace-workflow.md` -- "Load types: clone / copy / view" (#687)
- `plugins/kbagent/skills/kbagent/references/gotchas.md` -- three headings introduced by #695, #692 and #681 (found via `grep -rn '^##.*vNEXT' plugins/`)

The `serve --config-dir` heading fix is byte-identical to the one on the open PR #691 branch, so the two merge cleanly in either order.

Verified: no `^##.*vNEXT` headings remain anywhere under `plugins/`, and no inbound links reference the changed anchor slugs.

Docs-only: no version bump, no changelog entry (per the release process -- feature/docs PRs never bump).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/cli/pull/697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->