### PR TITLE
feat(telemetry): add CLI version and agent/human marker to usage events (CLI-12)

### DIFF
--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -5013,6 +5013,12 @@ It carries the command name, the outcome, and the duration -- never argument val
 
 - **It shows up in the project's own event log.** An agent auditing a project's events
   sees one `ext.keboola.cli.` entry per kbagent command. That is expected, not a stray write.
+- **The event body also carries the kbagent version** *(since vNEXT)*: `params.cliContext.userAgent`
+  holds the `keboola-cli/<version> (<os>; <arch>; <impl> <pyver>)` User-Agent, and
+  `params.cliContext.conversationId` holds the conversation id when one is set
+  (`KBAGENT_CONVERSATION_ID` / `--conversation-id`; over `serve` the request's `X-Conversation-ID`).
+  A usage report reads these to segment by version and to tell an agent run from a human one; they
+  are not argument values.
 - **Over `serve`, only mutating requests are logged.** A read (GET) posts nothing -- UI
   polling would otherwise write hundreds of events an hour into the project's event log.
   The CLI still logs reads, where volume is one event per invocation.

--- a/src/keboola_agent_cli/server/app.py
+++ b/src/keboola_agent_cli/server/app.py
@@ -708,6 +708,15 @@ class _UsageTelemetryMiddleware:
             values = parse_qs(scope.get("query_string", b"").decode("latin-1")).get("project")
             project_alias = values[0] if values else None
 
+        # The caller's X-Conversation-ID (set by kbagent's own clients) rides into
+        # params.cliContext so the telemetry reader tells an agent request from a
+        # human one; a web-UI request sends no such header and stays unmarked (CLI-12).
+        conversation_id: str | None = None
+        for key, value in scope.get("headers") or []:
+            if key == b"x-conversation-id":
+                conversation_id = value.decode("latin-1") or None
+                break
+
         await asyncio.to_thread(
             telemetry.send_serve_event,
             self._config_store,
@@ -717,6 +726,7 @@ class _UsageTelemetryMiddleware:
             status_code=status_code,
             duration_s=duration_s,
             project_alias=project_alias,
+            conversation_id=conversation_id,
         )
 
 

--- a/src/keboola_agent_cli/telemetry.py
+++ b/src/keboola_agent_cli/telemetry.py
@@ -5,6 +5,11 @@ events (``POST /v2/storage/events``), the same mechanism the kbc CLI uses. The
 event is stored as ``ext.keboola.cli.`` (CLI) or ``ext.keboola.cli.serve``
 (serve REST API) and stamped server-side with the caller's token + user agent.
 
+The event body also carries ``params.cliContext``: the kbagent User-Agent
+(version + OS/arch/Python) and, when set, the conversation id. The events store
+keeps the request body, not the server-stamped envelope, so a downstream reader
+reads the version and an agent-vs-human marker off the event itself (CLI-12).
+
 This is telemetry, NOT an audit trail: it is voluntary (the two env vars below
 disable it) and best-effort (a failed or blocked events endpoint never affects
 the command). Mutating operations are recorded server-side by Connection as
@@ -27,12 +32,14 @@ import typer
 from .auth.sentinel import is_session_token
 from .config_store import ConfigStore, resolve_config_dir
 from .constants import (
+    ENV_CONVERSATION_ID,
     ENV_DISABLE_TELEMETRY,
     ENV_DO_NOT_TRACK,
     TELEMETRY_COMPONENT_ID,
     TELEMETRY_SERVE_CONFIG_ID,
     TELEMETRY_TIMEOUT,
 )
+from .http_base import build_user_agent
 from .services.base import make_telemetry_client
 from .services.project_service import ProjectService
 
@@ -217,6 +224,7 @@ def emit_cli_invocation(
             duration_s=duration_s,
             configuration_id=None,
             extra_params=None,
+            conversation_id=os.environ.get(ENV_CONVERSATION_ID) or None,
         )
     except Exception as exc:
         logger.debug("usage event failed: %s", exc)
@@ -232,11 +240,14 @@ def send_serve_event(
     status_code: int,
     duration_s: float,
     project_alias: str | None,
+    conversation_id: str | None = None,
 ) -> None:
     """Post a usage event for one serve REST request. Never raises.
 
     Blocking (builds a sync client + posts), so serve calls this off the event
-    loop via a worker thread.
+    loop via a worker thread. ``conversation_id`` is the request's own
+    ``X-Conversation-ID`` (read by the middleware), so an agent-driven request is
+    marked and a human web-UI request -- which sends no such header -- is not.
     """
     try:
         if telemetry_disabled():
@@ -264,6 +275,7 @@ def send_serve_event(
             duration_s=duration_s,
             configuration_id=TELEMETRY_SERVE_CONFIG_ID,
             extra_params={"path": f"{method} {path}"},
+            conversation_id=conversation_id,
         )
     except Exception as exc:
         logger.debug("serve usage event failed: %s", exc)
@@ -301,10 +313,17 @@ def _send_event(
     duration_s: float,
     configuration_id: str | None,
     extra_params: dict[str, Any] | None,
+    conversation_id: str | None,
 ) -> None:
     params: dict[str, Any] = {"command": command}
     if extra_params:
         params.update(extra_params)
+    # KIDS reads the CLI version (auto-update adoption) and an agent-vs-human
+    # marker off the stored event body, so both ride in params.cliContext (CLI-12).
+    cli_context: dict[str, Any] = {"userAgent": build_user_agent()}
+    if conversation_id:
+        cli_context["conversationId"] = conversation_id
+    params["cliContext"] = cli_context
     results: dict[str, Any] = {}
     if project_id is not None:
         results["projectId"] = project_id

--- a/tests/test_serve_telemetry.py
+++ b/tests/test_serve_telemetry.py
@@ -45,7 +45,17 @@ def test_serve_logs_a_mutation_with_the_mapped_command(
     """
     captured: list[tuple[str, str | None]] = []
 
-    def fake_send(config_store, *, method, path, operation, status_code, duration_s, project_alias):
+    def fake_send(
+        config_store,
+        *,
+        method,
+        path,
+        operation,
+        status_code,
+        duration_s,
+        project_alias,
+        conversation_id=None,
+    ):
         captured.append((operation, project_alias))
 
     monkeypatch.setattr(telemetry, "send_serve_event", fake_send)
@@ -68,7 +78,17 @@ def test_unhandled_route_error_is_logged_as_a_failure(
     """
     captured: list[int] = []
 
-    def fake_send(config_store, *, method, path, operation, status_code, duration_s, project_alias):
+    def fake_send(
+        config_store,
+        *,
+        method,
+        path,
+        operation,
+        status_code,
+        duration_s,
+        project_alias,
+        conversation_id=None,
+    ):
         captured.append(status_code)
 
     monkeypatch.setattr(telemetry, "send_serve_event", fake_send)
@@ -100,7 +120,17 @@ def test_serve_maps_a_path_converter_route(
     """
     captured: list[str] = []
 
-    def fake_send(config_store, *, method, path, operation, status_code, duration_s, project_alias):
+    def fake_send(
+        config_store,
+        *,
+        method,
+        path,
+        operation,
+        status_code,
+        duration_s,
+        project_alias,
+        conversation_id=None,
+    ):
         captured.append(operation)
 
     monkeypatch.setattr(telemetry, "send_serve_event", fake_send)
@@ -125,7 +155,17 @@ def test_serve_skips_read_requests(tmp_config_dir: Path, monkeypatch: pytest.Mon
     """
     captured: list[tuple[str, str]] = []
 
-    def fake_send(config_store, *, method, path, operation, status_code, duration_s, project_alias):
+    def fake_send(
+        config_store,
+        *,
+        method,
+        path,
+        operation,
+        status_code,
+        duration_s,
+        project_alias,
+        conversation_id=None,
+    ):
         captured.append((method, operation))
 
     monkeypatch.setattr(telemetry, "send_serve_event", fake_send)
@@ -152,7 +192,17 @@ def test_serve_does_not_wait_for_the_telemetry_post(
     """
     posted = threading.Event()
 
-    def slow_send(config_store, *, method, path, operation, status_code, duration_s, project_alias):
+    def slow_send(
+        config_store,
+        *,
+        method,
+        path,
+        operation,
+        status_code,
+        duration_s,
+        project_alias,
+        conversation_id=None,
+    ):
         time.sleep(0.3)
         posted.set()
 
@@ -164,3 +214,36 @@ def test_serve_does_not_wait_for_the_telemetry_post(
         assert not posted.is_set()
         # ...but the event still fires, off the request path.
         assert posted.wait(2.0)
+
+
+def test_serve_passes_the_request_conversation_id(
+    tmp_config_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The request's X-Conversation-ID reaches send_serve_event; its absence sends None.
+
+    That header is the agent-vs-human marker for serve (CLI-12): an agent-driven
+    request carries it, a human web-UI request does not.
+    """
+    captured: list[str | None] = []
+
+    def fake_send(
+        config_store,
+        *,
+        method,
+        path,
+        operation,
+        status_code,
+        duration_s,
+        project_alias,
+        conversation_id=None,
+    ):
+        captured.append(conversation_id)
+
+    monkeypatch.setattr(telemetry, "send_serve_event", fake_send)
+    app = create_app(config_dir=str(tmp_config_dir), auth_token="tok")
+    with TestClient(app, raise_server_exceptions=False) as client:
+        headers = {"Authorization": "Bearer tok"}
+        client.post("/jobs/prod/run", headers={**headers, "X-Conversation-ID": "conv-xyz"}, json={})
+        client.post("/jobs/prod/run", headers=headers, json={})
+
+    assert captured == ["conv-xyz", None]

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -23,9 +23,15 @@ from keboola_agent_cli.auth.token_provider import reset_provider_registry
 _EVENTS_URL = "https://connection.keboola.com/v2/storage/events"
 
 
-def test_success_posts_expected_cli_event(tmp_config_dir: Path, httpx_mock) -> None:
+def test_success_posts_expected_cli_event(
+    tmp_config_dir: Path, httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A successful command posts one ``ext.keboola.cli.`` event with the command path."""
     telemetry.reset()
+    # This test asserts the no-conversation-id branch, so it must own that env var:
+    # cli.py sets KBAGENT_CONVERSATION_ID directly on os.environ for --conversation-id,
+    # which can leak across tests in one xdist worker.
+    monkeypatch.delenv("KBAGENT_CONVERSATION_ID", raising=False)
     setup_single_project(tmp_config_dir)  # sole project -> resolves without --project
     httpx_mock.add_response(url=_EVENTS_URL, method="POST", json={"id": "evt-1"})
 
@@ -42,12 +48,42 @@ def test_success_posts_expected_cli_event(tmp_config_dir: Path, httpx_mock) -> N
     assert body["component"] == "keboola.cli"
     assert "configurationId" not in body  # CLI -> ext.keboola.cli. (serve adds "serve")
     assert body["type"] == "info"
-    assert body["params"] == {"command": "config list"}
+    assert body["params"]["command"] == "config list"
+    # cliContext carries the version (via the User-Agent) into the event body,
+    # since the events store keeps the body, not the server-stamped envelope (CLI-12).
+    assert body["params"]["cliContext"]["userAgent"].startswith(
+        ("keboola-cli/", "keboola-agent-cli/")
+    )
+    # No KBAGENT_CONVERSATION_ID set -> no agent marker (a human invocation).
+    assert "conversationId" not in body["params"]["cliContext"]
     assert body["results"]["projectId"] == 258
     assert body["duration"] == 1  # ceil(0.4s)
     # The acting client identifies kbagent to Connection by its User-Agent, which
     # is what makes the server-side audit event attributable to kbagent too.
     assert requests[0].headers["User-Agent"].startswith(("keboola-cli/", "keboola-agent-cli/"))
+
+
+def test_conversation_id_marks_an_agent_run(
+    tmp_config_dir: Path, httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A set KBAGENT_CONVERSATION_ID lands in params.cliContext.conversationId.
+
+    Presence of the id is the agent-vs-human marker KIDS reads off the event (CLI-12).
+    """
+    telemetry.reset()
+    setup_single_project(tmp_config_dir)
+    monkeypatch.setenv("KBAGENT_CONVERSATION_ID", "conv-abc123")
+    httpx_mock.add_response(url=_EVENTS_URL, method="POST", json={"id": "evt-1"})
+
+    telemetry.emit_cli_invocation(
+        ["kbagent", "config", "list", "--config-dir", str(tmp_config_dir)],
+        exit_code=0,
+        error=None,
+        duration_s=0.4,
+    )
+
+    body = json.loads(httpx_mock.get_requests()[0].content)
+    assert body["params"]["cliContext"]["conversationId"] == "conv-abc123"
 
 
 def test_failed_command_reports_error_and_is_best_effort(tmp_config_dir: Path, httpx_mock) -> None:


### PR DESCRIPTION
## Why

The telemetry team (KIDS-522) reports on kbagent usage from the `ext.keboola.cli.` events. Their report needs the CLI version and an agent-vs-human marker. The stored event body carried neither. Elasticsearch keeps the request body, not the server-stamped envelope or the headers, so neither value reached the team.

## What

- `_send_event` writes `params.cliContext` on every usage event. It holds `userAgent` (the `keboola-cli/<version> (<os>; <arch>; <impl> <pyver>)` User-Agent, which carries the version and platform) and, when set, `conversationId`.
- The CLI path reads the conversation id from `KBAGENT_CONVERSATION_ID` / `--conversation-id`. The serve middleware reads it from the request's `X-Conversation-ID` header. A request that sends the header is marked. One without it is not.
- `gotchas.md` documents `params.cliContext`, tagged `(since vNEXT)`.

## Tests

- `test_telemetry.py`: the success event carries `cliContext.userAgent`, and a set `KBAGENT_CONVERSATION_ID` lands in `cliContext.conversationId`.
- `test_serve_telemetry.py`: the request's `X-Conversation-ID` reaches `send_serve_event`, and its absence sends `None`.

## Related

- Ticket: CLI-12 (blocks KIDS-522).
- Event schema: keboola/event-schema#33.
