### PR TITLE
fix: omit static Stream header when HTTP auth is supplied

### DIFF
--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -11,6 +11,17 @@ Versioning convention:
   behavior; the inline `(updated vX.Y.Z)` records when the refinement landed.
 -->
 
+## Explicit Stream HTTP auth must not compete with a Storage header
+
+*(since vNEXT)*
+
+Low-level `StreamClient(..., http_auth=...)` and the `KeboolaClient` Stream sub-client
+omit `X-StorageApi-Token` entirely when an auth hook is supplied. Previously they
+sent that header too, even for an empty token or session sentinel; it could defeat
+valid bearer authentication and return HTTP 401 while Storage worked. Static-token
+calls are unchanged. This does **not** broaden CLI session support or the public
+`Client` facade's static-token contract; their existing guards still apply.
+
 ## An HTTP 401 is not automatically a bad token
 
 *(since 0.92.0, #711)*

--- a/plugins/kbagent/skills/kbagent/references/gotchas.md
+++ b/plugins/kbagent/skills/kbagent/references/gotchas.md
@@ -483,15 +483,25 @@ calls are unchanged. This does **not** broaden CLI session support or the public
   its `in.c-otlp-<source_id>` sink bucket, then `token create --bucket-write
   in.c-otlp-<source_id> --expires-in 3600` mints exactly the token the device holds.
 
-## `stream create-source` uses a NORMAL Storage token — there is NO master-token gate
+## Stream writes require an Admin user's personal Storage master token
 
-- Creating a Data Streams source (`kbagent stream create-source` /
-  `Client.create_stream_source`) authenticates with the ordinary project Storage
-  token — **NOT** a master token. There is **no `stream.api.masterTokenRequired`
-  error code**; do not code against one or tell a user they need a master token.
-- The documented create-time errors are `stream.api.sourceAlreadyExists` (HTTP 409
-  — use `stream create-source --if-not-exists` to make it idempotent) and
-  `stream.api.resourceLimitReached` (HTTP 422 — the project hit its source quota).
+- `stream create-source` / `Client.create_stream_source` use the Storage header
+  `X-StorageApi-Token`, **not** a Manage/super-admin token. However, the
+  [Data Streams tutorial](https://help.keboola.com/storage/data-streams/tutorial/)
+  requires the **master token of a project user with the Admin role** for writes
+  and documents `403 only admin token can do write operations on streams`.
+- `isMasterToken=true`, `canManageBuckets=true` and `canManageTokens=true` are
+  insufficient: a master token bound to `admin.role=share` was rejected while
+  reads worked. Check the actual project user role, not just capability flags.
+  Use **Users & Settings → API Tokens → your own token** for an Admin user;
+  never promote a user or switch credentials automatically to bypass a denial.
+- The CLI currently forwards writes without a project-role preflight, so a403
+  can come from the service. Do not invent a `stream.api.masterTokenRequired`
+  error code. Other documented create errors include `stream.api.sourceAlreadyExists`
+  (409) and `stream.api.resourceLimitReached` (422). `--if-not-exists` may reconcile
+  existing sinks; use it only when touching those resources is explicitly in scope.
+- Explicit `sourceId`/`sinkId` are documented optional API fields; omitting them
+  generates IDs from names. Do not assume changing these fields changes authority.
 
 ## `sync status` + `doctor` flag plaintext `#`-secrets in synced configs (since v0.55.0)
 

--- a/src/keboola_agent_cli/stream_client.py
+++ b/src/keboola_agent_cli/stream_client.py
@@ -99,10 +99,9 @@ class StreamClient(BaseHttpClient):
     def __init__(self, stack_url: str, token: str, *, http_auth: httpx.Auth | None = None) -> None:
         self._stack_url = stack_url.rstrip("/")
         stream_base_url = self._derive_service_url(self._stack_url, "stream")
-        headers = {
-            "X-StorageApi-Token": token,
-            "Content-Type": "application/json",
-        }
+        headers = {"Content-Type": "application/json"}
+        if http_auth is None:
+            headers["X-StorageApi-Token"] = token
         super().__init__(
             base_url=stream_base_url,
             token=token,

--- a/tests/test_http_base_auth.py
+++ b/tests/test_http_base_auth.py
@@ -273,19 +273,35 @@ class TestSessionAuthFeatureGuard:
         with StreamClient(stack_url=STACK_URL, token="", http_auth=_StubBearerAuth()):
             pass
 
-    def test_stream_sub_client_inherits_the_bearer_hook(self, httpx_mock) -> None:
-        """``client/stream.py`` builds a ``StreamClient`` from the main client.
-
-        Without propagating ``http_auth`` it would send an empty
-        ``X-StorageApi-Token`` in session mode and draw an opaque 401.
-        """
+    @pytest.mark.parametrize("token", ["", SENTINEL_TOKEN, STATIC_TOKEN])
+    def test_stream_sub_client_inherits_the_bearer_hook(self, httpx_mock, token: str) -> None:
+        """The stream sub-client must not add a competing static auth header."""
         httpx_mock.add_response(
             url="https://stream.keboola.com/v1/branches/default/sources",
             json={"sources": []},
         )
-        with KeboolaClient(stack_url=STACK_URL, token="", http_auth=_StubBearerAuth()) as client:
-            client._get_stream_client().list_sources("default")
+        auth = _StubBearerAuth(project_id=3044)
+        with KeboolaClient(stack_url=STACK_URL, token=token, http_auth=auth) as client:
+            assert client.list_stream_sources() == []
 
         request = httpx_mock.get_requests()[0]
         assert request.headers["Authorization"] == f"Bearer {BEARER_TOKEN}"
-        assert not request.headers.get("X-StorageApi-Token")
+        assert request.headers["X-KBC-ProjectId"] == "3044"
+        assert "X-StorageApi-Token" not in request.headers
+
+    @pytest.mark.parametrize("token", ["", SENTINEL_TOKEN, STATIC_TOKEN])
+    def test_direct_stream_client_omits_static_header_with_auth(
+        self, httpx_mock, token: str
+    ) -> None:
+        httpx_mock.add_response(
+            url="https://stream.keboola.com/v1/branches/default/sources",
+            json={"sources": []},
+        )
+        auth = _StubBearerAuth(project_id=3044)
+        with StreamClient(stack_url=STACK_URL, token=token, http_auth=auth) as client:
+            assert client.list_sources("default") == {"sources": []}
+
+        request = httpx_mock.get_requests()[0]
+        assert request.headers["Authorization"] == f"Bearer {BEARER_TOKEN}"
+        assert request.headers["X-KBC-ProjectId"] == "3044"
+        assert "X-StorageApi-Token" not in request.headers


### PR DESCRIPTION
## Summary
Omit `X-StorageApi-Token` in `StreamClient` when the caller explicitly supplies `http_auth`, matching the existing Storage client contract. Previously StreamClient added the static header even in bearer mode, including empty/sentinel/stale-token values; a competing header could cause HTTP401 while the bearer credential itself was valid.

One constructor guard fixes direct StreamClient calls and the KeboolaClient stream sub-client. Static-token behavior and default CLI/facade session guards remain unchanged; no new session-support surface or version bump.

## Evidence
- Real EU GCP project read-only comparison: configured static-header request401; explicit session bearer with no static header200. No credential rotation or production mutation.
- Six regression cases (direct and facade sub-client × empty/sentinel/static token arguments) fail before the fix and pass after. Tests assert header ABSENCE, not merely falsiness, and preserve the project header.
- Patched SDK read-only source listing200; three sources returned. No secrets/raw source objects persisted in evidence.
- `make check` passed: 6574 passed,12 skipped; lint,format,typecheck and repository gates green. Existing warnings retained.
- `git diff --check` passed.

The configured static token's independent rejection is not fixed/hidden by this change. Explicit bearer auth remains caller-supplied, never an implicit auth fallback.

Plugin sync: no command/signature/permission changes; added a vNEXT low-level auth gotcha, explicitly retaining CLI/public facade guards. No release/changelog edits.

Self-review: main-agent code/test/call-site review completed. `/kbagent:review` plugin review skipped: unavailable in this Pi session; no independent-review claim. No live E2E mutation suite run against the user's project.
