### PR TITLE
docs(flow): fix get_flow_detail docstring -- no schedule info is returned

### DIFF
--- a/src/keboola_agent_cli/services/flow_service.py
+++ b/src/keboola_agent_cli/services/flow_service.py
@@ -422,7 +422,12 @@ class FlowService(BaseService):
         config_id: str,
         branch_id: int | None = None,
     ) -> dict[str, Any]:
-        """Return full flow detail including phases, tasks, and schedule info.
+        """Return flow configuration detail including parsed phases and tasks.
+
+        The result is the raw config detail enriched with ``phases``, ``tasks``,
+        ``phase_count``, ``task_count``, ``component_id``, ``branch_id`` and
+        ``project_alias``. Schedule info is NOT included -- schedules live in a
+        separate scheduler config (see ``list_flows(with_schedules=True)``).
 
         Raises:
             ConfigError: If alias is not found.


### PR DESCRIPTION
## Summary

The docstring of `FlowService.get_flow_detail` claimed it returns "full flow detail including phases, tasks, and schedule info", but the implementation performs no schedule join -- it returns the raw config detail enriched with parsed `phases`/`tasks`, `phase_count`/`task_count`, `component_id`, `branch_id` and `project_alias`. Schedules are only fetched via `list_flows(with_schedules=True)` (the `flow list --with-schedules` path) or during `flow schedule-remove`.

This PR fixes the docstring to match reality and points readers to the actual schedule path. Deliberately does NOT add a schedule fetch.

## Scope

- Docs-only (one docstring), no behavior change
- No version bump, no changelog entry (per the release-PR-only rule)
- No test changes needed