### PR TITLE
chore(release): pre-tag fixes for 0.91.0 — cover #625, move version tags out of headings

### DIFF
--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -458,7 +458,9 @@ Versioning convention:
   `--allow-plaintext-on-encrypt-failure`, which would write the PAT in
   plaintext into Storage.
 
-## `sync push` no longer leaves phantom `REMOTE MODIFIED` drift; `transform.sql` carries statement boundaries (since 0.91.0, #686)
+## `sync push` no longer leaves phantom `REMOTE MODIFIED` drift; `transform.sql` carries statement boundaries
+
+*(since 0.91.0, #686)*
 
 `pull_config_hash` in `.keboola/manifest.json` is the 3-way diff's base, and it
 means "the hash of this config **as the API returns it**". `sync pull` and the
@@ -527,7 +529,9 @@ it, and the next deploy re-created it (field report: 18 phantom configs hiding
   statements into one. Run `sync pull` for that project, then push again.
   Genuine SQL edits are never blocked by this guard.
 
-## `sync push` runs the same script-shape guard as `config update` (since 0.91.0)
+## `sync push` runs the same script-shape guard as `config update`
+
+*(since 0.91.0)*
 
 `sync push` now runs `normalize_blocks_codes_script` -- the runtime-safety guard
 `config update` and `transformation edit/create` have always run -- on every

--- a/plugins/kbagent/skills/kbagent/references/sync-workflow.md
+++ b/plugins/kbagent/skills/kbagent/references/sync-workflow.md
@@ -489,7 +489,9 @@ the 3-way diff state per config (and per row):
 > stops you loudly instead of losing work. To intentionally drop a local edit,
 > delete the file (or the config directory) and pull.
 
-## Migrating a tree pulled before 0.91.0 (#686)
+## Migrating a legacy sync tree (#686)
+
+*Applies to any tree last pulled before 0.91.0.*
 
 `sync push` used to stamp the manifest baseline from the files on disk while
 `sync pull` / `sync diff` computed it from the API. Any config the two

--- a/src/keboola_agent_cli/changelog.py
+++ b/src/keboola_agent_cli/changelog.py
@@ -89,6 +89,15 @@ CHANGELOG: dict[str, list[str]] = {
         "which beats `KBAGENT_CONFIG_DIR` / the `.kbagent` walk-up / global. Only an "
         "explicit root flag propagates; an env-var or walk-up resolution is left to the "
         "server, which reaches the identical directory on its own.",
+        "New (#625): the plugin gained `/kbagent:setup`, one command that runs first-time "
+        "setup end to end. The documented flow is now `/plugin marketplace add keboola/ai-kit` "
+        "then `/plugin install kbagent@keboola-claude-kit` then `/kbagent:setup`, replacing "
+        "five manual steps spread across a browser, a terminal and Claude Code. It installs "
+        "the CLI when missing (respecting a standalone `install_channel` rather than layering "
+        "a second kbagent over it), connects a project, and verifies with `kbagent doctor`. "
+        "Every step is conditional on a check, so it is idempotent and safe to re-run on a "
+        "half-finished setup, and it never overwrites an existing project or alias. No new "
+        "CLI surface -- it orchestrates existing verbs.",
         "Change (#627): the kbagent Claude Code plugin is now published through the "
         "`keboola-claude-kit` marketplace in `keboola/ai-kit`. Keboola had two competing "
         "marketplaces and no way for a user to tell which was real; this leaves one. Install "


### PR DESCRIPTION
Two pre-tag corrections to the v0.91.0 release (#699 is already merged; **v0.91.0 is not yet tagged**, so both land before the release goes out).

## 1. #625 was outside the changelog but inside the tag

#625 (`/kbagent:setup`) merged to `main` at 14:27 — after the release PR #699 branched off `b5d4be39`, before #699 itself merged at 14:36. The 0.91.0 entry was authored against the earlier scope, so it does not mention #625, and #625 is not trivial: a new plugin slash command, a rewritten onboarding flow in `README.md` / `docs/TUTORIAL.md` / `CLAUDE.md`, plus `install.sh` and `context.py`.

Tagging at `1e584ac0` as-is would have shipped that work with no release note. Adds one `New (#625):` bullet next to `Change (#627):` (both cover plugin distribution and onboarding). Headline 98 chars, cap is 160.

`make changelog-check` cannot see this class of miss: it proves each *released version* has an entry, never that the entry covers every commit under the tag.

## 2. Three resolved version tags left in markdown headings

Found by Devin Review on #699 ([1](https://github.com/keboola/cli/pull/699#discussion_r3854032693), [2](https://github.com/keboola/cli/pull/699#discussion_r3854032887), [3](https://github.com/keboola/cli/pull/699#discussion_r3854033125)) — all three confirmed and fixed here:

| File | Before | After |
|---|---|---|
| `gotchas.md:461` | `## … statement boundaries (since 0.91.0, #686)` | tag on first body line |
| `gotchas.md:530` | `## … guard as \`config update\` (since 0.91.0)` | tag on first body line |
| `sync-workflow.md:492` | `## Migrating a tree pulled before 0.91.0 (#686)` | `## Migrating a legacy sync tree (#686)` + version on a body line |

CONTRIBUTING.md step 4 forbids version tags in headings because resolving the placeholder changes the anchor slug. Verified by grep that **no inbound link references the affected anchors**, so nothing is broken today — but the slugs are now stable.

### Why #697 missed them

#697 did exactly this pass, via `grep -rn '^##.*vNEXT' plugins/`. It merged at 13:20; #694 introduced `gotchas.md:461` at 13:18 and #696 introduced `gotchas.md:530` at 13:21. Its grep ran against a tree that did not contain them yet — the same merge-train race as item 1.

## Follow-up worth filing (not in this PR)

**The "no version tags in headings" rule is entirely unenforced.** `scripts/check_version_gates.py` has no heading check; the `### What's-new popup *(since vNEXT)*` string in `tests/test_check_version_gates.py:146` is test data for path/line reporting, not heading detection. The rule currently depends on one contributor remembering to run a grep, which is how it lost this race. A cheap check — flag any `^#{1,6}.*(since v?X.Y.Z)` in the scanned globs — would close it.

## Checks

`make check`: **6317 passed, 12 skipped**; lint, format, typecheck, skill, version, version-gates, command-sync, endpoints, changelog, error-codes, sentinel-guards, loc all green. `make vnext-check`: all 557 gates across 77 versions resolve to a release.

No version change — `pyproject.toml` stays at 0.91.0.
