### PR TITLE
feat(cli): add --conversation-id global flag (#716)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,13 +348,15 @@ plugins/kbagent/
 
 ```
 # Global options: --json, --verbose, --no-color, --config-dir, --conversation-id, --deny-writes, --deny-destructive, --allow-env-manage-token
-# --conversation-id ID (since vNEXT, #716): sets the X-Conversation-ID observability header for the
+# --conversation-id ID (#716): sets the X-Conversation-ID observability header for the
 #   invocation; equivalent to KBAGENT_CONVERSATION_ID and takes precedence over it. Exists because an
 #   agent harness does not persist shell state between tool calls, so the documented one-time `export`
 #   was unsatisfiable -- and re-prepending `export ...` to every command stops it matching a
 #   `Bash(kbagent ...)` permission allow-rule, so every call fell through to the safety classifier.
 #   For a whole session, set the env var in the harness's own env block instead (Claude Code:
-#   settings.json -> env). Neither set = header omitted, as before.
+#   settings.json -> env). Neither set = header omitted, as before. Version gate for this entry
+#   lives in gotchas.md -- a `(since vNEXT)` tag cannot be written on these `# ` comment lines,
+#   because check_version_gates.py parses them as ATX markdown headings (where a `vNEXT` is fatal).
 # Headless / token-only (0.50.0+): export KBAGENT_PROJECT_FROM_ENV=1 + KBC_TOKEN + KBC_STORAGE_API_URL to synthesize an in-memory `__env__` project (no `project add`, no config.json on disk; token never persisted). Use `--project __env__`. Same env setup also powers `kbagent serve`.
 
 kbagent auth login [--stack URL|alias] [--device-code] [--register-projects]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,7 +347,14 @@ plugins/kbagent/
 > "Plugin synchronization map" for the full list.
 
 ```
-# Global options: --json, --verbose, --no-color, --config-dir, --deny-writes, --deny-destructive, --allow-env-manage-token
+# Global options: --json, --verbose, --no-color, --config-dir, --conversation-id, --deny-writes, --deny-destructive, --allow-env-manage-token
+# --conversation-id ID (since vNEXT, #716): sets the X-Conversation-ID observability header for the
+#   invocation; equivalent to KBAGENT_CONVERSATION_ID and takes precedence over it. Exists because an
+#   agent harness does not persist shell state between tool calls, so the documented one-time `export`
+#   was unsatisfiable -- and re-prepending `export ...` to every command stops it matching a
+#   `Bash(kbagent ...)` permission allow-rule, so every call fell through to the safety classifier.
+#   For a whole session, set the env var in the harness's own env block instead (Claude Code:
+#   settings.json -> env). Neither set = header omitted, as before.
 # Headless / token-only (0.50.0+): export KBAGENT_PROJECT_FROM_ENV=1 + KBC_TOKEN + KBC_STORAGE_API_URL to synthesize an in-memory `__env__` project (no `project add`, no config.json on disk; token never persisted). Use `--project __env__`. Same env setup also powers `kbagent serve`.
 
 kbagent auth login [--stack URL|alias] [--device-code] [--register-projects]

--- a/plugins/kbagent/skills/kbagent/SKILL.md
+++ b/plugins/kbagent/skills/kbagent/SKILL.md
@@ -33,7 +33,7 @@ If kbagent is not installed or you need the full standalone reference, run `kbag
 ## Rules
 
 1. **Always use `--json`**: `kbagent --json <command>` for parseable output
-2. **Set conversation ID**: before first kbagent call, run `export KBAGENT_CONVERSATION_ID="<unique-id>"` (e.g. session UUID). All API requests include this as `X-Conversation-ID` header for platform observability.
+2. **Set conversation ID**: pass `--conversation-id "<unique-id>"` (e.g. session UUID) on every kbagent call -- `kbagent --json --conversation-id <id> <command>`. All API requests include it as the `X-Conversation-ID` header for platform observability. **Do not use a standalone `export`**: agent harnesses (Claude Code included) do not persist shell state between tool calls, so the variable is gone by the next command -- and prefixing each command with `export ...` stops it matching a `Bash(kbagent ...)` permission allow-rule. For a whole session, set `KBAGENT_CONVERSATION_ID` in the harness's own env block (Claude Code: `settings.json` -> `env`) instead.
 3. **Multi-project by default**: read commands query ALL connected projects in parallel -- no need to loop
 4. **Write commands need `--project`**: specify the target project alias
 5. **Tokens are always masked** in output -- this is expected, not an error

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -2402,9 +2402,27 @@ type inventory and examples.
 
 ## Conversation ID
 
-Set `KBAGENT_CONVERSATION_ID` env var before running kbagent commands. All API
-requests include it as `X-Conversation-ID` header for platform observability.
-If unset, the header is omitted.
+Two channels, in precedence order:
+
+1. **`--conversation-id <id>` global flag** *(since vNEXT, #716)* -- the one to
+   use from an agent. `kbagent --json --conversation-id <id> <command>`.
+2. **`KBAGENT_CONVERSATION_ID` env var** -- for a persistent shell, or a
+   harness that can set env for the whole session.
+
+All API requests include the value as the `X-Conversation-ID` header for
+platform observability. If neither is given, the header is omitted.
+
+**A standalone `export` does not work in an agent harness.** Claude Code's
+Bash tool persists the working directory but *not* environment variables or
+shell functions, so an `export` in one tool call is gone by the next. Before
+the flag existed, the only way to comply was to re-prepend
+`export KBAGENT_CONVERSATION_ID=...` to every single command -- and because
+Claude Code permission allow-rules are prefix matches on the command string, a
+command starting with `export ...` can never match
+`Bash(kbagent --json workspace query:*)`. Every invocation then fell through to
+the safety classifier and prompted. Use the flag, so the command still begins
+with `kbagent`; or set the variable in the harness's own env block (Claude
+Code: `settings.json` -> `env`), which survives across tool calls.
 
 ## Config resolution order
 

--- a/src/keboola_agent_cli/cli.py
+++ b/src/keboola_agent_cli/cli.py
@@ -215,6 +215,17 @@ def main(
         "branch delete, etc.). Admin ops like 'project remove' and 'org setup' "
         "are NOT blocked -- use --deny-writes for the wide net.",
     ),
+    conversation_id: str | None = typer.Option(
+        None,
+        "--conversation-id",
+        help="Conversation/session ID sent as the X-Conversation-ID header on "
+        "every API request (platform observability). Equivalent to setting "
+        "KBAGENT_CONVERSATION_ID, and takes precedence over it. Exists because "
+        "agent harnesses do not persist shell state between tool calls, so a "
+        "standalone `export` cannot set it -- and prefixing every command with "
+        "`export ...` stops the command matching a `Bash(kbagent ...)` "
+        "permission allow-rule.",
+    ),
     allow_env_manage_token: bool = typer.Option(
         False,
         "--allow-env-manage-token",
@@ -225,7 +236,19 @@ def main(
     ),
 ) -> None:
     """Global options applied to all commands."""
+    import os
+
     from .auto_update import maybe_auto_update, show_post_update_changelog
+    from .constants import ENV_CONVERSATION_ID
+
+    # Published into the environment rather than threaded through the Typer
+    # context because that is where every consumer already reads it:
+    # `BaseHttpClient.__init__` stamps the header from os.environ for all
+    # seven clients, `doctor` reports on it, and scheduled-agent subprocesses
+    # inherit it for free. `serve` sets it the same way. The flag wins over an
+    # inherited env var -- it is the more specific instruction (issue #716).
+    if conversation_id is not None:
+        os.environ[ENV_CONVERSATION_ID] = conversation_id
 
     maybe_auto_update()
 

--- a/src/keboola_agent_cli/commands/context.py
+++ b/src/keboola_agent_cli/commands/context.py
@@ -23,11 +23,20 @@ structured JSON output for programmatic consumption.
 
 ## IMPORTANT: Set Conversation ID
 
-Before running any kbagent commands, set KBAGENT_CONVERSATION_ID to a unique
-identifier for the current conversation/session. This is REQUIRED for platform
-observability -- all API requests will include the X-Conversation-ID header.
+Identify the current conversation/session with a unique id. This is REQUIRED
+for platform observability -- all API requests will include the
+X-Conversation-ID header.
 
-  export KBAGENT_CONVERSATION_ID="<unique-conversation-id>"
+Pass it as a global flag on every call:
+
+  kbagent --json --conversation-id "<unique-conversation-id>" <command>
+
+Do NOT rely on a standalone `export`. Agent harnesses do not persist shell
+state between tool calls, so the variable is gone by the next command -- and a
+command starting with `export ...` no longer matches a `Bash(kbagent ...)`
+permission allow-rule. To set it once for a whole session, put
+KBAGENT_CONVERSATION_ID in the harness's own env block (Claude Code:
+settings.json -> env). The flag takes precedence over the env var.
 
 ## Quick Start
 
@@ -2024,7 +2033,9 @@ with `metastore.`. Auth: same `X-StorageApi-Token` as Storage. Alias:
      kbagent --json project status   # test all connections
 
 7. Environment variables:
-     KBAGENT_CONVERSATION_ID  Conversation/session ID (REQUIRED -- sent as X-Conversation-ID header)
+     KBAGENT_CONVERSATION_ID  Conversation/session ID (REQUIRED -- sent as X-Conversation-ID header).
+                              Prefer the --conversation-id global flag from an agent harness:
+                              a standalone `export` does not survive between tool calls.
      KBC_TOKEN                Storage API token (fallback for --token)
      KBC_STORAGE_API_URL      Default stack URL (fallback for --url)
      KBC_MANAGE_API_TOKEN     Manage API token (org setup, project refresh, data-app password).

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,9 @@ from helpers import make_mock_client
 from keboola_agent_cli.auth.sentinel import make_session_token
 from keboola_agent_cli.cli import app
 from keboola_agent_cli.config_store import ConfigStore
+from keboola_agent_cli.constants import ENV_CONVERSATION_ID
 from keboola_agent_cli.errors import ConfigError, KeboolaApiError
+from keboola_agent_cli.http_base import BaseHttpClient
 from keboola_agent_cli.models import AppConfig, ProjectConfig
 from keboola_agent_cli.services.config_service import ConfigService
 from keboola_agent_cli.services.job_service import JobService
@@ -8453,3 +8455,75 @@ class TestProjectRefresh:
         # The final result should contain projects_refreshed from the refresh call
         assert len(output["data"]["projects_refreshed"]) == 1
         assert output["data"]["projects_refreshed"][0]["alias"] == "existing-project"
+
+
+class TestConversationIdFlag:
+    """Tests for the top-level --conversation-id session flag (issue #716)."""
+
+    def _run(self, argv: list[str], env: dict[str, str], tmp_path: Path):
+        config_dir = tmp_path / "config"
+        config_dir.mkdir(exist_ok=True)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch.dict(os.environ, env, clear=False),
+        ):
+            os.environ.pop(ENV_CONVERSATION_ID, None)
+            os.environ.update(env)
+            MockStore.return_value = ConfigStore(config_dir=config_dir)
+            result = runner.invoke(app, argv)
+            observed = os.environ.get(ENV_CONVERSATION_ID)
+        return result, observed
+
+    def test_flag_sets_the_conversation_id(self, tmp_path: Path) -> None:
+        """The flag is the whole point: no `export` needed, so the command
+        still begins with `kbagent` and can match a permission allow-rule."""
+        _, observed = self._run(
+            ["--conversation-id", "kbagent-session-4242", "--json", "project", "list"],
+            {},
+            tmp_path,
+        )
+        assert observed == "kbagent-session-4242"
+
+    def test_flag_wins_over_the_env_var(self, tmp_path: Path) -> None:
+        """An explicit flag is the more specific instruction."""
+        _, observed = self._run(
+            ["--conversation-id", "from-flag", "--json", "project", "list"],
+            {ENV_CONVERSATION_ID: "from-env"},
+            tmp_path,
+        )
+        assert observed == "from-flag"
+
+    def test_env_var_still_honoured_without_the_flag(self, tmp_path: Path) -> None:
+        """The pre-existing channel is unchanged -- this is purely additive."""
+        _, observed = self._run(
+            ["--json", "project", "list"],
+            {ENV_CONVERSATION_ID: "from-env"},
+            tmp_path,
+        )
+        assert observed == "from-env"
+
+    def test_absent_flag_and_env_leaves_it_unset(self, tmp_path: Path) -> None:
+        """No flag, no env var -- the header stays omitted as before."""
+        _, observed = self._run(["--json", "project", "list"], {}, tmp_path)
+        assert observed is None
+
+    def test_flag_reaches_the_outgoing_header(self, tmp_path: Path) -> None:
+        """The flag is worthless unless it actually reaches the wire."""
+        config_dir = tmp_path / "config"
+        config_dir.mkdir(exist_ok=True)
+        with (
+            patch("keboola_agent_cli.cli.ConfigStore") as MockStore,
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            os.environ.pop(ENV_CONVERSATION_ID, None)
+            MockStore.return_value = ConfigStore(config_dir=config_dir)
+            runner.invoke(app, ["--conversation-id", "on-the-wire", "--json", "project", "list"])
+            client = BaseHttpClient(
+                base_url="https://connection.keboola.com",
+                token=TEST_TOKEN,
+                headers={},
+            )
+            try:
+                assert client._client.headers.get("X-Conversation-ID") == "on-the-wire"
+            finally:
+                client.close()


### PR DESCRIPTION
## What

`skills/kbagent/SKILL.md` rule 2 instructs the agent to set the observability conversation ID with a
one-time `export KBAGENT_CONVERSATION_ID="<unique-id>"`. **That instruction cannot be satisfied in an
agent harness.** Claude Code's Bash tool persists the working directory but not environment
variables, so the export is gone by the next tool call, and there was no flag alternative
(`kbagent --help | grep -c conversation` → 0).

The only way to comply was therefore to re-prepend the export to every command. Because Claude Code
permission allow-rules are prefix matches on the command string, a command starting with
`export ...` can never match `Bash(kbagent --json workspace query:*)` — so kbagent became impossible
to allowlist, every invocation fell through to the safety classifier, and a rule intended to
*improve* observability degraded the agent experience instead.

This PR implements option 1 from the issue (the flag) and option 2 (the doc correction).

## How

A `--conversation-id` global option on the Typer callback, published into the environment rather
than threaded through the Typer context — that is where every consumer already reads it:

- `BaseHttpClient.__init__` stamps `X-Conversation-ID` from `os.environ` for all seven HTTP clients;
- `doctor`'s `conversation_id` check reports on it;
- scheduled-agent / `cli_command` subprocesses inherit it for free;
- `serve` already sets it exactly this way (`commands/serve.py:271`).

Precedence: an explicit flag beats an inherited `KBAGENT_CONVERSATION_ID` (it is the more specific
instruction). With neither set, the header stays omitted, exactly as before — this is purely
additive.

## Not done here

Options 3 and 4 from the issue are product decisions rather than bug fixes, so they are deliberately
left out:

- **Auto-generating an ID when unset** changes what the platform's observability data looks like
  (every unset invocation would mint a fresh unique ID), which is a call for whoever consumes that
  telemetry.
- **Shipping recommended allow-rules with the plugin** is a plugin-config decision about which verbs
  are safe to pre-approve on someone else's machine.

## How it was tested

New `TestConversationIdFlag` in `tests/test_cli.py` (5 cases): flag sets the ID, flag wins over the
env var, env var still honoured without the flag, neither set leaves it unset, and — the one that
matters — the flag actually reaches the outgoing `X-Conversation-ID` header on a constructed client,
not just the environment.

Also verified end-to-end out-of-process: `kbagent --json --conversation-id kbagent-test-4242 doctor`
leaves the env set and a subsequently constructed client carries
`x-conversation-id: kbagent-test-4242`.

`make check` exits 0.

## Doc surfaces

Every surface that carried the unsatisfiable instruction now states that a standalone `export` does
not survive between tool calls, and points at the flag (or the harness's own env block for a whole
session):

- `plugins/kbagent/skills/kbagent/SKILL.md` rule 2 — the line the issue quotes.
- `plugins/kbagent/skills/kbagent/references/gotchas.md` "Conversation ID" — rewritten, tagged
  `(since vNEXT, #716)`.
- `src/keboola_agent_cli/commands/context.py` `AGENT_CONTEXT` — both the "IMPORTANT: Set Conversation
  ID" block and the env-var table.
- `CLAUDE.md` global-options line.

One process note worth flagging: a `(since vNEXT)` gate **cannot** be written on the `# ` comment
lines inside CLAUDE.md's `## All CLI Commands` fenced block — `scripts/check_version_gates.py` parses
them as ATX markdown headings, and a placeholder in a heading is always fatal. The version gate for
this entry therefore lives in `gotchas.md`, with a comment in CLAUDE.md explaining why.

No CLI *command* was added / renamed / removed (this is a global option), so the command-sync
surfaces are untouched; `make command-sync-check` and `make skill-check` are green.

No version bump and no `changelog.py` entry — that belongs to the release PR.

Fixes #716