### PR TITLE
chore: add CODEOWNERS to auto-request PR review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @keboola-pr-reviewer-bot @soustruh


### PR DESCRIPTION
## CODEOWNERS

Adds `.github/CODEOWNERS` so GitHub auto-requests a review from `@keboola-pr-reviewer-bot` and `@soustruh` on every pull request.

- The rule is `* @keboola-pr-reviewer-bot @soustruh` (all paths, both owners).
- CODEOWNERS only requests the review. It does not block merge. To block merge until an owner approves, turn on branch protection "Require review from Code Owners".
- The reviewer bot already runs on PRs through its App. This adds it to the Reviewers list as well.
